### PR TITLE
Added a minimal C guest example

### DIFF
--- a/examples/guest_c/.gitignore
+++ b/examples/guest_c/.gitignore
@@ -1,0 +1,4 @@
+# ignore the generated .wasm file
+# since other modules under example/ doesnt commit the .wasm 
+# but rather generates it post-build under the target/ dir which is ignored anyways 
+*.wasm

--- a/examples/guest_c/README.md
+++ b/examples/guest_c/README.md
@@ -1,0 +1,63 @@
+# Guest example in C
+
+Basic C example which compiles to WASM and performs a simple logging + DB-write style example
+
+> Note: This example intentionally keeps the guest minimal and avoids libc / stdlib usage to make the ABI interaction easier to inspect and reason about.
+
+## Important
+
+- Host functions are imported manually through the `nx` namespace.
+- Strings are passed as raw pointers + lengths.
+- The example uses `-nostdlib` for a minimal WASM module.
+- `--allow-undefined` is required because Numax provides imports at runtime.
+
+## Requirements
+
+- WASI SDK / clang in path
+- A built `nx` runtime
+
+The runtime can be built from the repository root with:
+
+```bash
+cargo build --release
+```
+
+## Build
+
+### Windows
+
+```bash
+cd /examples/guest_c
+./build.bat
+```
+
+### Linux / MacOS
+
+```bash
+cd /examples/guest_c
+chmod +x build.sh
+./build.sh
+```
+
+This generates:
+
+```bash
+guest.wasm
+```
+
+In the guest_c directory
+
+## Run
+
+From the repository root:
+
+```bash
+.\target\release\nx.exe run .\examples\guest_c\guest.wasm
+```
+
+output:
+
+```bash
+[guest] Hello from C guest!
+[guest] db_set ok
+```

--- a/examples/guest_c/README.md
+++ b/examples/guest_c/README.md
@@ -51,8 +51,16 @@ In the guest_c directory
 
 From the repository root:
 
+### Run on Windows
+
 ```bash
 .\target\release\nx.exe run .\examples\guest_c\guest.wasm
+```
+
+### Run on MacOS/Linux
+
+```bash
+./target/release/nx run ./examples/guest_c/guest.wasm
 ```
 
 output:

--- a/examples/guest_c/build.bat
+++ b/examples/guest_c/build.bat
@@ -1,0 +1,15 @@
+@echo off
+
+clang ^
+  --target=wasm32-wasip1 ^
+  -O3 ^
+  -nostdlib ^
+  -Wl,--no-entry ^
+  -Wl,--export=run ^
+  -Wl,--allow-undefined ^
+  -o guest.wasm ^
+  src\guest.c
+
+echo.
+echo Build complete:
+echo guest.wasm

--- a/examples/guest_c/build.bat
+++ b/examples/guest_c/build.bat
@@ -1,5 +1,7 @@
 @echo off
 
+echo Building guest_c WASM module
+
 clang ^
   --target=wasm32-wasip1 ^
   -O3 ^
@@ -9,6 +11,13 @@ clang ^
   -Wl,--allow-undefined ^
   -o guest.wasm ^
   src\guest.c
+
+IF %ERRORLEVEL% NEQ 0 (
+    echo.
+    echo build failed.
+    echo contains compiler errors
+    exit /b %ERRORLEVEL%
+)
 
 echo.
 echo Build complete:

--- a/examples/guest_c/build.sh
+++ b/examples/guest_c/build.sh
@@ -1,4 +1,13 @@
+#!/usr/bin/env bash
+
 set -e
+
+if ! command -v clang >/dev/null 2>&1; then
+    echo "[error] clang not found in PATH"
+    exit 1
+fi
+
+echo "Building guest_c WASM module"
 
 clang \
   --target=wasm32-wasip1 \

--- a/examples/guest_c/build.sh
+++ b/examples/guest_c/build.sh
@@ -1,0 +1,15 @@
+set -e
+
+clang \
+  --target=wasm32-wasip1 \
+  -O3 \
+  -nostdlib \
+  -Wl,--no-entry \
+  -Wl,--export=run \
+  -Wl,--allow-undefined \
+  -o guest.wasm \
+  src/guest.c
+
+echo
+echo "Build complete:"
+echo "guest.wasm"

--- a/examples/guest_c/src/guest.c
+++ b/examples/guest_c/src/guest.c
@@ -25,13 +25,14 @@ extern int db_set(
  */
 __attribute__((export_name("run")))
 void run() {
-    const char* msg = "Hello from C guest!";
-    host_log_v2(msg, 21);
+    const char msg[] = "Hello from C guest!";
+    host_log_v2(msg, sizeof(msg) - 1);
 
     const char* key = "hello";
     const char* val = "numax";
 
     db_set(key, 5, val, 5);
 
-    host_log_v2("db_set ok", 9);
+    const char done[] = "db_set ok";
+    host_log_v2(done, sizeof(done) - 1);
 }

--- a/examples/guest_c/src/guest.c
+++ b/examples/guest_c/src/guest.c
@@ -1,0 +1,37 @@
+/*
+ * import `host_log_v2` from the `nx` namespace.
+ * strings are passed as: (pointer, length)
+ * signature: (u32, u32) -> i32
+ */
+__attribute__((import_module("nx")))
+__attribute__((import_name("host_log_v2")))
+extern int host_log_v2(const char* ptr, int len);
+
+/*
+ * IMPORTANT: import `db_set` from the `nx` namespace.
+ * writes a key/value pair into the embedded datastore.
+ */
+__attribute__((import_module("nx")))
+__attribute__((import_name("db_set")))
+extern int db_set(
+    const char* key_ptr,
+    int key_len,
+    const char* val_ptr,
+    int val_len
+);
+
+/*
+ * exported guest entrypoint expected by Numax.
+ */
+__attribute__((export_name("run")))
+void run() {
+    const char* msg = "Hello from C guest!";
+    host_log_v2(msg, 21);
+
+    const char* key = "hello";
+    const char* val = "numax";
+
+    db_set(key, 5, val, 5);
+
+    host_log_v2("db_set ok", 9);
+}


### PR DESCRIPTION
## Summary

Adds a minimal non-Rust guest example written in C and compiled to .wasm (Web Assembly). 
I've tried to comply to the issue #49 requirements to the best of my ability

Closes #49

## Files added

* `examples/guest_c`
* `build.bat`
* `build.sh`
* README containing:

  * build instructions
  * run instructions

## Note

A small quirk I encountered was that all imports defaulted to the `env` namespace unless `import_module("nx")` was explicitly specified.

```bash
[nx-cli] error: Link error while instantiating module: unknown import: `env::db_set` has not been defined
```

The example intentionally keeps the guest minimal and avoids libc / stdlib usage to make the ABI interaction easier to inspect and reason about.