### PR TITLE
Phase7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,9 +78,23 @@ jobs:
       - name: Build vote_tally_tls
         run: cargo build --release --target wasm32-unknown-unknown --manifest-path examples/vote_tally_tls/Cargo.toml
 
+  cli-smoke:
+    name: CLI Multi-process Smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+      - name: Build distributed_counter
+        run: cargo build --release --target wasm32-unknown-unknown --manifest-path examples/distributed_counter/Cargo.toml
+      - name: Run multi-process CLI smoke test
+        run: cargo test -p nx-cli --test multiprocess_smoke -- --ignored
+
   ci-success:
     name: CI Success
-    needs: [check, fmt, clippy, test, build-wasm]
+    needs: [check, fmt, clippy, test, build-wasm, cli-smoke]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -90,7 +104,8 @@ jobs:
              [[ "${{ needs.fmt.result }}" != "success" ]] || \
              [[ "${{ needs.clippy.result }}" != "success" ]] || \
              [[ "${{ needs.test.result }}" != "success" ]] || \
-             [[ "${{ needs.build-wasm.result }}" != "success" ]]; then
+             [[ "${{ needs.build-wasm.result }}" != "success" ]] || \
+             [[ "${{ needs.cli-smoke.result }}" != "success" ]]; then
             echo "One or more jobs failed"
             exit 1
           fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2087,6 +2087,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "sized-chunks"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2321,6 +2331,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Three things, and only three:
 
 You write a WASM module. numax runs it. The state is there. Sync just happens.
 
-> **Status:** `v0.1.0-alpha.1` - first public technical preview.
+> **Status:** `v0.1.0-alpha.2` - public technical preview.
 > It works, it's tested, it's honest about what's missing. See [`ROADMAP.md`](./ROADMAP.md).
 
 ---

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -220,7 +220,7 @@ nx run counter.wasm --listen 127.0.0.1:9001 --peer 127.0.0.1:9000 \
 - [x] Multi-process CLI smoke test: two `nx run distributed_counter.wasm`
       converge and print the same value within a few seconds.
 - [x] Signal handling (SIGTERM, SIGINT, SIGHUP)
-- [ ] Graceful shutdown: complete in-flight ops, close connections
+- [x] Graceful shutdown: complete in-flight ops, close connections
 - [ ] Store flush before exit
 - [ ] Configurable timeout for shutdown (default 30s)
 - [ ] Test: kill -TERM → no data corruption

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -221,8 +221,8 @@ nx run counter.wasm --listen 127.0.0.1:9001 --peer 127.0.0.1:9000 \
       converge and print the same value within a few seconds.
 - [x] Signal handling (SIGTERM, SIGINT, SIGHUP)
 - [x] Graceful shutdown: complete in-flight ops, close connections
-- [ ] Store flush before exit
-- [ ] Configurable timeout for shutdown (default 30s)
+- [x] Store flush before exit
+- [x] Configurable timeout for shutdown (default 30s)
 - [ ] Test: kill -TERM → no data corruption
 - [ ] Test: crash → restart → consistent state
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -214,7 +214,7 @@ nx run counter.wasm --listen 127.0.0.1:9001 --peer 127.0.0.1:9000 \
 - [x] Robust long-running mode for the runtime with sync enabled.
 - [x] Hydration on startup: rebuild the GCounter registry from the values
       materialized in sled.
-- [ ] Settle mode for `nx run` with sync enabled: give time to handshake,
+- [x] Settle mode for `nx run` with sync enabled: give time to handshake,
       PushOps and remote apply before exit, or replace it with a long-running
       lifecycle.
 - [ ] Multi-process CLI smoke test: two `nx run distributed_counter.wasm`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -212,7 +212,7 @@ nx run counter.wasm --listen 127.0.0.1:9001 --peer 127.0.0.1:9000 \
 **Goal**: Clean shutdown and recovery from crash
 
 - [ ] Robust long-running mode for the runtime with sync enabled.
-- [ ] Hydration on startup: rebuild the GCounter registry from the values
+- [x] Hydration on startup: rebuild the GCounter registry from the values
       materialized in sled.
 - [ ] Settle mode for `nx run` with sync enabled: give time to handshake,
       PushOps and remote apply before exit, or replace it with a long-running

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -217,7 +217,7 @@ nx run counter.wasm --listen 127.0.0.1:9001 --peer 127.0.0.1:9000 \
 - [x] Settle mode for `nx run` with sync enabled: give time to handshake,
       PushOps and remote apply before exit, or replace it with a long-running
       lifecycle.
-- [ ] Multi-process CLI smoke test: two `nx run distributed_counter.wasm`
+- [x] Multi-process CLI smoke test: two `nx run distributed_counter.wasm`
       converge and print the same value within a few seconds.
 - [ ] Signal handling (SIGTERM, SIGINT, SIGHUP)
 - [ ] Graceful shutdown: complete in-flight ops, close connections

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -219,7 +219,7 @@ nx run counter.wasm --listen 127.0.0.1:9001 --peer 127.0.0.1:9000 \
       lifecycle.
 - [x] Multi-process CLI smoke test: two `nx run distributed_counter.wasm`
       converge and print the same value within a few seconds.
-- [ ] Signal handling (SIGTERM, SIGINT, SIGHUP)
+- [x] Signal handling (SIGTERM, SIGINT, SIGHUP)
 - [ ] Graceful shutdown: complete in-flight ops, close connections
 - [ ] Store flush before exit
 - [ ] Configurable timeout for shutdown (default 30s)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -211,7 +211,7 @@ nx run counter.wasm --listen 127.0.0.1:9001 --peer 127.0.0.1:9000 \
 ### Phase 7: Graceful Lifecycle 🔄
 **Goal**: Clean shutdown and recovery from crash
 
-- [ ] Robust long-running mode for the runtime with sync enabled.
+- [x] Robust long-running mode for the runtime with sync enabled.
 - [x] Hydration on startup: rebuild the GCounter registry from the values
       materialized in sled.
 - [ ] Settle mode for `nx run` with sync enabled: give time to handshake,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -223,8 +223,8 @@ nx run counter.wasm --listen 127.0.0.1:9001 --peer 127.0.0.1:9000 \
 - [x] Graceful shutdown: complete in-flight ops, close connections
 - [x] Store flush before exit
 - [x] Configurable timeout for shutdown (default 30s)
-- [ ] Test: kill -TERM → no data corruption
-- [ ] Test: crash → restart → consistent state
+- [x] Test: kill -TERM → no data corruption
+- [x] Test: crash → restart → consistent state
 
 > These tasks complete the CLI criterion left open by Phase 6.5 and bring it
 > inside a general lifecycle: service loop, signal-aware shutdown, final flush

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Numax Roadmap
 
-> **Current release**: `v0.1.0-alpha.1` - developer preview.
+> **Current release**: `v0.1.0-alpha.2` - developer preview.
 > **Final goal `v0.1.0`**: production-ready runtime for non-critical workloads.
 > **Status**: alpha for feedback; production hardening still in progress.
 
@@ -8,8 +8,8 @@
 
 ## Release Status
 
-### v0.1.0-alpha.1 ✅
-**Purpose**: first technical preview to publish in order to gather feedback.
+### v0.1.0-alpha.2 ✅
+**Purpose**: second technical preview, focused on making sync usable from the CLI.
 
 Includes:
 - Wasmtime runtime + WASI preview1.
@@ -20,16 +20,14 @@ Includes:
 - TLS/mTLS, NodeID derived from certificate and allowlist.
 - End-to-end internal wiring between guest CRDT API, SyncManager and datastore.
 - Sled materialization of the GCounter total on local/remote update.
+- Runtime lifecycle for sync-enabled nodes: long-running mode, settle mode,
+  signal-aware shutdown and final store flush.
+- Startup hydration of materialized GCounter values.
 - `SyncManager` E2E tests for handshake, PushOps, convergence and idempotency.
 - Examples: `distributed_counter`, `distributed_chat` local-only, `vote_tally_tls`.
 
 Known limitations:
-- `nx run` executes the guest once and then terminates; the multi-process CLI
-  criterion from Phase 6.5 is not yet fully respected to the letter.
-- Hydration of the GCounter registry from the values materialized in sled is not
-  yet implemented.
-- Long-running lifecycle, graceful shutdown, backpressure, observability and
-  network resilience are still open phases.
+- Backpressure, observability and full network resilience are still open phases.
 - API and wire format may change before `v0.1.0`.
 
 ### v0.1.0 🎯
@@ -194,17 +192,18 @@ Includes the restructuring of the host API to separate local KV and replicated C
 **Closing criterion**:
 ```bash
 # Terminal A
-nx run counter.wasm --listen 127.0.0.1:9000 --datastore-path ./data-a
+nx run counter.wasm --listen 127.0.0.1:9000 --peer 127.0.0.1:9001 \
+    --datastore-path ./data-a --wait-before-run 1500ms \
+    --settle-for 2s --print-gcounter counter:visits
 # Terminal B
 nx run counter.wasm --listen 127.0.0.1:9001 --peer 127.0.0.1:9000 \
-    --datastore-path ./data-b
-# Both nodes print the same value of gcounter::value("visits")
-# within a few seconds.
+    --datastore-path ./data-b --wait-before-run 1500ms \
+    --settle-for 2s --print-gcounter counter:visits
+# Both nodes print: counter:visits = 2
 ```
 
 > Note: the internal wiring of Phase 6.5 is covered by E2E tests on `SyncManager`, including handshake, PushOps, convergence and sled materialization.
-> The CLI criterion above is not yet fully respected to the letter because today `nx run` executes the guest once and then terminates: it does not yet have a lifecycle/settle mode that would give stable time for handshake, broadcast and remote apply between CLI processes. Furthermore, the in-memory GCounter registry is not yet rebuilt from the values materialized in sled at startup.
-> These aspects are tracked in Phase 7.
+> The CLI criterion above is now covered by the Phase 7 lifecycle/smoke tests: startup hydration, settle mode, signal-aware shutdown, final flush and multi-process convergence.
 
 ---
 
@@ -412,7 +411,7 @@ criterion remains tracked in Phase 7 as lifecycle/settle/hydration.
 - [x] Phases 0-5 complete
 - [x] Phase 6 (TLS) complete
 - [x] Phase 6.5 (End-to-End Sync) complete
-- [ ] Phase 7 (Graceful shutdown) complete
+- [x] Phase 7 (Graceful shutdown) complete
 - [ ] Phase 8 (Backpressure) complete
 - [ ] Phase 9 (Observability) at least logging + health
 - [ ] Phase 10 (Resilience) at least reconnect + dedup
@@ -425,11 +424,12 @@ criterion remains tracked in Phase 7 as lifecycle/settle/hydration.
 
 ---
 
-## v0.1.0-alpha.1 Release Criteria
+## v0.1.0-alpha.2 Release Criteria
 
 - [x] Phases 0-5 complete
 - [x] Phase 6 (TLS) complete
 - [x] Phase 6.5 internal wiring covered by `SyncManager` E2E tests
+- [x] Phase 7 graceful lifecycle complete
 - [x] Base WASM examples present
 - [x] `cargo test` passes outside the sandbox
 - [x] `cargo clippy --all-targets --all-features -- -D warnings` passes

--- a/WHITEPAPER.md
+++ b/WHITEPAPER.md
@@ -1,7 +1,7 @@
 # Numax Runtime - Technical Whitepaper
 
 > **Note**
-> This whitepaper is aligned with **v0.1.0-alpha.1**, the first public technical preview of Numax.
+> This whitepaper is aligned with **v0.1.0-alpha.2**, the current public technical preview of Numax.
 > Compared to previous drafts, most of the `TODO`s have been resolved based on the code present in the repository. What remains open is explicitly labeled as *(Planned)* and tracked in the roadmap.
 >
 > **Status labels (consistent with the code):**
@@ -9,7 +9,7 @@
 > - **(Prototype)**: partially present; internal wiring or critical paths already verified, but not yet production-ready.
 > - **(Planned)**: foreseen in the roadmap, not yet implemented.
 >
-> **Version reference**: `v0.1.0-alpha.1` - technical preview, API and wire format may change before the stable v0.1.0.
+> **Version reference**: `v0.1.0-alpha.2` - technical preview, API and wire format may change before the stable v0.1.0.
 >
 > > 📍 **Reference roadmap:** the phases cited in this document (Phase 7, Phase 8, …) are defined in [`ROADMAP.md`](./ROADMAP.md).
 > Whenever you read *Phase N*, you can consult the roadmap for details, completion criteria and progress status :)
@@ -474,7 +474,7 @@ Numax assumes a hostile network: the transport can be observed, altered or redir
 
 **Dedicated CLI flags:** `--tls-cert`, `--tls-key`, `--tls-ca`, `--allowed-peers`, `--tls-insecure` (the latter only for local development).
 
-**Out of scope for v0.1.0-alpha.1:**
+**Out of scope for v0.1.0-alpha.2:**
 
 - automatic certificate rotation;
 - advanced certificate pinning;
@@ -520,32 +520,47 @@ pub extern "C" fn run() {
 The CLI is the main interface to run a Numax node.
 
 ```bash
-# Runs a WASM module (single-shot today; long-running in Phase 7)
+# Runs a WASM module once
 nx run <module.wasm>
 
 # Runs with a custom data directory
-nx run <module.wasm> --data-dir ./my-data
+nx run <module.wasm> --datastore-path ./my-data
 
-# Runs with sync enabled and TLS/mTLS
-nx run <module.wasm> --sync \
-    --sync-listen 0.0.0.0:9000 \
-    --sync-peers 192.168.1.10:9000,192.168.1.11:9000 \
-    --sync-keys "counter:,votes:" \
+# Runs as a sync-enabled node
+nx run <module.wasm> \
+    --listen 0.0.0.0:9000 \
+    --peer 192.168.1.10:9000 \
+    --peer 192.168.1.11:9000 \
+    --datastore-path ./node-data
+
+# Runs a bounded sync demo and prints a final GCounter value
+nx run <module.wasm> \
+    --listen 0.0.0.0:9000 \
+    --peer 192.168.1.10:9000 \
+    --wait-before-run 1500ms \
+    --settle-for 2s \
+    --print-gcounter counter:visits
+
+# Adds mTLS and peer allowlisting to a sync node
+nx run <module.wasm> \
+    --listen 0.0.0.0:9000 \
     --tls-cert ./certs/node.crt \
-    --tls-key  ./certs/node.key \
-    --tls-ca   ./certs/ca.crt \
-    --allowed-peers ./peers.allow
+    --tls-key ./certs/node.key \
+    --tls-ca ./certs/ca.crt \
+    --allowed-peers id1,id2,id3
 ```
 
 **Main options:**
 
 | Flag | Description |
 |------|-------------|
-| `--data-dir` | Directory for persistent data |
-| `--sync` | Enables synchronization |
-| `--sync-listen` | Address on which to accept peer connections |
-| `--sync-peers` | List of initial peers (comma-separated) |
-| `--sync-keys` | Prefixes of the keys to synchronize |
+| `--datastore-path` | Directory for persistent data |
+| `--listen` | Address on which to accept peer connections and enable sync |
+| `--peer` | Initial peer address (repeatable) |
+| `--wait-before-run` | Bounded pre-run window for peer handshakes |
+| `--settle-for` | Bounded post-run window for PushOps and remote apply |
+| `--print-gcounter` | Print a final host-side GCounter value |
+| `--shutdown-timeout` | Maximum graceful shutdown duration (default 30s) |
 | `--tls-cert` / `--tls-key` / `--tls-ca` | TLS material for mTLS |
 | `--allowed-peers` | Allowlist of accepted peer NodeIDs |
 | `--tls-insecure` | Disables TLS (local dev only) |
@@ -689,7 +704,7 @@ The project includes an automated test suite that covers runtime, store, CRDT, n
 
 ## 8. Use Cases
 
-The use cases below are **concretely achievable today** with the primitives of v0.1.0-alpha.1. They do not describe visions: they describe what the runtime already knows how to do, or will know how to do as soon as the last preview phases are closed.
+The use cases below are **concretely achievable today** with the primitives of v0.1.0-alpha.2. They do not describe visions: they describe what the runtime already knows how to do, or will know how to do as soon as the last preview phases are closed.
 
 ### 8.1 Distributed counters and metrics (example: `distributed_counter`)
 
@@ -697,7 +712,7 @@ The use cases below are **concretely achievable today** with the primitives of v
 
 **Why Numax.** A GCounter CRDT guarantees that each node can increment its own slot locally, without coordination, and that totals converge automatically. No central database, no distributed locks.
 
-**What you need today.** A WASM module that calls `crdt_gcounter_inc` / `crdt_gcounter_value` via the SDK; multiple `nx run` instances with `--sync` and mTLS active. This is exactly what the `distributed_counter` example in the repo does.
+**What you need today.** A WASM module that calls `crdt_gcounter_inc` / `crdt_gcounter_value` via the SDK; multiple `nx run` instances with `--listen` / `--peer`, optionally protected by mTLS. This is exactly what the `distributed_counter` example in the repo does.
 
 ### 8.2 Voting, polling, distributed tally (example: `vote_tally_tls`)
 
@@ -755,10 +770,9 @@ Numax is not AI. It is one of the things that AI can, comfortably, run on top of
 
 ## 10. Limitations
 
-v0.1.0-alpha.1 is a technical preview. We recognize its limits, explicitly:
+v0.1.0-alpha.2 is a technical preview. We recognize its limits, explicitly:
 
-- **`nx run` runs the guest only once and terminates.** Long-running mode with managed lifecycle is in Phase 7.
-- **GCounter hydration from sled at startup is not yet implemented.** Data persists, but the automatic replay of the CRDT state at boot is on the roadmap (Phase 7).
+- **Anti-entropy is not implemented yet.** Nodes exchange live PushOps, but automatic recovery of missed deltas after long disconnections is Phase 10 work.
 - **K-fanout gossip and full network resilience are in progress.** The architecture is defined; reconnect with backoff, automatic anti-entropy and op dedup are in Phase 10.
 - **TLS/mTLS is implemented, but not yet hardened for all scenarios.** It is solid enough for controlled scenarios (dev, lab, defined deployments); the full hardening (rotation, advanced pinning, extreme hostile scenarios) continues.
 - **Minimal observability.** Advanced structured logging, Prometheus metrics and health checks are in Phase 9.
@@ -783,11 +797,11 @@ Numax proposes a unified runtime that combines:
 
 The goal is not to replicate the existing ecosystem, but **to reduce the self-imposed complexity** that today dominates distributed systems development, while preserving control over the necessary complexity of one's own domain.
 
-v0.1.0-alpha.1 is a technical preview. What it contains is real, tested, working: WASM runtime, sled store, GCounter CRDT, async SyncManager, TCP networking, TLS 1.3 + mTLS with identity derived from the key, stable host API for database, log and CRDT, multi-OS CI, end-to-end examples.
+v0.1.0-alpha.2 is a technical preview. What it contains is real, tested, working: WASM runtime, sled store, GCounter CRDT, async SyncManager, TCP networking, TLS 1.3 + mTLS with identity derived from the key, stable host API for database, log and CRDT, multi-OS CI, end-to-end examples.
 
 What is still missing is declared explicitly and tracked in the roadmap. Subsequent iterations will refine details, practical examples, comparisons and experimental results.
 
-**v0.1.0-alpha.1 is just the beginning.** But it is a beginning built on code, not on promises.
+**v0.1.0-alpha.2 is just the beginning.** But it is a beginning built on code, not on promises.
 
 In closing, I love software and I love numax.
 

--- a/crates/nx-cli/src/main.rs
+++ b/crates/nx-cli/src/main.rs
@@ -144,25 +144,34 @@ async fn real_main() -> Result<()> {
             }
 
             let mut rt = Runtime::new(cfg)?;
-            rt.start_sync().await?;
-            if let Some(duration) = wait_before_run {
-                rt.wait_before_run(duration).await?;
+            let run_result: Result<()> = async {
+                rt.start_sync().await?;
+                if let Some(duration) = wait_before_run {
+                    rt.wait_before_run(duration).await?;
+                }
+                rt.run_module(&bytes).await?;
+                match settle_for {
+                    Some(duration) => rt.settle_for(duration).await?,
+                    None if rt.sync_enabled() => rt.serve().await?,
+                    None => {}
+                }
+                if let Some(key) = print_gcounter {
+                    let value = rt
+                        .get_counter_value(&key)
+                        .await
+                        .ok_or_else(|| anyhow::anyhow!("--print-gcounter requires sync"))?;
+                    println!("{key} = {value}");
+                }
+                Ok(())
             }
-            rt.run_module(&bytes).await?;
-            match settle_for {
-                Some(duration) => rt.settle_for(duration).await?,
-                None if rt.sync_enabled() => rt.serve().await?,
-                None => {}
-            }
-            if let Some(key) = print_gcounter {
-                let value = rt
-                    .get_counter_value(&key)
-                    .await
-                    .ok_or_else(|| anyhow::anyhow!("--print-gcounter requires sync"))?;
-                println!("{key} = {value}");
-            }
-            rt.shutdown_with_timeout(shutdown_timeout.unwrap_or(DEFAULT_SHUTDOWN_TIMEOUT))
-                .await?;
+            .await;
+
+            let shutdown_result = rt
+                .shutdown_with_timeout(shutdown_timeout.unwrap_or(DEFAULT_SHUTDOWN_TIMEOUT))
+                .await;
+
+            run_result?;
+            shutdown_result?;
         }
     }
 

--- a/crates/nx-cli/src/main.rs
+++ b/crates/nx-cli/src/main.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 use std::fs;
 use std::path::PathBuf;
+use std::time::Duration;
 
 use anyhow::{Result, bail};
 use clap::Parser;
@@ -28,6 +29,10 @@ enum Cli {
         /// Peer addresses to connect to (can be repeated). Requires --listen.
         #[arg(long = "peer", value_name = "ADDR")]
         peers: Vec<String>,
+
+        /// Keep sync alive for a bounded duration after running the module (e.g. 500ms, 5s, 2m).
+        #[arg(long, value_name = "DURATION", value_parser = parse_duration)]
+        settle_for: Option<Duration>,
 
         /// Enable verbose logging
         #[arg(short, long)]
@@ -76,6 +81,7 @@ async fn real_main() -> Result<()> {
             datastore_path,
             listen,
             peers,
+            settle_for,
             verbose,
             tls_cert,
             tls_key,
@@ -100,6 +106,7 @@ async fn real_main() -> Result<()> {
 
             // Build SyncConfig (if sync flags were provided)
             let sync = build_sync_config(listen, peers, tls)?;
+            validate_settle_mode(&sync, settle_for)?;
 
             // Read the wasm module
             let bytes = fs::read(&module)?;
@@ -122,8 +129,10 @@ async fn real_main() -> Result<()> {
             let mut rt = Runtime::new(cfg)?;
             rt.start_sync().await?;
             rt.run_module(&bytes).await?;
-            if rt.sync_enabled() {
-                rt.serve().await?;
+            match settle_for {
+                Some(duration) => rt.settle_for(duration).await?,
+                None if rt.sync_enabled() => rt.serve().await?,
+                None => {}
             }
         }
     }
@@ -148,6 +157,44 @@ fn validate_tls_flags(
     if allowed_peers.is_some() && tls_ca.is_none() && !tls_insecure {
         bail!("--allowed-peers requires --tls-ca (peers must be authenticated via mTLS)");
     }
+    Ok(())
+}
+
+fn parse_duration(input: &str) -> Result<Duration, String> {
+    let input = input.trim();
+    if input.is_empty() {
+        return Err("expected duration like 500ms, 5s, or 2m".to_string());
+    }
+
+    let (number, multiplier) = if let Some(number) = input.strip_suffix("ms") {
+        (number, 1)
+    } else if let Some(number) = input.strip_suffix('s') {
+        (number, 1_000)
+    } else if let Some(number) = input.strip_suffix('m') {
+        (number, 60_000)
+    } else {
+        (input, 1_000)
+    };
+
+    let amount = number
+        .parse::<u64>()
+        .map_err(|_| "expected duration like 500ms, 5s, or 2m".to_string())?;
+    if amount == 0 {
+        return Err("duration must be greater than zero".to_string());
+    }
+
+    let millis = amount
+        .checked_mul(multiplier)
+        .ok_or_else(|| "duration is too large".to_string())?;
+
+    Ok(Duration::from_millis(millis))
+}
+
+fn validate_settle_mode(sync: &Option<SyncConfig>, settle_for: Option<Duration>) -> Result<()> {
+    if settle_for.is_some() && sync.is_none() {
+        bail!("--settle-for requires sync to be enabled with --listen");
+    }
+
     Ok(())
 }
 
@@ -238,6 +285,40 @@ mod tests {
         Some(PathBuf::from(s))
     }
 
+    mod duration_parser {
+        use super::*;
+
+        #[test]
+        fn parses_milliseconds() {
+            assert_eq!(parse_duration("500ms").unwrap(), Duration::from_millis(500));
+        }
+
+        #[test]
+        fn parses_seconds() {
+            assert_eq!(parse_duration("5s").unwrap(), Duration::from_secs(5));
+        }
+
+        #[test]
+        fn parses_minutes() {
+            assert_eq!(parse_duration("2m").unwrap(), Duration::from_secs(120));
+        }
+
+        #[test]
+        fn parses_plain_number_as_seconds() {
+            assert_eq!(parse_duration("3").unwrap(), Duration::from_secs(3));
+        }
+
+        #[test]
+        fn rejects_invalid_duration() {
+            assert!(parse_duration("soon").is_err());
+        }
+
+        #[test]
+        fn rejects_zero_duration() {
+            assert!(parse_duration("0s").is_err());
+        }
+    }
+
     // validate_tls_flags
     mod validate_tls {
         use super::*;
@@ -303,6 +384,29 @@ mod tests {
         #[test]
         fn insecure_alone_ok() {
             assert!(validate_tls_flags(&None, &None, &None, &None, true).is_ok());
+        }
+    }
+
+    mod validate_settle {
+        use super::*;
+
+        #[test]
+        fn settle_without_sync_fails() {
+            let err = validate_settle_mode(&None, Some(Duration::from_secs(1)))
+                .unwrap_err()
+                .to_string();
+            assert!(err.contains("--settle-for requires sync"));
+        }
+
+        #[test]
+        fn settle_with_sync_is_ok() {
+            let sync = Some(SyncConfig::new().with_listen_addr("127.0.0.1:9000"));
+            assert!(validate_settle_mode(&sync, Some(Duration::from_secs(1))).is_ok());
+        }
+
+        #[test]
+        fn no_settle_without_sync_is_ok() {
+            assert!(validate_settle_mode(&None, None).is_ok());
         }
     }
 
@@ -499,6 +603,21 @@ mod tests {
                     assert_eq!(listen.as_deref(), Some("127.0.0.1:9000"));
                 }
             }
+        }
+
+        #[test]
+        fn settle_for_parsed() {
+            let cli = Cli::try_parse_from(["nx", "run", "x.wasm", "--settle-for", "5s"]).unwrap();
+            match cli {
+                Cli::Run { settle_for, .. } => {
+                    assert_eq!(settle_for, Some(Duration::from_secs(5)));
+                }
+            }
+        }
+
+        #[test]
+        fn invalid_settle_for_fails() {
+            assert!(Cli::try_parse_from(["nx", "run", "x.wasm", "--settle-for", "later"]).is_err());
         }
 
         #[test]

--- a/crates/nx-cli/src/main.rs
+++ b/crates/nx-cli/src/main.rs
@@ -122,6 +122,9 @@ async fn real_main() -> Result<()> {
             let mut rt = Runtime::new(cfg)?;
             rt.start_sync().await?;
             rt.run_module(&bytes).await?;
+            if rt.sync_enabled() {
+                rt.serve().await?;
+            }
         }
     }
 

--- a/crates/nx-cli/src/main.rs
+++ b/crates/nx-cli/src/main.rs
@@ -34,6 +34,14 @@ enum Cli {
         #[arg(long, value_name = "DURATION", value_parser = parse_duration)]
         settle_for: Option<Duration>,
 
+        /// Wait for a bounded duration after starting sync and before running the module.
+        #[arg(long, value_name = "DURATION", value_parser = parse_duration)]
+        wait_before_run: Option<Duration>,
+
+        /// Print the final value of a GCounter after settle/serve completes.
+        #[arg(long, value_name = "KEY")]
+        print_gcounter: Option<String>,
+
         /// Enable verbose logging
         #[arg(short, long)]
         verbose: bool,
@@ -82,6 +90,8 @@ async fn real_main() -> Result<()> {
             listen,
             peers,
             settle_for,
+            wait_before_run,
+            print_gcounter,
             verbose,
             tls_cert,
             tls_key,
@@ -107,6 +117,8 @@ async fn real_main() -> Result<()> {
             // Build SyncConfig (if sync flags were provided)
             let sync = build_sync_config(listen, peers, tls)?;
             validate_settle_mode(&sync, settle_for)?;
+            validate_wait_before_run(&sync, wait_before_run)?;
+            validate_print_gcounter(&sync, &print_gcounter)?;
 
             // Read the wasm module
             let bytes = fs::read(&module)?;
@@ -128,11 +140,21 @@ async fn real_main() -> Result<()> {
 
             let mut rt = Runtime::new(cfg)?;
             rt.start_sync().await?;
+            if let Some(duration) = wait_before_run {
+                rt.wait_before_run(duration).await?;
+            }
             rt.run_module(&bytes).await?;
             match settle_for {
                 Some(duration) => rt.settle_for(duration).await?,
                 None if rt.sync_enabled() => rt.serve().await?,
                 None => {}
+            }
+            if let Some(key) = print_gcounter {
+                let value = rt
+                    .get_counter_value(&key)
+                    .await
+                    .ok_or_else(|| anyhow::anyhow!("--print-gcounter requires sync"))?;
+                println!("{key} = {value}");
             }
         }
     }
@@ -193,6 +215,28 @@ fn parse_duration(input: &str) -> Result<Duration, String> {
 fn validate_settle_mode(sync: &Option<SyncConfig>, settle_for: Option<Duration>) -> Result<()> {
     if settle_for.is_some() && sync.is_none() {
         bail!("--settle-for requires sync to be enabled with --listen");
+    }
+
+    Ok(())
+}
+
+fn validate_wait_before_run(
+    sync: &Option<SyncConfig>,
+    wait_before_run: Option<Duration>,
+) -> Result<()> {
+    if wait_before_run.is_some() && sync.is_none() {
+        bail!("--wait-before-run requires sync to be enabled with --listen");
+    }
+
+    Ok(())
+}
+
+fn validate_print_gcounter(
+    sync: &Option<SyncConfig>,
+    print_gcounter: &Option<String>,
+) -> Result<()> {
+    if print_gcounter.is_some() && sync.is_none() {
+        bail!("--print-gcounter requires sync to be enabled with --listen");
     }
 
     Ok(())
@@ -410,6 +454,42 @@ mod tests {
         }
     }
 
+    mod validate_wait_before_run {
+        use super::*;
+
+        #[test]
+        fn wait_without_sync_fails() {
+            let err = validate_wait_before_run(&None, Some(Duration::from_secs(1)))
+                .unwrap_err()
+                .to_string();
+            assert!(err.contains("--wait-before-run requires sync"));
+        }
+
+        #[test]
+        fn wait_with_sync_is_ok() {
+            let sync = Some(SyncConfig::new().with_listen_addr("127.0.0.1:9000"));
+            assert!(validate_wait_before_run(&sync, Some(Duration::from_secs(1))).is_ok());
+        }
+    }
+
+    mod validate_print_counter {
+        use super::*;
+
+        #[test]
+        fn print_without_sync_fails() {
+            let err = validate_print_gcounter(&None, &Some("counter:visits".to_string()))
+                .unwrap_err()
+                .to_string();
+            assert!(err.contains("--print-gcounter requires sync"));
+        }
+
+        #[test]
+        fn print_with_sync_is_ok() {
+            let sync = Some(SyncConfig::new().with_listen_addr("127.0.0.1:9000"));
+            assert!(validate_print_gcounter(&sync, &Some("counter:visits".to_string())).is_ok());
+        }
+    }
+
     // build_tls_config
     mod build_tls {
         use super::*;
@@ -618,6 +698,31 @@ mod tests {
         #[test]
         fn invalid_settle_for_fails() {
             assert!(Cli::try_parse_from(["nx", "run", "x.wasm", "--settle-for", "later"]).is_err());
+        }
+
+        #[test]
+        fn wait_before_run_parsed() {
+            let cli =
+                Cli::try_parse_from(["nx", "run", "x.wasm", "--wait-before-run", "500ms"]).unwrap();
+            match cli {
+                Cli::Run {
+                    wait_before_run, ..
+                } => {
+                    assert_eq!(wait_before_run, Some(Duration::from_millis(500)));
+                }
+            }
+        }
+
+        #[test]
+        fn print_gcounter_parsed() {
+            let cli =
+                Cli::try_parse_from(["nx", "run", "x.wasm", "--print-gcounter", "counter:visits"])
+                    .unwrap();
+            match cli {
+                Cli::Run { print_gcounter, .. } => {
+                    assert_eq!(print_gcounter.as_deref(), Some("counter:visits"));
+                }
+            }
         }
 
         #[test]

--- a/crates/nx-cli/src/main.rs
+++ b/crates/nx-cli/src/main.rs
@@ -156,6 +156,7 @@ async fn real_main() -> Result<()> {
                     .ok_or_else(|| anyhow::anyhow!("--print-gcounter requires sync"))?;
                 println!("{key} = {value}");
             }
+            rt.shutdown().await?;
         }
     }
 

--- a/crates/nx-cli/src/main.rs
+++ b/crates/nx-cli/src/main.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use anyhow::{Result, bail};
 use clap::Parser;
-use nx_core::runtime::{Runtime, RuntimeConfig};
+use nx_core::runtime::{DEFAULT_SHUTDOWN_TIMEOUT, Runtime, RuntimeConfig};
 use nx_core::{SyncConfig, TlsConfig};
 use tracing::{info, warn};
 
@@ -41,6 +41,10 @@ enum Cli {
         /// Print the final value of a GCounter after settle/serve completes.
         #[arg(long, value_name = "KEY")]
         print_gcounter: Option<String>,
+
+        /// Maximum time allowed for shutdown before returning an error.
+        #[arg(long, value_name = "DURATION", value_parser = parse_duration)]
+        shutdown_timeout: Option<Duration>,
 
         /// Enable verbose logging
         #[arg(short, long)]
@@ -92,6 +96,7 @@ async fn real_main() -> Result<()> {
             settle_for,
             wait_before_run,
             print_gcounter,
+            shutdown_timeout,
             verbose,
             tls_cert,
             tls_key,
@@ -156,7 +161,8 @@ async fn real_main() -> Result<()> {
                     .ok_or_else(|| anyhow::anyhow!("--print-gcounter requires sync"))?;
                 println!("{key} = {value}");
             }
-            rt.shutdown().await?;
+            rt.shutdown_with_timeout(shutdown_timeout.unwrap_or(DEFAULT_SHUTDOWN_TIMEOUT))
+                .await?;
         }
     }
 
@@ -724,6 +730,26 @@ mod tests {
                     assert_eq!(print_gcounter.as_deref(), Some("counter:visits"));
                 }
             }
+        }
+
+        #[test]
+        fn shutdown_timeout_parsed() {
+            let cli =
+                Cli::try_parse_from(["nx", "run", "x.wasm", "--shutdown-timeout", "10s"]).unwrap();
+            match cli {
+                Cli::Run {
+                    shutdown_timeout, ..
+                } => {
+                    assert_eq!(shutdown_timeout, Some(Duration::from_secs(10)));
+                }
+            }
+        }
+
+        #[test]
+        fn invalid_shutdown_timeout_fails() {
+            assert!(
+                Cli::try_parse_from(["nx", "run", "x.wasm", "--shutdown-timeout", "nope"]).is_err()
+            );
         }
 
         #[test]

--- a/crates/nx-cli/tests/multiprocess_smoke.rs
+++ b/crates/nx-cli/tests/multiprocess_smoke.rs
@@ -192,7 +192,7 @@ fn sigterm_shutdown_preserves_counter_state() {
         .spawn()
         .expect("spawn SIGTERM node");
 
-    std::thread::sleep(std::time::Duration::from_millis(600));
+    std::thread::sleep(std::time::Duration::from_millis(1500));
     send_signal(child.id(), "TERM");
     let output = child.wait_with_output().expect("wait SIGTERM node");
     assert_success(&output, "SIGTERM node");
@@ -221,7 +221,7 @@ fn crash_restart_keeps_counter_state_consistent() {
         .spawn()
         .expect("spawn crash node");
 
-    std::thread::sleep(std::time::Duration::from_millis(600));
+    std::thread::sleep(std::time::Duration::from_millis(1500));
     send_signal(child.id(), "KILL");
     let output = child.wait_with_output().expect("wait crash node");
     assert!(

--- a/crates/nx-cli/tests/multiprocess_smoke.rs
+++ b/crates/nx-cli/tests/multiprocess_smoke.rs
@@ -1,0 +1,122 @@
+use std::net::TcpListener;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const COUNTER_KEY: &str = "counter:visits";
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("nx-cli should live under crates/nx-cli")
+        .to_path_buf()
+}
+
+fn free_addr() -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+    listener.local_addr().unwrap().to_string()
+}
+
+fn temp_path(name: &str) -> PathBuf {
+    let mut path = std::env::temp_dir();
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    path.push(format!("numax-{name}-{nanos}"));
+    path
+}
+
+fn nx_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_nx"))
+}
+
+fn distributed_counter_wasm() -> PathBuf {
+    workspace_root().join(
+        "examples/distributed_counter/target/wasm32-unknown-unknown/release/distributed_counter.wasm",
+    )
+}
+
+fn assert_success(output: &Output, label: &str) {
+    assert!(
+        output.status.success(),
+        "{label} failed\nstatus: {}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn assert_printed_counter(output: &Output, label: &str, expected: u64) {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let needle = format!("{COUNTER_KEY} = {expected}");
+    assert!(
+        stdout.contains(&needle),
+        "{label} did not print final converged value {expected}\nstdout:\n{stdout}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+#[ignore = "requires built distributed_counter.wasm and local TCP sockets"]
+fn two_nx_run_processes_converge_distributed_counter() {
+    let wasm = distributed_counter_wasm();
+    assert!(
+        wasm.exists(),
+        "missing {wasm:?}; build it with: cargo build --release --target wasm32-unknown-unknown --manifest-path examples/distributed_counter/Cargo.toml"
+    );
+
+    let addr_a = free_addr();
+    let addr_b = free_addr();
+    let data_a = temp_path("cli-smoke-a");
+    let data_b = temp_path("cli-smoke-b");
+    let nx = nx_bin();
+
+    let node_a = Command::new(&nx)
+        .arg("run")
+        .arg(&wasm)
+        .arg("--listen")
+        .arg(&addr_a)
+        .arg("--peer")
+        .arg(&addr_b)
+        .arg("--datastore-path")
+        .arg(&data_a)
+        .arg("--wait-before-run")
+        .arg("1500ms")
+        .arg("--settle-for")
+        .arg("1800ms")
+        .arg("--print-gcounter")
+        .arg(COUNTER_KEY)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn node A");
+
+    std::thread::sleep(std::time::Duration::from_millis(200));
+
+    let output_b = Command::new(&nx)
+        .arg("run")
+        .arg(&wasm)
+        .arg("--listen")
+        .arg(&addr_b)
+        .arg("--peer")
+        .arg(&addr_a)
+        .arg("--datastore-path")
+        .arg(&data_b)
+        .arg("--wait-before-run")
+        .arg("1500ms")
+        .arg("--settle-for")
+        .arg("1800ms")
+        .arg("--print-gcounter")
+        .arg(COUNTER_KEY)
+        .output()
+        .expect("run node B");
+
+    let output_a = node_a.wait_with_output().expect("wait node A");
+
+    assert_success(&output_a, "node A");
+    assert_success(&output_b, "node B");
+    assert_printed_counter(&output_a, "node A", 2);
+    assert_printed_counter(&output_b, "node B", 2);
+}

--- a/crates/nx-cli/tests/multiprocess_smoke.rs
+++ b/crates/nx-cli/tests/multiprocess_smoke.rs
@@ -58,14 +58,63 @@ fn assert_printed_counter(output: &Output, label: &str, expected: u64) {
     );
 }
 
-#[test]
-#[ignore = "requires built distributed_counter.wasm and local TCP sockets"]
-fn two_nx_run_processes_converge_distributed_counter() {
+fn printed_counter_value(output: &Output, label: &str) -> u64 {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let prefix = format!("{COUNTER_KEY} = ");
+    stdout
+        .lines()
+        .find_map(|line| line.strip_prefix(&prefix))
+        .and_then(|value| value.parse::<u64>().ok())
+        .unwrap_or_else(|| {
+            panic!(
+                "{label} did not print a final counter value\nstdout:\n{stdout}\nstderr:\n{}",
+                String::from_utf8_lossy(&output.stderr)
+            )
+        })
+}
+
+fn assert_counter_wasm_exists() -> PathBuf {
     let wasm = distributed_counter_wasm();
     assert!(
         wasm.exists(),
         "missing {wasm:?}; build it with: cargo build --release --target wasm32-unknown-unknown --manifest-path examples/distributed_counter/Cargo.toml"
     );
+    wasm
+}
+
+#[cfg(unix)]
+fn send_signal(pid: u32, signal: &str) {
+    let status = Command::new("kill")
+        .arg(format!("-{signal}"))
+        .arg(pid.to_string())
+        .status()
+        .expect("send signal with kill");
+    assert!(status.success(), "kill -{signal} {pid} failed: {status}");
+}
+
+fn restart_and_print_counter(nx: &Path, wasm: &Path, data_dir: &Path, label: &str) -> Output {
+    let output = Command::new(nx)
+        .arg("run")
+        .arg(wasm)
+        .arg("--listen")
+        .arg("127.0.0.1:0")
+        .arg("--datastore-path")
+        .arg(data_dir)
+        .arg("--settle-for")
+        .arg("200ms")
+        .arg("--print-gcounter")
+        .arg(COUNTER_KEY)
+        .output()
+        .unwrap_or_else(|e| panic!("restart {label}: {e}"));
+
+    assert_success(&output, label);
+    output
+}
+
+#[test]
+#[ignore = "requires built distributed_counter.wasm and local TCP sockets"]
+fn two_nx_run_processes_converge_distributed_counter() {
+    let wasm = assert_counter_wasm_exists();
 
     let addr_a = free_addr();
     let addr_b = free_addr();
@@ -119,4 +168,71 @@ fn two_nx_run_processes_converge_distributed_counter() {
     assert_success(&output_b, "node B");
     assert_printed_counter(&output_a, "node A", 2);
     assert_printed_counter(&output_b, "node B", 2);
+}
+
+#[cfg(unix)]
+#[test]
+#[ignore = "requires built distributed_counter.wasm, local TCP sockets and Unix signals"]
+fn sigterm_shutdown_preserves_counter_state() {
+    let wasm = assert_counter_wasm_exists();
+    let data = temp_path("cli-sigterm-data");
+    let nx = nx_bin();
+
+    let child = Command::new(&nx)
+        .arg("run")
+        .arg(&wasm)
+        .arg("--listen")
+        .arg("127.0.0.1:0")
+        .arg("--datastore-path")
+        .arg(&data)
+        .arg("--shutdown-timeout")
+        .arg("3s")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn SIGTERM node");
+
+    std::thread::sleep(std::time::Duration::from_millis(600));
+    send_signal(child.id(), "TERM");
+    let output = child.wait_with_output().expect("wait SIGTERM node");
+    assert_success(&output, "SIGTERM node");
+
+    let restart = restart_and_print_counter(&nx, &wasm, &data, "restart after SIGTERM");
+    assert_printed_counter(&restart, "restart after SIGTERM", 2);
+}
+
+#[cfg(unix)]
+#[test]
+#[ignore = "requires built distributed_counter.wasm, local TCP sockets and Unix signals"]
+fn crash_restart_keeps_counter_state_consistent() {
+    let wasm = assert_counter_wasm_exists();
+    let data = temp_path("cli-crash-data");
+    let nx = nx_bin();
+
+    let child = Command::new(&nx)
+        .arg("run")
+        .arg(&wasm)
+        .arg("--listen")
+        .arg("127.0.0.1:0")
+        .arg("--datastore-path")
+        .arg(&data)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn crash node");
+
+    std::thread::sleep(std::time::Duration::from_millis(600));
+    send_signal(child.id(), "KILL");
+    let output = child.wait_with_output().expect("wait crash node");
+    assert!(
+        !output.status.success(),
+        "crash node should not exit successfully after SIGKILL"
+    );
+
+    let restart = restart_and_print_counter(&nx, &wasm, &data, "restart after crash");
+    let value = printed_counter_value(&restart, "restart after crash");
+    assert!(
+        (1..=2).contains(&value),
+        "restart after crash produced inconsistent value {value}"
+    );
 }

--- a/crates/nx-core/Cargo.toml
+++ b/crates/nx-core/Cargo.toml
@@ -10,5 +10,5 @@ wasmtime-wasi = "43.0.1"
 nx-store = { path = "../nx-store" }
 nx-sync = { path = "../nx-sync" }
 nx-net = { path = "../nx-net" }
-tokio = { version = "1", features = ["signal", "sync"] }
+tokio = { version = "1", features = ["signal", "sync", "time"] }
 tracing = "0.1"

--- a/crates/nx-core/Cargo.toml
+++ b/crates/nx-core/Cargo.toml
@@ -10,5 +10,5 @@ wasmtime-wasi = "43.0.1"
 nx-store = { path = "../nx-store" }
 nx-sync = { path = "../nx-sync" }
 nx-net = { path = "../nx-net" }
-tokio = { version = "1", features = ["sync"] }
+tokio = { version = "1", features = ["signal", "sync"] }
 tracing = "0.1"

--- a/crates/nx-core/src/runtime.rs
+++ b/crates/nx-core/src/runtime.rs
@@ -14,6 +14,8 @@ use crate::host_api;
 use crate::sync_config::SyncConfig;
 use crate::sync_manager::{SyncHandle, SyncManager};
 
+pub const DEFAULT_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(30);
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ShutdownSignal {
     Interrupt,
@@ -137,15 +139,29 @@ impl Runtime {
 
     /// Stop sync background tasks and close network connections.
     pub async fn shutdown(&mut self) -> Result<()> {
-        let Some(manager) = self.sync_manager.as_mut() else {
-            tracing::debug!("shutdown: no sync configured, skipping");
-            return Ok(());
-        };
+        self.shutdown_with_timeout(DEFAULT_SHUTDOWN_TIMEOUT).await
+    }
 
-        manager
-            .shutdown()
+    /// Stop background tasks and flush the local store, bounded by `timeout`.
+    pub async fn shutdown_with_timeout(&mut self, timeout: Duration) -> Result<()> {
+        tokio::time::timeout(timeout, self.shutdown_inner())
             .await
-            .map_err(|e| anyhow!("sync manager failed to shut down: {e}"))?;
+            .map_err(|_| anyhow!("shutdown timed out after {:?}", timeout))?
+    }
+
+    async fn shutdown_inner(&mut self) -> Result<()> {
+        if let Some(manager) = self.sync_manager.as_mut() {
+            manager
+                .shutdown()
+                .await
+                .map_err(|e| anyhow!("sync manager failed to shut down: {e}"))?;
+        } else {
+            tracing::debug!("shutdown: no sync configured, skipping sync manager");
+        }
+
+        self.store
+            .flush()
+            .map_err(|e| anyhow!("failed to flush datastore: {e}"))?;
         tracing::info!("runtime shutdown complete");
         Ok(())
     }
@@ -445,5 +461,22 @@ mod tests {
         runtime.settle_for(duration).await.unwrap();
 
         assert!(started.elapsed() >= duration);
+    }
+
+    #[tokio::test]
+    async fn shutdown_with_timeout_flushes_store_without_sync() {
+        let config = RuntimeConfig {
+            datastore_path: temp_datastore_path("numax-runtime-shutdown-flush-test"),
+            ..RuntimeConfig::default()
+        };
+        let mut runtime = Runtime::new(config).unwrap();
+
+        runtime.store.set(b"key", b"value").unwrap();
+        runtime
+            .shutdown_with_timeout(Duration::from_secs(1))
+            .await
+            .unwrap();
+
+        assert_eq!(runtime.store.get(b"key").unwrap(), Some(b"value".to_vec()));
     }
 }

--- a/crates/nx-core/src/runtime.rs
+++ b/crates/nx-core/src/runtime.rs
@@ -1,4 +1,5 @@
 use anyhow::{Result, anyhow};
+use std::future::Future;
 use std::path::PathBuf;
 use std::sync::Arc;
 use wasmtime::{Engine, Linker, Module, Store};
@@ -130,6 +131,38 @@ impl Runtime {
         self.sync_handle.clone()
     }
 
+    /// Return true when this runtime owns an active sync manager.
+    pub fn sync_enabled(&self) -> bool {
+        self.sync_handle.is_some()
+    }
+
+    /// Keep the runtime alive while sync background tasks do their work.
+    pub async fn serve(&self) -> Result<()> {
+        self.serve_until_shutdown(async {
+            if let Err(e) = tokio::signal::ctrl_c().await {
+                tracing::warn!(error = %e, "failed to listen for shutdown signal");
+            }
+        })
+        .await
+    }
+
+    /// Testable variant of `serve`: the caller provides the shutdown signal.
+    pub async fn serve_until_shutdown<S>(&self, shutdown: S) -> Result<()>
+    where
+        S: Future<Output = ()>,
+    {
+        if !self.sync_enabled() {
+            tracing::debug!("serve: sync disabled, nothing to keep alive");
+            return Ok(());
+        }
+
+        tracing::info!("runtime entering long-running sync mode");
+        shutdown.await;
+        tracing::info!("runtime shutdown requested");
+
+        Ok(())
+    }
+
     pub async fn run_module(&self, wasm_bytes: &[u8]) -> Result<()> {
         // handle shared to the DB
         let store_db = Arc::clone(&self.store);
@@ -176,5 +209,75 @@ impl Runtime {
             .map_err(|e| anyhow!("Error while executing module: {e}"))?;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sync_config::SyncConfig;
+    use std::time::{SystemTime, UNIX_EPOCH};
+    use tokio::sync::oneshot;
+    use tokio::time::{Duration, timeout};
+
+    fn temp_datastore_path(prefix: &str) -> PathBuf {
+        let mut path = std::env::temp_dir();
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        path.push(format!("{prefix}-{nanos}"));
+        path
+    }
+
+    #[tokio::test]
+    async fn serve_returns_immediately_when_sync_is_disabled() {
+        let config = RuntimeConfig {
+            datastore_path: temp_datastore_path("numax-runtime-nosync-test"),
+            ..RuntimeConfig::default()
+        };
+        let runtime = Runtime::new(config).unwrap();
+        let (_tx, rx) = oneshot::channel::<()>();
+
+        runtime
+            .serve_until_shutdown(async {
+                let _ = rx.await;
+            })
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn serve_keeps_runtime_alive_until_shutdown() {
+        let config = RuntimeConfig {
+            datastore_path: temp_datastore_path("numax-runtime-serve-test"),
+            sync: Some(SyncConfig::new().with_listen_addr("127.0.0.1:0")),
+            ..RuntimeConfig::default()
+        };
+        let runtime = Runtime::new(config).unwrap();
+        let (_tx, rx) = oneshot::channel::<()>();
+
+        assert!(
+            timeout(
+                Duration::from_millis(25),
+                runtime.serve_until_shutdown(async {
+                    let _ = rx.await;
+                })
+            )
+            .await
+            .is_err()
+        );
+
+        let (tx, rx) = oneshot::channel::<()>();
+        tx.send(()).unwrap();
+        timeout(
+            Duration::from_secs(1),
+            runtime.serve_until_shutdown(async {
+                let _ = rx.await;
+            }),
+        )
+        .await
+        .unwrap()
+        .unwrap();
     }
 }

--- a/crates/nx-core/src/runtime.rs
+++ b/crates/nx-core/src/runtime.rs
@@ -3,7 +3,7 @@ use std::future::Future;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::time::{Duration as TokioDuration, Instant};
+use tokio::time::Instant;
 use wasmtime::{Engine, Linker, Module, Store};
 use wasmtime_wasi::{WasiCtx, p1};
 
@@ -229,7 +229,7 @@ impl Runtime {
         }
 
         tracing::info!(?duration, "runtime waiting before guest run");
-        let deadline = Instant::now() + TokioDuration::from(duration);
+        let deadline = Instant::now() + duration;
 
         loop {
             if let Some(manager) = self.sync_manager.as_ref() {
@@ -242,7 +242,7 @@ impl Runtime {
             }
 
             let remaining = deadline - now;
-            tokio::time::sleep(remaining.min(TokioDuration::from_millis(100))).await;
+            tokio::time::sleep(remaining.min(Duration::from_millis(100))).await;
         }
 
         Ok(())

--- a/crates/nx-core/src/runtime.rs
+++ b/crates/nx-core/src/runtime.rs
@@ -3,6 +3,7 @@ use std::future::Future;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
+use tokio::time::{Duration as TokioDuration, Instant};
 use wasmtime::{Engine, Linker, Module, Store};
 use wasmtime_wasi::{WasiCtx, p1};
 
@@ -137,6 +138,12 @@ impl Runtime {
         self.sync_handle.is_some()
     }
 
+    /// Return the current value of a GCounter, if sync is enabled.
+    pub async fn get_counter_value(&self, key: &str) -> Option<u64> {
+        let manager = self.sync_manager.as_ref()?;
+        Some(manager.get_counter_value(key).await)
+    }
+
     /// Keep the runtime alive while sync background tasks do their work.
     pub async fn serve(&self) -> Result<()> {
         self.serve_until_shutdown(async {
@@ -174,6 +181,33 @@ impl Runtime {
         tracing::info!(?duration, "runtime entering sync settle mode");
         tokio::time::sleep(duration).await;
         tracing::info!("runtime settle complete");
+
+        Ok(())
+    }
+
+    /// Keep sync alive before the guest runs, retrying configured peers during the window.
+    pub async fn wait_before_run(&self, duration: Duration) -> Result<()> {
+        if !self.sync_enabled() {
+            tracing::debug!("wait_before_run: sync disabled, nothing to wait for");
+            return Ok(());
+        }
+
+        tracing::info!(?duration, "runtime waiting before guest run");
+        let deadline = Instant::now() + TokioDuration::from(duration);
+
+        loop {
+            if let Some(manager) = self.sync_manager.as_ref() {
+                manager.reconnect_configured_peers().await;
+            }
+
+            let now = Instant::now();
+            if now >= deadline {
+                break;
+            }
+
+            let remaining = deadline - now;
+            tokio::time::sleep(remaining.min(TokioDuration::from_millis(100))).await;
+        }
 
         Ok(())
     }

--- a/crates/nx-core/src/runtime.rs
+++ b/crates/nx-core/src/runtime.rs
@@ -2,6 +2,7 @@ use anyhow::{Result, anyhow};
 use std::future::Future;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Duration;
 use wasmtime::{Engine, Linker, Module, Store};
 use wasmtime_wasi::{WasiCtx, p1};
 
@@ -163,6 +164,20 @@ impl Runtime {
         Ok(())
     }
 
+    /// Keep sync alive for a bounded settle window, then return.
+    pub async fn settle_for(&self, duration: Duration) -> Result<()> {
+        if !self.sync_enabled() {
+            tracing::debug!("settle_for: sync disabled, nothing to settle");
+            return Ok(());
+        }
+
+        tracing::info!(?duration, "runtime entering sync settle mode");
+        tokio::time::sleep(duration).await;
+        tracing::info!("runtime settle complete");
+
+        Ok(())
+    }
+
     pub async fn run_module(&self, wasm_bytes: &[u8]) -> Result<()> {
         // handle shared to the DB
         let store_db = Arc::clone(&self.store);
@@ -218,6 +233,7 @@ mod tests {
     use crate::sync_config::SyncConfig;
     use std::time::{SystemTime, UNIX_EPOCH};
     use tokio::sync::oneshot;
+    use tokio::time::Instant;
     use tokio::time::{Duration, timeout};
 
     fn temp_datastore_path(prefix: &str) -> PathBuf {
@@ -279,5 +295,35 @@ mod tests {
         .await
         .unwrap()
         .unwrap();
+    }
+
+    #[tokio::test]
+    async fn settle_returns_immediately_when_sync_is_disabled() {
+        let config = RuntimeConfig {
+            datastore_path: temp_datastore_path("numax-runtime-settle-nosync-test"),
+            ..RuntimeConfig::default()
+        };
+        let runtime = Runtime::new(config).unwrap();
+        let started = Instant::now();
+
+        runtime.settle_for(Duration::from_secs(5)).await.unwrap();
+
+        assert!(started.elapsed() < Duration::from_millis(100));
+    }
+
+    #[tokio::test]
+    async fn settle_waits_for_requested_duration_when_sync_is_enabled() {
+        let config = RuntimeConfig {
+            datastore_path: temp_datastore_path("numax-runtime-settle-test"),
+            sync: Some(SyncConfig::new().with_listen_addr("127.0.0.1:0")),
+            ..RuntimeConfig::default()
+        };
+        let runtime = Runtime::new(config).unwrap();
+        let duration = Duration::from_millis(25);
+        let started = Instant::now();
+
+        runtime.settle_for(duration).await.unwrap();
+
+        assert!(started.elapsed() >= duration);
     }
 }

--- a/crates/nx-core/src/runtime.rs
+++ b/crates/nx-core/src/runtime.rs
@@ -135,6 +135,21 @@ impl Runtime {
         Ok(())
     }
 
+    /// Stop sync background tasks and close network connections.
+    pub async fn shutdown(&mut self) -> Result<()> {
+        let Some(manager) = self.sync_manager.as_mut() else {
+            tracing::debug!("shutdown: no sync configured, skipping");
+            return Ok(());
+        };
+
+        manager
+            .shutdown()
+            .await
+            .map_err(|e| anyhow!("sync manager failed to shut down: {e}"))?;
+        tracing::info!("runtime shutdown complete");
+        Ok(())
+    }
+
     /// Return a clonable handle to the SyncManager (if present).
     pub fn sync_handle(&self) -> Option<SyncHandle> {
         self.sync_handle.clone()

--- a/crates/nx-core/src/runtime.rs
+++ b/crates/nx-core/src/runtime.rs
@@ -14,6 +14,13 @@ use crate::host_api;
 use crate::sync_config::SyncConfig;
 use crate::sync_manager::{SyncHandle, SyncManager};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ShutdownSignal {
+    Interrupt,
+    Terminate,
+    Hangup,
+}
+
 // Runtime config
 #[derive(Debug, Clone)]
 pub struct RuntimeConfig {
@@ -146,29 +153,27 @@ impl Runtime {
 
     /// Keep the runtime alive while sync background tasks do their work.
     pub async fn serve(&self) -> Result<()> {
-        self.serve_until_shutdown(async {
-            if let Err(e) = tokio::signal::ctrl_c().await {
-                tracing::warn!(error = %e, "failed to listen for shutdown signal");
-            }
-        })
-        .await
+        let _ = self
+            .serve_until_shutdown(wait_for_shutdown_signal())
+            .await?;
+        Ok(())
     }
 
     /// Testable variant of `serve`: the caller provides the shutdown signal.
-    pub async fn serve_until_shutdown<S>(&self, shutdown: S) -> Result<()>
+    pub async fn serve_until_shutdown<S>(&self, shutdown: S) -> Result<Option<ShutdownSignal>>
     where
-        S: Future<Output = ()>,
+        S: Future<Output = ShutdownSignal>,
     {
         if !self.sync_enabled() {
             tracing::debug!("serve: sync disabled, nothing to keep alive");
-            return Ok(());
+            return Ok(None);
         }
 
         tracing::info!("runtime entering long-running sync mode");
-        shutdown.await;
-        tracing::info!("runtime shutdown requested");
+        let signal = shutdown.await;
+        tracing::info!(?signal, "runtime shutdown requested");
 
-        Ok(())
+        Ok(Some(signal))
     }
 
     /// Keep sync alive for a bounded settle window, then return.
@@ -261,6 +266,51 @@ impl Runtime {
     }
 }
 
+#[cfg(unix)]
+async fn wait_for_shutdown_signal() -> ShutdownSignal {
+    use tokio::signal::unix::{SignalKind, signal};
+
+    let mut sigint = match signal(SignalKind::interrupt()) {
+        Ok(signal) => signal,
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to listen for SIGINT; falling back to ctrl_c");
+            let _ = tokio::signal::ctrl_c().await;
+            return ShutdownSignal::Interrupt;
+        }
+    };
+    let mut sigterm = match signal(SignalKind::terminate()) {
+        Ok(signal) => signal,
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to listen for SIGTERM; falling back to ctrl_c");
+            let _ = tokio::signal::ctrl_c().await;
+            return ShutdownSignal::Interrupt;
+        }
+    };
+    let mut sighup = match signal(SignalKind::hangup()) {
+        Ok(signal) => signal,
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to listen for SIGHUP; falling back to ctrl_c");
+            let _ = tokio::signal::ctrl_c().await;
+            return ShutdownSignal::Interrupt;
+        }
+    };
+
+    tokio::select! {
+        _ = sigint.recv() => ShutdownSignal::Interrupt,
+        _ = sigterm.recv() => ShutdownSignal::Terminate,
+        _ = sighup.recv() => ShutdownSignal::Hangup,
+    }
+}
+
+#[cfg(not(unix))]
+async fn wait_for_shutdown_signal() -> ShutdownSignal {
+    if let Err(e) = tokio::signal::ctrl_c().await {
+        tracing::warn!(error = %e, "failed to listen for Ctrl+C");
+    }
+
+    ShutdownSignal::Interrupt
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -292,6 +342,7 @@ mod tests {
         runtime
             .serve_until_shutdown(async {
                 let _ = rx.await;
+                ShutdownSignal::Interrupt
             })
             .await
             .unwrap();
@@ -312,6 +363,7 @@ mod tests {
                 Duration::from_millis(25),
                 runtime.serve_until_shutdown(async {
                     let _ = rx.await;
+                    ShutdownSignal::Interrupt
                 })
             )
             .await
@@ -320,15 +372,34 @@ mod tests {
 
         let (tx, rx) = oneshot::channel::<()>();
         tx.send(()).unwrap();
-        timeout(
+        let signal = timeout(
             Duration::from_secs(1),
             runtime.serve_until_shutdown(async {
                 let _ = rx.await;
+                ShutdownSignal::Terminate
             }),
         )
         .await
         .unwrap()
         .unwrap();
+
+        assert_eq!(signal, Some(ShutdownSignal::Terminate));
+    }
+
+    #[tokio::test]
+    async fn serve_returns_none_when_sync_is_disabled() {
+        let config = RuntimeConfig {
+            datastore_path: temp_datastore_path("numax-runtime-nosync-signal-test"),
+            ..RuntimeConfig::default()
+        };
+        let runtime = Runtime::new(config).unwrap();
+
+        let signal = runtime
+            .serve_until_shutdown(async { ShutdownSignal::Hangup })
+            .await
+            .unwrap();
+
+        assert_eq!(signal, None);
     }
 
     #[tokio::test]

--- a/crates/nx-core/src/sync_manager.rs
+++ b/crates/nx-core/src/sync_manager.rs
@@ -75,12 +75,18 @@ impl SyncManager {
     /// new SyncManager.
     pub fn new(node_id: NodeId, config: SyncConfig, store: Arc<NxStore>) -> Self {
         let (op_tx, op_rx) = mpsc::channel(100);
+        let mut counters = HashMap::new();
+
+        if let Err(e) = hydrate_gcounter_registry(&store, &node_id, &mut counters) {
+            warn!(error = %e, "failed to hydrate GCounter registry");
+        }
+        let counters = Arc::new(RwLock::new(counters));
 
         Self {
             node_id,
             config,
             node: None,
-            counters: Arc::new(RwLock::new(HashMap::new())),
+            counters,
             store,
             seen_ops: Arc::new(RwLock::new(HashSet::new())),
             op_tx,
@@ -236,6 +242,60 @@ pub(crate) fn materialized_gcounter_key(key: &str) -> Vec<u8> {
     out.extend_from_slice(GCOUNTER_STORE_PREFIX.as_bytes());
     out.extend_from_slice(key.as_bytes());
     out
+}
+
+fn logical_gcounter_key(store_key: &[u8]) -> anyhow::Result<String> {
+    let key = store_key
+        .strip_prefix(GCOUNTER_STORE_PREFIX.as_bytes())
+        .ok_or_else(|| anyhow::anyhow!("invalid GCounter materialized key"))?;
+
+    String::from_utf8(key.to_vec())
+        .map_err(|e| anyhow::anyhow!("invalid UTF-8 in GCounter materialized key: {e}"))
+}
+
+fn parse_materialized_gcounter_value(bytes: &[u8]) -> anyhow::Result<u64> {
+    let buf: [u8; 8] = bytes.try_into().map_err(|_| {
+        anyhow::anyhow!(
+            "invalid materialized GCounter value length: expected 8, got {}",
+            bytes.len()
+        )
+    })?;
+
+    Ok(u64::from_le_bytes(buf))
+}
+
+fn hydrate_gcounter_registry(
+    store: &NxStore,
+    node_id: &NodeId,
+    counters: &mut HashMap<String, GCounter>,
+) -> anyhow::Result<usize> {
+    let entries = store.scan_prefix(GCOUNTER_STORE_PREFIX.as_bytes())?;
+    let mut hydrated = 0;
+
+    for (store_key, value_bytes) in entries {
+        let key = match logical_gcounter_key(&store_key) {
+            Ok(key) => key,
+            Err(e) => {
+                warn!(error = %e, "skipping invalid materialized GCounter key");
+                continue;
+            }
+        };
+        let value = match parse_materialized_gcounter_value(&value_bytes) {
+            Ok(value) => value,
+            Err(e) => {
+                warn!(key = %key, error = %e, "skipping invalid materialized GCounter value");
+                continue;
+            }
+        };
+
+        let mut counter = GCounter::new();
+        counter.increment(node_id, value);
+        counters.insert(key, counter);
+        hydrated += 1;
+    }
+
+    debug!(count = hydrated, "hydrated GCounter registry from sled");
+    Ok(hydrated)
 }
 
 pub(crate) fn materialize_gcounter_value(
@@ -398,6 +458,22 @@ mod tests {
         buf.copy_from_slice(&bytes);
 
         assert_eq!(u64::from_le_bytes(buf), 3);
+    }
+
+    #[tokio::test]
+    async fn manager_hydrates_gcounter_registry_from_materialized_values() {
+        let store = temp_store();
+        materialize_gcounter_value(&store, "counter:visits", 42).unwrap();
+
+        let node_id = NodeId::new("local-node");
+        let config = SyncConfig::new();
+        let manager = SyncManager::new(node_id.clone(), config, Arc::clone(&store));
+
+        assert_eq!(manager.get_counter_value("counter:visits").await, 42);
+
+        let counters = manager.counters.read().await;
+        let counter = counters.get("counter:visits").unwrap();
+        assert_eq!(counter.value_for(&node_id), 42);
     }
 
     #[tokio::test]

--- a/crates/nx-core/src/sync_manager.rs
+++ b/crates/nx-core/src/sync_manager.rs
@@ -4,7 +4,8 @@ use std::sync::Arc;
 use nx_net::{Node, NodeConfig, NodeEvent};
 use nx_store::Store as NxStore;
 use nx_sync::{GCounter, NodeId, Op, OpKind};
-use tokio::sync::{RwLock, mpsc};
+use tokio::sync::{RwLock, mpsc, watch};
+use tokio::task::JoinHandle;
 use tracing::{debug, error, info, warn};
 
 use crate::sync_config::SyncConfig;
@@ -69,12 +70,22 @@ pub struct SyncManager {
 
     /// Receiver drained by `start` into the broadcast task.
     op_rx: Option<mpsc::Receiver<Op>>,
+
+    /// Shutdown signal shared with background tasks.
+    shutdown_tx: watch::Sender<bool>,
+
+    /// Inbound event loop task.
+    event_task: Option<JoinHandle<()>>,
+
+    /// Outbound broadcast drain task.
+    broadcast_task: Option<JoinHandle<()>>,
 }
 
 impl SyncManager {
     /// new SyncManager.
     pub fn new(node_id: NodeId, config: SyncConfig, store: Arc<NxStore>) -> Self {
         let (op_tx, op_rx) = mpsc::channel(100);
+        let (shutdown_tx, _shutdown_rx) = watch::channel(false);
         let mut counters = HashMap::new();
 
         if let Err(e) = hydrate_gcounter_registry(&store, &node_id, &mut counters) {
@@ -91,6 +102,9 @@ impl SyncManager {
             seen_ops: Arc::new(RwLock::new(HashSet::new())),
             op_tx,
             op_rx: Some(op_rx),
+            shutdown_tx,
+            event_task: None,
+            broadcast_task: None,
         }
     }
 
@@ -157,35 +171,38 @@ impl SyncManager {
         let counters = Arc::clone(&self.counters);
         let seen_ops = Arc::clone(&self.seen_ops);
         let store = Arc::clone(&self.store);
-        tokio::spawn(async move {
-            while let Some(event) = event_rx.recv().await {
-                match event {
-                    NodeEvent::OpsReceived { from, ops } => {
-                        debug!(from = %from, count = ops.len(), "received ops from peer");
-                        for op in ops {
-                            if let Err(e) = apply_remote_op(&op, &counters, &seen_ops, &store).await
-                            {
-                                error!(error = %e, "failed to apply remote op");
-                            }
+        let mut shutdown_rx = self.shutdown_tx.subscribe();
+        self.event_task = Some(tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    _ = shutdown_rx.changed() => {
+                        if *shutdown_rx.borrow() {
+                            debug!("event loop shutdown requested");
+                            drain_node_events(&mut event_rx, &counters, &seen_ops, &store).await;
+                            break;
                         }
                     }
-                    NodeEvent::PeerConnected { node_id } => {
-                        info!(peer = %node_id, "peer connected");
-                    }
-                    NodeEvent::PeerDisconnected { node_id } => {
-                        info!(peer = %node_id, "peer disconnected");
+                    event = event_rx.recv() => {
+                        let Some(event) = event else {
+                            break;
+                        };
+                        handle_node_event(event, &counters, &seen_ops, &store).await;
                     }
                 }
             }
             debug!("event loop terminated");
-        });
+        }));
 
         // Outbound loop: drain locally-produced ops into the network.
         let op_rx = self
             .op_rx
             .take()
             .expect("op_rx already taken: SyncManager::start called twice?");
-        spawn_broadcast_loop(Arc::clone(&node), op_rx);
+        self.broadcast_task = Some(spawn_broadcast_loop(
+            Arc::clone(&node),
+            op_rx,
+            self.shutdown_tx.subscribe(),
+        ));
 
         Ok(())
     }
@@ -218,32 +235,119 @@ impl SyncManager {
         let counters = self.counters.read().await;
         counters.get(key).map(|c| c.value()).unwrap_or(0)
     }
+
+    /// Gracefully stop sync tasks and close network connections.
+    pub async fn shutdown(&mut self) -> anyhow::Result<()> {
+        let _ = self.shutdown_tx.send(true);
+
+        if let Some(task) = self.broadcast_task.take()
+            && let Err(e) = task.await
+        {
+            warn!(error = %e, "broadcast task failed during shutdown");
+        }
+
+        if let Some(node) = self.node.as_ref() {
+            node.shutdown().await;
+        }
+
+        if let Some(task) = self.event_task.take()
+            && let Err(e) = task.await
+        {
+            warn!(error = %e, "event task failed during shutdown");
+        }
+
+        info!("sync manager shut down");
+        Ok(())
+    }
 }
 
 /// Spawn the outbound broadcast drain loop.
-fn spawn_broadcast_loop(node: Arc<Node>, mut op_rx: mpsc::Receiver<Op>) {
+fn spawn_broadcast_loop(
+    node: Arc<Node>,
+    mut op_rx: mpsc::Receiver<Op>,
+    mut shutdown_rx: watch::Receiver<bool>,
+) -> JoinHandle<()> {
     tokio::spawn(async move {
-        while let Some(first) = op_rx.recv().await {
-            let mut batch = Vec::with_capacity(BROADCAST_BATCH_MAX);
-            batch.push(first);
-
-            // Coalesce any ops already queued, without yielding.
-            while batch.len() < BROADCAST_BATCH_MAX {
-                match op_rx.try_recv() {
-                    Ok(op) => batch.push(op),
-                    Err(_) => break,
+        loop {
+            tokio::select! {
+                _ = shutdown_rx.changed() => {
+                    if *shutdown_rx.borrow() {
+                        debug!("broadcast loop shutdown requested");
+                        drain_broadcast_queue(&node, &mut op_rx).await;
+                        break;
+                    }
+                }
+                op = op_rx.recv() => {
+                    let Some(first) = op else {
+                        break;
+                    };
+                    broadcast_batch(&node, &mut op_rx, first).await;
                 }
             }
+        }
+        debug!("broadcast loop terminated");
+    })
+}
 
-            let count = batch.len();
-            if let Err(e) = node.broadcast_ops(batch).await {
-                warn!(error = %e, count, "broadcast failed; ops dropped for this round");
-            } else {
-                debug!(count, "broadcast batch sent");
+async fn broadcast_batch(node: &Arc<Node>, op_rx: &mut mpsc::Receiver<Op>, first: Op) {
+    let mut batch = Vec::with_capacity(BROADCAST_BATCH_MAX);
+    batch.push(first);
+
+    // Coalesce any ops already queued, without yielding.
+    while batch.len() < BROADCAST_BATCH_MAX {
+        match op_rx.try_recv() {
+            Ok(op) => batch.push(op),
+            Err(_) => break,
+        }
+    }
+
+    let count = batch.len();
+    if let Err(e) = node.broadcast_ops(batch).await {
+        warn!(error = %e, count, "broadcast failed; ops dropped for this round");
+    } else {
+        debug!(count, "broadcast batch sent");
+    }
+}
+
+async fn drain_broadcast_queue(node: &Arc<Node>, op_rx: &mut mpsc::Receiver<Op>) {
+    while let Ok(first) = op_rx.try_recv() {
+        broadcast_batch(node, op_rx, first).await;
+    }
+}
+
+async fn drain_node_events(
+    event_rx: &mut mpsc::Receiver<NodeEvent>,
+    counters: &Arc<RwLock<HashMap<String, GCounter>>>,
+    seen_ops: &Arc<RwLock<HashSet<String>>>,
+    store: &Arc<NxStore>,
+) {
+    while let Ok(event) = event_rx.try_recv() {
+        handle_node_event(event, counters, seen_ops, store).await;
+    }
+}
+
+async fn handle_node_event(
+    event: NodeEvent,
+    counters: &Arc<RwLock<HashMap<String, GCounter>>>,
+    seen_ops: &Arc<RwLock<HashSet<String>>>,
+    store: &Arc<NxStore>,
+) {
+    match event {
+        NodeEvent::OpsReceived { from, ops } => {
+            debug!(from = %from, count = ops.len(), "received ops from peer");
+            for op in ops {
+                if let Err(e) = apply_remote_op(&op, counters, seen_ops, store).await {
+                    error!(error = %e, "failed to apply remote op");
+                }
             }
         }
-        debug!("broadcast loop terminated (op channel closed)");
-    });
+        NodeEvent::PeerConnected { node_id } => {
+            info!(peer = %node_id, "peer connected");
+        }
+        NodeEvent::PeerDisconnected { node_id } => {
+            info!(peer = %node_id, "peer disconnected");
+        }
+    }
 }
 
 pub(crate) fn materialized_gcounter_key(key: &str) -> Vec<u8> {
@@ -520,6 +624,24 @@ mod tests {
         wait_for_counter(&manager_b, key, 2).await;
         assert_eq!(read_materialized(&store_a, key), 2);
         assert_eq!(read_materialized(&store_b, key), 2);
+    }
+
+    #[tokio::test]
+    async fn shutdown_drains_queued_ops_before_closing_connections() {
+        let key = "visits";
+        let addr_a = free_addr();
+        let addr_b = free_addr();
+        let (mut manager_a, handle_a, _store_a) = started_manager(addr_a).await;
+        let (manager_b, _handle_b, store_b) = started_manager(addr_b.clone()).await;
+
+        manager_a.connect_to_peer(&addr_b).await.unwrap();
+
+        let op = Op::gcounter_increment(handle_a.node_id().clone(), key, 1);
+        handle_a.op_sender().send(op).await.unwrap();
+        manager_a.shutdown().await.unwrap();
+
+        wait_for_counter(&manager_b, key, 1).await;
+        assert_eq!(read_materialized(&store_b, key), 1);
     }
 
     #[test]

--- a/crates/nx-core/src/sync_manager.rs
+++ b/crates/nx-core/src/sync_manager.rs
@@ -199,6 +199,15 @@ impl SyncManager {
         Ok(())
     }
 
+    /// Retry connecting to the peers configured at startup.
+    pub async fn reconnect_configured_peers(&self) {
+        for peer_addr in &self.config.peers {
+            if let Err(e) = self.connect_to_peer(peer_addr).await {
+                debug!(peer = %peer_addr, error = %e, "configured peer reconnect failed");
+            }
+        }
+    }
+
     /// Broadcast of pending operations, this method can be used for forced flush
     pub async fn broadcast_pending(&self) -> anyhow::Result<()> {
         Ok(())

--- a/crates/nx-net/src/node.rs
+++ b/crates/nx-net/src/node.rs
@@ -121,8 +121,15 @@ impl Node {
                         let tls = tls.clone();
 
                         tokio::spawn(async move {
-                            if let Err(e) =
-                                handle_incoming(stream, tls, node_id, peers, event_tx).await
+                            if let Err(e) = handle_incoming(
+                                stream,
+                                addr.to_string(),
+                                tls,
+                                node_id,
+                                peers,
+                                event_tx,
+                            )
+                            .await
                             {
                                 error!(%addr, error = %e, "connection error");
                             }
@@ -297,14 +304,23 @@ impl Node {
             .filter(|c| c.state == PeerState::Connected)
             .count()
     }
+
+    /// Close outbound peer connections by dropping their writers.
+    pub async fn shutdown(&self) {
+        let mut peers = self.peers.write().await;
+        let count = peers.len();
+        peers.clear();
+        debug!(count, "node peer connections closed");
+    }
 }
 
 /// Manage an incoming connection from a peer (handshake + read loop).
 async fn handle_incoming(
     stream: TcpStream,
+    addr: String,
     tls: Option<TlsConfig>,
     our_node_id: NodeId,
-    _peers: Arc<RwLock<HashMap<String, PeerConnection>>>,
+    peers: Arc<RwLock<HashMap<String, PeerConnection>>>,
     event_tx: mpsc::Sender<NodeEvent>,
 ) -> NetResult<()> {
     let stream: NetStream = match tls {
@@ -366,6 +382,18 @@ async fn handle_incoming(
     let ack = Message::hello_ack(our_node_id);
     write_message(&mut writer, &ack).await?;
 
+    {
+        let mut peers = peers.write().await;
+        peers.insert(
+            addr.clone(),
+            PeerConnection {
+                info: PeerInfo::new(&addr).with_node_id(peer_node_id.clone()),
+                state: PeerState::Connected,
+                writer: Some(writer),
+            },
+        );
+    }
+
     info!(peer = %peer_node_id, "incoming peer connected");
 
     // Notify Event
@@ -377,6 +405,11 @@ async fn handle_incoming(
 
     // Read Loop
     read_loop(reader, peer_node_id.clone(), event_tx.clone()).await?;
+
+    {
+        let mut peers = peers.write().await;
+        peers.remove(&addr);
+    }
 
     let _ = event_tx
         .send(NodeEvent::PeerDisconnected {

--- a/crates/nx-net/src/node.rs
+++ b/crates/nx-net/src/node.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use nx_sync::{NodeId, Op};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
-use tokio::sync::{RwLock, mpsc};
+use tokio::sync::{RwLock, mpsc, watch};
 use tracing::{debug, error, info, warn};
 
 use crate::error::{NetError, NetResult};
@@ -76,18 +76,21 @@ pub struct Node {
     peers: Arc<RwLock<HashMap<String, PeerConnection>>>,
     event_tx: mpsc::Sender<NodeEvent>,
     event_rx: Option<mpsc::Receiver<NodeEvent>>,
+    shutdown_tx: watch::Sender<bool>,
 }
 
 impl Node {
     /// crate new node
     pub fn new(config: NodeConfig) -> Self {
         let (event_tx, event_rx) = mpsc::channel(100);
+        let (shutdown_tx, _shutdown_rx) = watch::channel(false);
 
         Self {
             config,
             peers: Arc::new(RwLock::new(HashMap::new())),
             event_tx,
             event_rx: Some(event_rx),
+            shutdown_tx,
         }
     }
 
@@ -109,34 +112,45 @@ impl Node {
         let node_id = self.config.node_id.clone();
         let event_tx = self.event_tx.clone();
         let tls = self.config.tls.clone();
+        let mut shutdown_rx = self.shutdown_tx.subscribe();
 
         tokio::spawn(async move {
             loop {
-                match listener.accept().await {
-                    Ok((stream, addr)) => {
-                        info!(%addr, "incoming connection");
-                        let peers = Arc::clone(&peers);
-                        let node_id = node_id.clone();
-                        let event_tx = event_tx.clone();
-                        let tls = tls.clone();
-
-                        tokio::spawn(async move {
-                            if let Err(e) = handle_incoming(
-                                stream,
-                                addr.to_string(),
-                                tls,
-                                node_id,
-                                peers,
-                                event_tx,
-                            )
-                            .await
-                            {
-                                error!(%addr, error = %e, "connection error");
-                            }
-                        });
+                tokio::select! {
+                    _ = shutdown_rx.changed() => {
+                        if *shutdown_rx.borrow() {
+                            debug!("listener shutdown requested");
+                            break;
+                        }
                     }
-                    Err(e) => {
-                        error!(error = %e, "accept error");
+                    accepted = listener.accept() => {
+                        match accepted {
+                            Ok((stream, addr)) => {
+                                info!(%addr, "incoming connection");
+                                let peers = Arc::clone(&peers);
+                                let node_id = node_id.clone();
+                                let event_tx = event_tx.clone();
+                                let tls = tls.clone();
+
+                                tokio::spawn(async move {
+                                    if let Err(e) = handle_incoming(
+                                        stream,
+                                        addr.to_string(),
+                                        tls,
+                                        node_id,
+                                        peers,
+                                        event_tx,
+                                    )
+                                    .await
+                                    {
+                                        error!(%addr, error = %e, "connection error");
+                                    }
+                                });
+                            }
+                            Err(e) => {
+                                error!(error = %e, "accept error");
+                            }
+                        }
                     }
                 }
             }
@@ -307,6 +321,7 @@ impl Node {
 
     /// Close outbound peer connections by dropping their writers.
     pub async fn shutdown(&self) {
+        let _ = self.shutdown_tx.send(true);
         let mut peers = self.peers.write().await;
         let count = peers.len();
         peers.clear();

--- a/crates/nx-store/src/store.rs
+++ b/crates/nx-store/src/store.rs
@@ -44,6 +44,11 @@ impl Store {
         Ok(())
     }
 
+    pub fn flush(&self) -> Result<(), StoreError> {
+        self.db.flush()?;
+        Ok(())
+    }
+
     #[allow(clippy::type_complexity)]
     pub fn scan_prefix(&self, prefix: &[u8]) -> Result<Vec<(Vec<u8>, Vec<u8>)>, StoreError> {
         let mut out = Vec::new();

--- a/crates/nx-store/tests/basic.rs
+++ b/crates/nx-store/tests/basic.rs
@@ -38,6 +38,17 @@ fn scan_prefix_works() {
 }
 
 #[test]
+fn flush_works() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = Store::open(dir.path()).unwrap();
+
+    store.set(b"key", b"value").unwrap();
+    store.flush().unwrap();
+
+    assert_eq!(store.get(b"key").unwrap(), Some(b"value".to_vec()));
+}
+
+#[test]
 fn open_creates_dir_if_missing() {
     let tmp = tempfile::tempdir().unwrap();
     let db_dir = tmp.path().join("nx-store-data-does-not-exist-yet");

--- a/examples/distributed_counter/README.md
+++ b/examples/distributed_counter/README.md
@@ -16,7 +16,11 @@ cargo build --release --target wasm32-unknown-unknown
 ```bash
 nx run target/wasm32-unknown-unknown/release/distributed_counter.wasm \
     --listen 0.0.0.0:9000 \
+    --peer 127.0.0.1:9001 \
     --datastore-path ./data-a \
+    --wait-before-run 1500ms \
+    --settle-for 2s \
+    --print-gcounter counter:visits \
     -v
 ```
 
@@ -27,19 +31,28 @@ nx run target/wasm32-unknown-unknown/release/distributed_counter.wasm \
     --listen 0.0.0.0:9001 \
     --peer 127.0.0.1:9000 \
     --datastore-path ./data-b \
+    --wait-before-run 1500ms \
+    --settle-for 2s \
+    --print-gcounter counter:visits \
     -v
 ```
 
 ## Expected behavior
 
-Running the guest repeatedly on both nodes, the counter converges:
+Each invocation runs the guest once, waits for the configured settle window,
+prints the final materialized GCounter value, flushes the local store and exits:
 - each run performs one local increment (`crdt::gcounter::inc(key, 1)`)
 - the increment is broadcast to peers asynchronously
-- subsequent runs on any node observe the sum of all increments produced
-  across the cluster so far
+- `--wait-before-run` gives both processes time to connect before the guest
+  emits its increment
+- `--settle-for` gives PushOps and remote apply time to complete before exit
+- `--print-gcounter counter:visits` prints a final host-side value after settle
 
-Example: run 3 times on A, 2 times on B → after replication settles, both
-nodes report `value = 5`.
+With the two commands above, both nodes should print:
+
+```text
+counter:visits = 2
+```
 
 ## Notes
 
@@ -50,6 +63,9 @@ nodes report `value = 5`.
   will log a message and exit, since `crdt::*` APIs require replication
   to be enabled on the runtime.
 - Each node has its own datastore (`./data-a`, `./data-b`). Counter totals are
-  materialized to sled after local and remote updates; startup recovery from
-  those materialized values is still planned work.
-- The `-v` flag enables verbose logs to observe the broadcast / apply path.
+  materialized to sled after local and remote updates, flushed on shutdown and
+  hydrated back into the in-memory registry on startup.
+- Without `--settle-for`, a sync-enabled runtime stays alive until it receives
+  SIGINT/SIGTERM/SIGHUP.
+- The `-v` flag enables verbose logs to observe lifecycle, broadcast and apply
+  paths.

--- a/examples/distributed_counter/src/lib.rs
+++ b/examples/distributed_counter/src/lib.rs
@@ -11,7 +11,11 @@
 //! ```bash
 //! nx run distributed_counter.wasm \
 //!     --listen 0.0.0.0:9000 \
-//!     --datastore-path ./data-a
+//!     --peer 127.0.0.1:9001 \
+//!     --datastore-path ./data-a \
+//!     --wait-before-run 1500ms \
+//!     --settle-for 2s \
+//!     --print-gcounter counter:visits
 //! ```
 //!
 //! Terminal 2 (Node B):
@@ -19,7 +23,10 @@
 //! nx run distributed_counter.wasm \
 //!     --listen 0.0.0.0:9001 \
 //!     --peer 127.0.0.1:9000 \
-//!     --datastore-path ./data-b
+//!     --datastore-path ./data-b \
+//!     --wait-before-run 1500ms \
+//!     --settle-for 2s \
+//!     --print-gcounter counter:visits
 //! ```
 
 extern crate alloc;

--- a/examples/vote_tally_tls/README.md
+++ b/examples/vote_tally_tls/README.md
@@ -105,6 +105,9 @@ nx run target/wasm32-unknown-unknown/release/vote_tally_tls.wasm \
     --tls-key tls/node-a-key.pem \
     --tls-ca tls/ca.pem \
     --allowed-peers "$ALLOWLIST" \
+    --wait-before-run 2s \
+    --settle-for 3s \
+    --print-gcounter vote:tally:yes \
     -v
 ```
 
@@ -120,6 +123,9 @@ nx run target/wasm32-unknown-unknown/release/vote_tally_tls.wasm \
     --tls-key tls/node-b-key.pem \
     --tls-ca tls/ca.pem \
     --allowed-peers "$ALLOWLIST" \
+    --wait-before-run 2s \
+    --settle-for 3s \
+    --print-gcounter vote:tally:yes \
     -v
 ```
 
@@ -135,7 +141,18 @@ nx run target/wasm32-unknown-unknown/release/vote_tally_tls.wasm \
     --tls-key tls/node-c-key.pem \
     --tls-ca tls/ca.pem \
     --allowed-peers "$ALLOWLIST" \
+    --wait-before-run 2s \
+    --settle-for 3s \
+    --print-gcounter vote:tally:yes \
     -v
+```
+
+With the three commands above, each process casts one local vote, waits for
+peer replication, prints the final host-side tally and exits. Once all three
+nodes have exchanged their PushOps, each node should print:
+
+```text
+vote:tally:yes = 3
 ```
 
 ## Notes
@@ -144,5 +161,8 @@ nx run target/wasm32-unknown-unknown/release/vote_tally_tls.wasm \
 - The allowlist admits only the three certificate-derived NodeIds.
 - The guest never writes votes through `nx_sdk::db::*`; replicated state goes
   through `nx_sdk::crdt::gcounter`.
-- Current runtime lifecycle is one guest run per `nx run`. Run the nodes again
-  after peers have connected to observe newly replicated/materialized totals.
+- `--wait-before-run` gives the three TLS handshakes time to complete before
+  the guest emits its vote.
+- `--settle-for` gives PushOps and remote apply time to complete before exit.
+- Without `--settle-for`, a sync-enabled runtime stays alive until SIGINT,
+  SIGTERM or SIGHUP and flushes the store during shutdown.


### PR DESCRIPTION
## Summary

Hiiii ! The first alpha version was surprisingly more successful than expected, so I decided to release a second one right away.

The `v0.1.0-alpha.2` version concludes Phase 7 and makes synchronization usable from the command line: long-running synchronization nodes, limited synchronization mode, startup hydration, signal-based shutdown, final store flushing, and multi-process smoke coverage.

## What changed

- Sync-enabled `nx run` can now stay alive as a runtime node.
- CLI demos can use `--wait-before-run`, `--settle-for`, and
  `--print-gcounter` to show convergence in a bounded run.
- GCounter values materialized in sled are hydrated back into the runtime on
  startup.
- SIGINT, SIGTERM and SIGHUP now trigger graceful shutdown.
- Shutdown drains in-flight sync work, closes connections, and flushes the store.
- The distributed examples and docs now reflect the alpha.2 lifecycle.

## Why it matters

The previous alpha proved the internal sync path.
This one makes it visible from real CLI processes: separate runtimes, separate
datastores, real network replication, convergent CRDT state.

## What is next

`v0.1.0-alpha.3` is already planned and will focus on the next hardening step.
The goal is to keep the previews small, honest, and immediately testable.

Thank you so much everyone !!
