### PR TITLE
v0.1.0-alpha.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2465,6 +2465,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2474,12 +2484,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1468,7 +1468,9 @@ dependencies = [
  "anyhow",
  "clap",
  "nx-core",
+ "serde",
  "tokio",
+ "toml",
  "tracing",
  "tracing-subscriber",
 ]

--- a/HOST_API.md
+++ b/HOST_API.md
@@ -113,8 +113,8 @@ fn db_delete(key_ptr: u32, key_len: u32) -> i32
 CRDT functions operate on replicated data types. In the current implementation,
 GCounter state is held in the runtime sync manager's in-memory registry and
 the current total is materialized to sled after each local or remote update.
-Operations are broadcast to peers when sync is enabled. Startup hydration from
-the materialized sled value is planned but not complete yet.
+Operations are broadcast to peers when sync is enabled. On startup, the runtime
+hydrates the in-memory GCounter registry from the materialized sled values.
 
 #### `crdt_gcounter_inc`
 
@@ -295,7 +295,7 @@ pub extern "C" fn run() {
 - [x] `crdt_gcounter_inc` - Increment GCounter
 - [x] `crdt_gcounter_value` - Read GCounter value
 - [x] Durable GCounter materialization in sled
-- [ ] Startup hydration from materialized GCounter values
+- [x] Startup hydration from materialized GCounter values
 - [ ] `crdt_set_add` - Add element to ORSet
 - [ ] `crdt_set_remove` - Remove element from ORSet
 - [ ] `crdt_set_contains` - Check membership

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Three things, and only three:
 
 You write a WASM module. numax runs it. The state is there. Sync just happens.
 
-> **Status:** `v0.1.0-alpha.2` - public technical preview.
+> **Status:** `v0.1.0-alpha.3` - public technical preview.
 > It works, it's tested, it's honest about what's missing. See [`ROADMAP.md`](./ROADMAP.md).
 
 ---

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -241,16 +241,16 @@ kill -TERM $PID  # Completes operations, exits with code 0
 
 - [x] Peer connection limit (default: 64)
 - [x] Queued ops limit (default: 10000)
-- [ ] Message size limit (default: 16 MiB)
-- [ ] Graceful rejection when overloaded
-- [ ] Socket read/write timeouts (default: 30s)
-- [ ] Test: 1000 simultaneous connections → no crash
+- [x] Message size limit (default: 16 MiB)
+- [x] Graceful rejection when overloaded
+- [x] Socket read/write timeouts (default: 30s)
+- [x] Test: 1000 simultaneous connections → no crash
 
 **Configuration**:
 ```toml
 [limits]
 max_peers = 64
-max_pending_ops = 10000
+queued_ops_limit = 10000
 max_message_size = "16MiB"
 socket_timeout_secs = 30
 ```

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -226,14 +226,6 @@ nx run counter.wasm --listen 127.0.0.1:9001 --peer 127.0.0.1:9000 \
 - [x] Test: kill -TERM → no data corruption
 - [x] Test: crash → restart → consistent state
 
-> These tasks complete the CLI criterion left open by Phase 6.5 and bring it
-> inside a general lifecycle: service loop, signal-aware shutdown, final flush
-> and orderly handling of connections.
->
-> Production hardening follow-up for `v0.1.0`: network read loops should exit
-> cooperatively on shutdown, emit the normal disconnect cleanup path and use
-> forced task abort only as a bounded fallback.
-
 **Remaining hardening:**
 - [x] Read loops listen to the runtime shutdown signal instead of relying only
       on socket close/timeout.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -229,6 +229,18 @@ nx run counter.wasm --listen 127.0.0.1:9001 --peer 127.0.0.1:9000 \
 > These tasks complete the CLI criterion left open by Phase 6.5 and bring it
 > inside a general lifecycle: service loop, signal-aware shutdown, final flush
 > and orderly handling of connections.
+>
+> Production hardening follow-up for `v0.1.0`: network read loops should exit
+> cooperatively on shutdown, emit the normal disconnect cleanup path and use
+> forced task abort only as a bounded fallback.
+
+**Remaining hardening:**
+- [ ] Read loops listen to the runtime shutdown signal instead of relying only
+      on socket close/timeout.
+- [ ] Node shutdown waits a bounded time for network tasks to exit
+      cooperatively before aborting them.
+- [ ] Test: active peer connections shut down without waiting for the socket
+      read timeout.
 
 **Criteria**:
 ```bash
@@ -310,8 +322,14 @@ HTTP endpoint over Tokio.
 - [ ] Peer rotation (replace dead peers)
 - [ ] Periodic anti-entropy (pull every N seconds)
 - [ ] Op deduplication (bloom filter or set of OpIds)
+- [ ] Durable CRDT state or op log, so restart/reconnect can recover full
+      CRDT state rather than only materialized totals.
+- [ ] Startup hydration from durable CRDT state/op log.
+- [ ] Persist dedup metadata, or otherwise prevent duplicate remote ops after
+      restart.
 - [ ] Test: intermittent network (10% packet loss)
 - [ ] Test: node dies and comes back → converges
+- [ ] Test: duplicate op after restart does not double count
 
 ---
 
@@ -435,7 +453,7 @@ criterion remains tracked in Phase 7 as lifecycle/settle/hydration.
 - [x] Phase 7 (Graceful shutdown) complete
 - [ ] Phase 8 (Backpressure) complete
 - [ ] Phase 9 (Observability) at least logging + health
-- [ ] Phase 10 (Resilience) at least reconnect + dedup
+- [ ] Phase 10 (Resilience) at least reconnect + dedup + durable CRDT recovery
 - [ ] Phase 11 (Serialization) JSON + bincode working
 - [ ] Phase 12 (Host API) at least db_scan, time_now, random_bytes
 - [ ] Phase 13 (Load testing) at least the 3-nodes-1h scenario

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -235,11 +235,11 @@ nx run counter.wasm --listen 127.0.0.1:9001 --peer 127.0.0.1:9000 \
 > forced task abort only as a bounded fallback.
 
 **Remaining hardening:**
-- [ ] Read loops listen to the runtime shutdown signal instead of relying only
+- [x] Read loops listen to the runtime shutdown signal instead of relying only
       on socket close/timeout.
-- [ ] Node shutdown waits a bounded time for network tasks to exit
+- [x] Node shutdown waits a bounded time for network tasks to exit
       cooperatively before aborting them.
-- [ ] Test: active peer connections shut down without waiting for the socket
+- [x] Test: active peer connections shut down without waiting for the socket
       read timeout.
 
 **Criteria**:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Numax Roadmap
 
-> **Current release**: `v0.1.0-alpha.2` - developer preview.
+> **Current release**: `v0.1.0-alpha.3` - developer preview.
 > **Final goal `v0.1.0`**: production-ready runtime for non-critical workloads.
 > **Status**: alpha for feedback; production hardening still in progress.
 
@@ -29,6 +29,24 @@ Includes:
 Known limitations:
 - Full network resilience, serialization hardening and the extended host API are
   still open phases.
+- API and wire format may change before `v0.1.0`.
+
+### v0.1.0-alpha.3 ✅
+**Purpose**: hardening preview for lifecycle, backpressure and observability.
+
+Includes:
+- Everything in `v0.1.0-alpha.2`.
+- Phase 7 lifecycle hardening: stable runtime NodeId, startup hydration,
+  cooperative network read-loop shutdown, bounded task shutdown fallback and
+  final store flush.
+- Phase 8 backpressure and limits: peer limit during handshake, queued ops
+  limit, message size limit and socket read/write timeouts.
+- Phase 9 minimal observability: configurable logging, `/metrics`, `/health`
+  and `/ready`.
+
+Known limitations:
+- Durable full CRDT state/op-log recovery, automatic reconnect and anti-entropy
+  remain tracked in Phase 10.
 - API and wire format may change before `v0.1.0`.
 
 ### v0.1.0 🎯
@@ -417,9 +435,9 @@ For each one: implementation, property tests, OpKind, docs, example.
 | 0-5 | Foundation | ✅ | - |
 | 6 | Transport Security | ✅ | **P0** |
 | 6.5 | End-to-End Sync Wiring | ✅* | **P0** |
-| 7 | Graceful Lifecycle | ⏳ | **P0** |
-| 8 | Backpressure | ⏳ | **P0** |
-| 9 | Observability | ⏳ | **P1** |
+| 7 | Graceful Lifecycle | ✅ | **P0** |
+| 8 | Backpressure | ✅ | **P0** |
+| 9 | Observability | ✅ | **P1** |
 | 10 | Network Resilience | ⏳ | **P1** |
 | 11 | Dual Serialization | ⏳ | **P1** |
 | 12 | Extended Host API | ⏳ | **P1** |
@@ -443,8 +461,8 @@ criterion remains tracked in Phase 7 as lifecycle/settle/hydration.
 - [x] Phase 6 (TLS) complete
 - [x] Phase 6.5 (End-to-End Sync) complete
 - [x] Phase 7 (Graceful shutdown) complete
-- [ ] Phase 8 (Backpressure) complete
-- [ ] Phase 9 (Observability) at least logging + health
+- [x] Phase 8 (Backpressure) complete
+- [x] Phase 9 (Observability) at least logging + health
 - [ ] Phase 10 (Resilience) at least reconnect + dedup + durable CRDT recovery
 - [ ] Phase 11 (Serialization) JSON + bincode working
 - [ ] Phase 12 (Host API) at least db_scan, time_now, random_bytes
@@ -464,6 +482,17 @@ criterion remains tracked in Phase 7 as lifecycle/settle/hydration.
 - [x] Base WASM examples present
 - [x] `cargo test` passes outside the sandbox
 - [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
+- [x] Known limitations documented in the roadmap
+
+---
+
+## v0.1.0-alpha.3 Release Criteria
+
+- [x] Phase 7 graceful lifecycle hardening complete
+- [x] Phase 8 backpressure complete
+- [x] Phase 9 minimal observability complete
+- [x] `cargo test` passes
+- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
 - [x] Known limitations documented in the roadmap
 
 ---

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -27,7 +27,8 @@ Includes:
 - Examples: `distributed_counter`, `distributed_chat` local-only, `vote_tally_tls`.
 
 Known limitations:
-- Backpressure, observability and full network resilience are still open phases.
+- Full network resilience, serialization hardening and the extended host API are
+  still open phases.
 - API and wire format may change before `v0.1.0`.
 
 ### v0.1.0 🎯
@@ -261,23 +262,32 @@ socket_timeout_secs = 30
 **Goal**: Visibility into what the runtime is doing
 
 **Structured logging**:
-- [ ] JSON format for logs
-- [ ] Configurable levels (trace/debug/info/warn/error)
-- [ ] Correlation ID to trace operations
+- [x] JSON format for logs
+- [x] Configurable levels (trace/debug/info/warn/error)
+- [x] Correlation ID to trace operations
 
 **Metrics**:
-- [ ] `numax_ops_total` - Operations processed
-- [ ] `numax_peers_connected` - Active peers
-- [ ] `numax_sync_latency_ms` - Sync latency
-- [ ] `numax_store_keys` - Keys in the store
-- [ ] `numax_store_bytes` - Bytes used
-- [ ] `/metrics` endpoint (Prometheus format)
+- [x] `numax_ops_total` - Operations processed
+- [x] `numax_peers_connected` - Active peers
+- [x] `numax_sync_latency_ms` - Sync latency
+- [x] `numax_store_keys` - Keys in the store
+- [x] `numax_store_bytes` - Bytes used
+- [x] `/metrics` endpoint (Prometheus format)
 
 **Health check**:
-- [ ] `/health` endpoint (liveness)
-- [ ] `/ready` endpoint (readiness)
+- [x] `/health` endpoint (liveness)
+- [x] `/ready` endpoint (readiness)
 
-**Libraries**: `tracing`, `tracing-subscriber`, `metrics`, `metrics-exporter-prometheus`
+**Configuration**:
+```toml
+[observability]
+listen = "127.0.0.1:9100"
+log_level = "info"
+log_format = "text"
+```
+
+**Implementation**: `tracing`, `tracing-subscriber`, minimal Prometheus-compatible
+HTTP endpoint over Tokio.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -239,8 +239,8 @@ kill -TERM $PID  # Completes operations, exits with code 0
 ### Phase 8: Backpressure and Limits ⚡
 **Goal**: Stability under load
 
-- [ ] Peer connection limit (default: 64)
-- [ ] Queued ops limit (default: 10000)
+- [x] Peer connection limit (default: 64)
+- [x] Queued ops limit (default: 10000)
 - [ ] Message size limit (default: 16 MiB)
 - [ ] Graceful rejection when overloaded
 - [ ] Socket read/write timeouts (default: 30s)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -272,11 +272,21 @@ socket_timeout_secs = 30
 - [x] `numax_sync_latency_ms` - Sync latency
 - [x] `numax_store_keys` - Keys in the store
 - [x] `numax_store_bytes` - Bytes used
+- [x] `numax_sync_errors_total` - Sync errors
+- [x] `numax_observability_requests_total` - Observability requests
+- [x] `numax_observability_errors_total` - Observability request errors
+- [x] `numax_peer_connects_total` - Peer connections observed
+- [x] `numax_peer_disconnects_total` - Peer disconnections observed
+- [x] `numax_broadcast_batches_total` - Broadcast batches sent
+- [x] `numax_broadcast_ops_total` - Broadcast ops sent
 - [x] `/metrics` endpoint (Prometheus format)
 
 **Health check**:
 - [x] `/health` endpoint (liveness)
 - [x] `/ready` endpoint (readiness)
+- [x] Test: `/ready` returns 503 before runtime readiness
+- [x] Test: unknown observability paths return 404
+- [x] Test: observability request timeout is bounded
 
 **Configuration**:
 ```toml
@@ -284,6 +294,7 @@ socket_timeout_secs = 30
 listen = "127.0.0.1:9100"
 log_level = "info"
 log_format = "text"
+request_timeout_secs = 5
 ```
 
 **Implementation**: `tracing`, `tracing-subscriber`, minimal Prometheus-compatible

--- a/WHITEPAPER.md
+++ b/WHITEPAPER.md
@@ -306,6 +306,10 @@ This convention allows the guest to handle errors deterministically, without exc
 | Key length | 1024 bytes |
 | Value length | 1 MB |
 | Output buffer | 10 MB |
+| Peer connections | 64 |
+| Queued CRDT ops | 10000 |
+| Wire message size | 16 MiB |
+| Socket read/write timeout | 30s |
 
 ### 5.2 Numax Store - Local datastore *(Implemented)*
 
@@ -455,9 +459,10 @@ Numax Net handles communication between nodes for state synchronization.
 
 - TCP + TLS 1.3 + mTLS channel *(Implemented)*;
 - handshake, push/pull and keepalive *(Implemented)*;
+- peer connection limit, queued-op limit, message-size limit and socket read/write timeouts *(Implemented)*;
 - peer-to-peer gossip with K-fanout: architecture defined, full integration in progress *(Prototype)*;
 - full network resilience (reconnect with exponential backoff, automatic anti-entropy, op dedup) *(Planned, Phase 10)*;
-- backpressure and connection limits *(Planned, Phase 8)*.
+- automatic anti-entropy after long disconnections *(Planned, Phase 10)*.
 
 ### 5.5 Channel security *(Implemented)*
 
@@ -526,6 +531,9 @@ nx run <module.wasm>
 # Runs with a custom data directory
 nx run <module.wasm> --datastore-path ./my-data
 
+# Runs with a TOML configuration file
+nx run <module.wasm> --config ./numax.toml
+
 # Runs as a sync-enabled node
 nx run <module.wasm> \
     --listen 0.0.0.0:9000 \
@@ -555,6 +563,7 @@ nx run <module.wasm> \
 | Flag | Description |
 |------|-------------|
 | `--datastore-path` | Directory for persistent data |
+| `--config` | TOML configuration file |
 | `--listen` | Address on which to accept peer connections and enable sync |
 | `--peer` | Initial peer address (repeatable) |
 | `--wait-before-run` | Bounded pre-run window for peer handshakes |
@@ -564,6 +573,18 @@ nx run <module.wasm> \
 | `--tls-cert` / `--tls-key` / `--tls-ca` | TLS material for mTLS |
 | `--allowed-peers` | Allowlist of accepted peer NodeIDs |
 | `--tls-insecure` | Disables TLS (local dev only) |
+
+The implemented `limits` section is intentionally small:
+
+```toml
+[limits]
+max_peers = 64
+queued_ops_limit = 10000
+max_message_size = "16MiB"
+socket_timeout_secs = 30
+```
+
+The same values are the runtime defaults when no config file is provided.
 
 ### 5.8 Topology: epidemic gossip *(Prototype)*
 
@@ -655,11 +676,20 @@ Increment operations are materialized on sled and propagated to peers through th
 | `env_get` | Filtered environment variable reading | *Planned* |
 | `http_fetch` | HTTP request with whitelist | *Planned* |
 
-### 6.3 Configuration and Deployment *(Planned - Phase 15)*
+### 6.3 Configuration and Deployment *(Prototype)*
 
-Deployment will consist in shipping a `.wasm` file and a minimal configuration. Example (format being defined):
+Deployment will consist in shipping a `.wasm` file and a minimal configuration.
+
+The `limits` section below is implemented today. The other deployment sections
+remain planned work.
 
 ```toml
+[limits]
+max_peers = 64
+queued_ops_limit = 10000
+max_message_size = "16MiB"
+socket_timeout_secs = 30
+
 [module]
 name = "cart_handler"
 path = "cart_handler.wasm"

--- a/WHITEPAPER.md
+++ b/WHITEPAPER.md
@@ -596,6 +596,7 @@ socket_timeout_secs = 30
 listen = "127.0.0.1:9100"
 log_level = "info"
 log_format = "text"
+request_timeout_secs = 5
 ```
 
 The same limit values are the runtime defaults when no config file is provided.
@@ -609,6 +610,11 @@ The endpoint exposes:
 | `/metrics` | Prometheus-compatible text metrics |
 | `/health` | Liveness |
 | `/ready` | Readiness |
+
+The first metric set is deliberately operational:
+operation counts, connected peers, last sync latency, sync errors,
+observability request/error counters, peer connect/disconnect counters,
+broadcast batch/op counters and local store size.
 
 ### 5.8 Topology: epidemic gossip *(Prototype)*
 

--- a/WHITEPAPER.md
+++ b/WHITEPAPER.md
@@ -1,7 +1,7 @@
 # Numax Runtime - Technical Whitepaper
 
 > **Note**
-> This whitepaper is aligned with **v0.1.0-alpha.2**, the current public technical preview of Numax.
+> This whitepaper is aligned with **v0.1.0-alpha.3**, the current public technical preview of Numax.
 > Compared to previous drafts, most of the `TODO`s have been resolved based on the code present in the repository. What remains open is explicitly labeled as *(Planned)* and tracked in the roadmap.
 >
 > **Status labels (consistent with the code):**
@@ -9,7 +9,7 @@
 > - **(Prototype)**: partially present; internal wiring or critical paths already verified, but not yet production-ready.
 > - **(Planned)**: foreseen in the roadmap, not yet implemented.
 >
-> **Version reference**: `v0.1.0-alpha.2` - technical preview, API and wire format may change before the stable v0.1.0.
+> **Version reference**: `v0.1.0-alpha.3` - technical preview, API and wire format may change before the stable v0.1.0.
 >
 > > 📍 **Reference roadmap:** the phases cited in this document (Phase 7, Phase 8, …) are defined in [`ROADMAP.md`](./ROADMAP.md).
 > Whenever you read *Phase N*, you can consult the roadmap for details, completion criteria and progress status :)
@@ -414,7 +414,7 @@ pub fn merge(&mut self, other: &GCounter) {
 - propagates operations to active peers through nx-net,
 - covered by end-to-end E2E tests.
 
-**Hydration** *(Planned, Phase 7)* - rebuilding the GCounter state from sled at node startup is not yet implemented. Today the state is rebuilt during execution through operations; the persistence of the materialized CRDT state is present but replay at startup is on the roadmap.
+**Hydration** *(Implemented)* - on startup, the runtime rebuilds the in-memory GCounter registry from the values materialized in sled. Durable full CRDT state/op-log recovery remains planned in Phase 10 for stronger restart/reconnect resilience.
 
 **Planned CRDTs (Phase 14):**
 
@@ -479,7 +479,7 @@ Numax assumes a hostile network: the transport can be observed, altered or redir
 
 **Dedicated CLI flags:** `--tls-cert`, `--tls-key`, `--tls-ca`, `--allowed-peers`, `--tls-insecure` (the latter only for local development).
 
-**Out of scope for v0.1.0-alpha.2:**
+**Out of scope for v0.1.0-alpha.3:**
 
 - automatic certificate rotation;
 - advanced certificate pinning;
@@ -764,7 +764,7 @@ The project includes an automated test suite that covers runtime, store, CRDT, n
 
 ## 8. Use Cases
 
-The use cases below are **concretely achievable today** with the primitives of v0.1.0-alpha.2. They do not describe visions: they describe what the runtime already knows how to do, or will know how to do as soon as the last preview phases are closed.
+The use cases below are **concretely achievable today** with the primitives of v0.1.0-alpha.3. They do not describe visions: they describe what the runtime already knows how to do, or will know how to do as soon as the last preview phases are closed.
 
 ### 8.1 Distributed counters and metrics (example: `distributed_counter`)
 
@@ -830,7 +830,7 @@ Numax is not AI. It is one of the things that AI can, comfortably, run on top of
 
 ## 10. Limitations
 
-v0.1.0-alpha.2 is a technical preview. We recognize its limits, explicitly:
+v0.1.0-alpha.3 is a technical preview. We recognize its limits, explicitly:
 
 - **Anti-entropy is not implemented yet.** Nodes exchange live PushOps, but automatic recovery of missed deltas after long disconnections is Phase 10 work.
 - **K-fanout gossip and full network resilience are in progress.** The architecture is defined; reconnect with backoff, automatic anti-entropy and op dedup are in Phase 10.
@@ -857,11 +857,11 @@ Numax proposes a unified runtime that combines:
 
 The goal is not to replicate the existing ecosystem, but **to reduce the self-imposed complexity** that today dominates distributed systems development, while preserving control over the necessary complexity of one's own domain.
 
-v0.1.0-alpha.2 is a technical preview. What it contains is real, tested, working: WASM runtime, sled store, GCounter CRDT, async SyncManager, TCP networking, TLS 1.3 + mTLS with identity derived from the key, stable host API for database, log and CRDT, multi-OS CI, end-to-end examples.
+v0.1.0-alpha.3 is a technical preview. What it contains is real, tested, working: WASM runtime, sled store, GCounter CRDT, async SyncManager, TCP networking, TLS 1.3 + mTLS with identity derived from the key, stable host API for database, log and CRDT, lifecycle/backpressure hardening, opt-in observability, multi-OS CI, end-to-end examples.
 
 What is still missing is declared explicitly and tracked in the roadmap. Subsequent iterations will refine details, practical examples, comparisons and experimental results.
 
-**v0.1.0-alpha.2 is just the beginning.** But it is a beginning built on code, not on promises.
+**v0.1.0-alpha.3 is just the beginning.** But it is a beginning built on code, not on promises.
 
 In closing, I love software and I love numax.
 

--- a/WHITEPAPER.md
+++ b/WHITEPAPER.md
@@ -534,6 +534,12 @@ nx run <module.wasm> --datastore-path ./my-data
 # Runs with a TOML configuration file
 nx run <module.wasm> --config ./numax.toml
 
+# Runs with the observability endpoint enabled
+nx run <module.wasm> \
+    --observability-listen 127.0.0.1:9100 \
+    --log-level info \
+    --log-format json
+
 # Runs as a sync-enabled node
 nx run <module.wasm> \
     --listen 0.0.0.0:9000 \
@@ -564,6 +570,9 @@ nx run <module.wasm> \
 |------|-------------|
 | `--datastore-path` | Directory for persistent data |
 | `--config` | TOML configuration file |
+| `--observability-listen` | Enable `/metrics`, `/health` and `/ready` on the given address |
+| `--log-level` | Logging level: `trace`, `debug`, `info`, `warn`, `error` |
+| `--log-format` | Logging format: `text` or `json` |
 | `--listen` | Address on which to accept peer connections and enable sync |
 | `--peer` | Initial peer address (repeatable) |
 | `--wait-before-run` | Bounded pre-run window for peer handshakes |
@@ -582,9 +591,24 @@ max_peers = 64
 queued_ops_limit = 10000
 max_message_size = "16MiB"
 socket_timeout_secs = 30
+
+[observability]
+listen = "127.0.0.1:9100"
+log_level = "info"
+log_format = "text"
 ```
 
-The same values are the runtime defaults when no config file is provided.
+The same limit values are the runtime defaults when no config file is provided.
+The observability endpoint is opt-in: without `--observability-listen` or
+`[observability].listen`, no HTTP endpoint is opened.
+
+The endpoint exposes:
+
+| Path | Meaning |
+|------|---------|
+| `/metrics` | Prometheus-compatible text metrics |
+| `/health` | Liveness |
+| `/ready` | Readiness |
 
 ### 5.8 Topology: epidemic gossip *(Prototype)*
 
@@ -805,7 +829,7 @@ v0.1.0-alpha.2 is a technical preview. We recognize its limits, explicitly:
 - **Anti-entropy is not implemented yet.** Nodes exchange live PushOps, but automatic recovery of missed deltas after long disconnections is Phase 10 work.
 - **K-fanout gossip and full network resilience are in progress.** The architecture is defined; reconnect with backoff, automatic anti-entropy and op dedup are in Phase 10.
 - **TLS/mTLS is implemented, but not yet hardened for all scenarios.** It is solid enough for controlled scenarios (dev, lab, defined deployments); the full hardening (rotation, advanced pinning, extreme hostile scenarios) continues.
-- **Minimal observability.** Advanced structured logging, Prometheus metrics and health checks are in Phase 9.
+- **Minimal observability.** Structured logs, Prometheus-compatible metrics and health checks are available as an opt-in endpoint; richer dashboards and alerting remain outside the current preview.
 - **Wire format and Host API can change.** Before the stable v0.1.0, we expect non-backward-compatible changes. Dual-mode JSON/bincode serialization is planned in Phase 11.
 - **Available CRDTs limited to GCounter.** PNCounter, LWW-Register, ORSet, LWW-Map and RGA will arrive with Phase 14.
 - **It does not replace complex orchestrators.** It is not designed to manage extensive clusters or highly scalable deployments with advanced scheduling.

--- a/crates/nx-cli/Cargo.toml
+++ b/crates/nx-cli/Cargo.toml
@@ -11,7 +11,7 @@ serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 toml = "0.9"
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 [[bin]]
 name = "nx"

--- a/crates/nx-cli/Cargo.toml
+++ b/crates/nx-cli/Cargo.toml
@@ -7,7 +7,9 @@ edition = "2024"
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 nx-core = { path = "../nx-core" }
+serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+toml = "0.9"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 

--- a/crates/nx-cli/src/main.rs
+++ b/crates/nx-cli/src/main.rs
@@ -127,7 +127,7 @@ async fn real_main() -> Result<()> {
             let tls = build_tls_config(tls_cert, tls_key, tls_ca, allowed_peers, tls_insecure);
 
             // Build SyncConfig (if sync flags were provided)
-            let sync = build_sync_config(listen, peers, tls)?
+            let sync = build_sync_config(listen, peers, tls, file_config.limits.is_some())?
                 .map(|sync| apply_limit_config(sync, file_config.limits.as_ref()))
                 .transpose()?;
             validate_settle_mode(&sync, settle_for)?;
@@ -399,14 +399,15 @@ fn build_sync_config(
     listen: Option<String>,
     peers: Vec<String>,
     tls: Option<TlsConfig>,
+    force_enabled: bool,
 ) -> Result<Option<SyncConfig>> {
-    if listen.is_none() && peers.is_empty() {
+    if listen.is_none() && peers.is_empty() && !force_enabled {
         return Ok(None);
     }
 
     if listen.is_none() {
         bail!(
-            "--peer requires --listen: dialer-only mode is not yet supported. \
+            "sync configuration requires --listen: dialer-only mode is not yet supported. \
              Pass --listen <addr> to enable sync."
         );
     }
@@ -726,13 +727,13 @@ mod tests {
 
         #[test]
         fn no_flags_is_none() {
-            let r = build_sync_config(None, vec![], None).unwrap();
+            let r = build_sync_config(None, vec![], None, false).unwrap();
             assert!(r.is_none());
         }
 
         #[test]
         fn listen_alone_is_some() {
-            let cfg = build_sync_config(Some("0.0.0.0:9000".into()), vec![], None)
+            let cfg = build_sync_config(Some("0.0.0.0:9000".into()), vec![], None, false)
                 .unwrap()
                 .expect("sync should be enabled with --listen alone");
             assert!(cfg.is_enabled());
@@ -742,10 +743,18 @@ mod tests {
 
         #[test]
         fn peer_without_listen_is_error() {
-            let r = build_sync_config(None, vec!["127.0.0.1:9000".into()], None);
+            let r = build_sync_config(None, vec!["127.0.0.1:9000".into()], None, false);
             assert!(r.is_err(), "peers without --listen must fail loudly");
             let err = r.unwrap_err().to_string();
-            assert!(err.contains("--peer requires --listen"), "got: {err}");
+            assert!(err.contains("requires --listen"), "got: {err}");
+        }
+
+        #[test]
+        fn limits_config_without_listen_is_error() {
+            let r = build_sync_config(None, vec![], None, true);
+            assert!(r.is_err(), "limits without --listen must fail loudly");
+            let err = r.unwrap_err().to_string();
+            assert!(err.contains("requires --listen"), "got: {err}");
         }
 
         #[test]
@@ -754,6 +763,7 @@ mod tests {
                 Some("0.0.0.0:9000".into()),
                 vec!["a:1".into(), "b:2".into()],
                 None,
+                false,
             )
             .unwrap()
             .unwrap();
@@ -765,7 +775,7 @@ mod tests {
         #[test]
         fn tls_is_propagated() {
             let tls = Some(TlsConfig::insecure_dev());
-            let cfg = build_sync_config(Some("0.0.0.0:9000".into()), vec![], tls)
+            let cfg = build_sync_config(Some("0.0.0.0:9000".into()), vec![], tls, false)
                 .unwrap()
                 .unwrap();
             assert!(cfg.tls.is_some());

--- a/crates/nx-cli/src/main.rs
+++ b/crates/nx-cli/src/main.rs
@@ -7,6 +7,7 @@ use anyhow::{Result, bail};
 use clap::Parser;
 use nx_core::runtime::{DEFAULT_SHUTDOWN_TIMEOUT, Runtime, RuntimeConfig};
 use nx_core::{SyncConfig, TlsConfig};
+use serde::Deserialize;
 use tracing::{info, warn};
 
 #[derive(Parser, Debug)]
@@ -21,6 +22,10 @@ enum Cli {
         /// Datastore directory path (default: ./nx-data)
         #[arg(long, value_name = "PATH")]
         datastore_path: Option<PathBuf>,
+
+        /// Path to a Numax TOML configuration file.
+        #[arg(long, value_name = "PATH")]
+        config: Option<PathBuf>,
 
         /// Enable sync and listen on this address (e.g., "0.0.0.0:9000")
         #[arg(long, value_name = "ADDR")]
@@ -91,6 +96,7 @@ async fn real_main() -> Result<()> {
         Cli::Run {
             module,
             datastore_path,
+            config,
             listen,
             peers,
             settle_for,
@@ -115,12 +121,15 @@ async fn real_main() -> Result<()> {
 
             // Validate TLS flag combinations
             validate_tls_flags(&tls_cert, &tls_key, &tls_ca, &allowed_peers, tls_insecure)?;
+            let file_config = load_run_config(config.as_ref())?;
 
             // Build TlsConfig (if any TLS-related flag was provided)
             let tls = build_tls_config(tls_cert, tls_key, tls_ca, allowed_peers, tls_insecure);
 
             // Build SyncConfig (if sync flags were provided)
-            let sync = build_sync_config(listen, peers, tls)?;
+            let sync = build_sync_config(listen, peers, tls)?
+                .map(|sync| apply_limit_config(sync, file_config.limits.as_ref()))
+                .transpose()?;
             validate_settle_mode(&sync, settle_for)?;
             validate_wait_before_run(&sync, wait_before_run)?;
             validate_print_gcounter(&sync, &print_gcounter)?;
@@ -176,6 +185,87 @@ async fn real_main() -> Result<()> {
     }
 
     Ok(())
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RunFileConfig {
+    limits: Option<LimitsFileConfig>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LimitsFileConfig {
+    max_peers: Option<usize>,
+    queued_ops_limit: Option<usize>,
+    max_message_size: Option<String>,
+    socket_timeout_secs: Option<u64>,
+}
+
+fn load_run_config(path: Option<&PathBuf>) -> Result<RunFileConfig> {
+    let Some(path) = path else {
+        return Ok(RunFileConfig::default());
+    };
+
+    let text = fs::read_to_string(path)?;
+    toml::from_str(&text).map_err(Into::into)
+}
+
+fn apply_limit_config(
+    mut sync: SyncConfig,
+    limits: Option<&LimitsFileConfig>,
+) -> Result<SyncConfig> {
+    let Some(limits) = limits else {
+        return Ok(sync);
+    };
+
+    if let Some(max_peers) = limits.max_peers {
+        sync = sync.with_max_peers(max_peers);
+    }
+    if let Some(queued_ops_limit) = limits.queued_ops_limit {
+        if queued_ops_limit == 0 {
+            bail!("limits.queued_ops_limit must be greater than zero");
+        }
+        sync = sync.with_queued_ops_limit(queued_ops_limit);
+    }
+    if let Some(max_message_size) = &limits.max_message_size {
+        sync = sync.with_max_message_size(parse_byte_size(max_message_size)?);
+    }
+    if let Some(socket_timeout_secs) = limits.socket_timeout_secs {
+        if socket_timeout_secs == 0 {
+            bail!("limits.socket_timeout_secs must be greater than zero");
+        }
+        sync = sync.with_socket_timeout(Duration::from_secs(socket_timeout_secs));
+    }
+
+    Ok(sync)
+}
+
+fn parse_byte_size(input: &str) -> Result<usize> {
+    let input = input.trim();
+    if input.is_empty() {
+        bail!("expected byte size like 16MiB");
+    }
+
+    let compact = input.replace(' ', "");
+    let (number, multiplier) = if let Some(n) = compact.strip_suffix("MiB") {
+        (n, 1024usize * 1024)
+    } else if let Some(n) = compact.strip_suffix("KiB") {
+        (n, 1024usize)
+    } else if let Some(n) = compact.strip_suffix('B') {
+        (n, 1usize)
+    } else {
+        (compact.as_str(), 1usize)
+    };
+
+    let amount = number
+        .parse::<usize>()
+        .map_err(|_| anyhow::anyhow!("expected byte size like 16MiB"))?;
+    if amount == 0 {
+        bail!("byte size must be greater than zero");
+    }
+
+    amount
+        .checked_mul(multiplier)
+        .ok_or_else(|| anyhow::anyhow!("byte size is too large"))
 }
 
 /// Validate that the TLS-related CLI flags form a coherent combination.
@@ -376,6 +466,83 @@ mod tests {
         #[test]
         fn rejects_zero_duration() {
             assert!(parse_duration("0s").is_err());
+        }
+    }
+
+    mod byte_size_parser {
+        use super::*;
+
+        #[test]
+        fn parses_mib() {
+            assert_eq!(parse_byte_size("16MiB").unwrap(), 16 * 1024 * 1024);
+        }
+
+        #[test]
+        fn parses_kib_with_space() {
+            assert_eq!(parse_byte_size("4 KiB").unwrap(), 4 * 1024);
+        }
+
+        #[test]
+        fn parses_plain_bytes() {
+            assert_eq!(parse_byte_size("128").unwrap(), 128);
+        }
+
+        #[test]
+        fn rejects_zero() {
+            assert!(parse_byte_size("0MiB").is_err());
+        }
+    }
+
+    mod file_config {
+        use super::*;
+
+        #[test]
+        fn parses_limits_toml() {
+            let cfg: RunFileConfig = toml::from_str(
+                r#"
+                [limits]
+                max_peers = 64
+                queued_ops_limit = 10000
+                max_message_size = "16MiB"
+                socket_timeout_secs = 30
+                "#,
+            )
+            .unwrap();
+
+            let limits = cfg.limits.unwrap();
+            assert_eq!(limits.max_peers, Some(64));
+            assert_eq!(limits.queued_ops_limit, Some(10_000));
+            assert_eq!(limits.max_message_size.as_deref(), Some("16MiB"));
+            assert_eq!(limits.socket_timeout_secs, Some(30));
+        }
+
+        #[test]
+        fn applies_limits_to_sync_config() {
+            let limits = LimitsFileConfig {
+                max_peers: Some(8),
+                queued_ops_limit: Some(256),
+                max_message_size: Some("2MiB".into()),
+                socket_timeout_secs: Some(5),
+            };
+
+            let cfg = apply_limit_config(SyncConfig::new(), Some(&limits)).unwrap();
+
+            assert_eq!(cfg.max_peers, 8);
+            assert_eq!(cfg.queued_ops_limit, 256);
+            assert_eq!(cfg.max_message_size, 2 * 1024 * 1024);
+            assert_eq!(cfg.socket_timeout, Duration::from_secs(5));
+        }
+
+        #[test]
+        fn rejects_empty_queue_limit() {
+            let limits = LimitsFileConfig {
+                max_peers: None,
+                queued_ops_limit: Some(0),
+                max_message_size: None,
+                socket_timeout_secs: None,
+            };
+
+            assert!(apply_limit_config(SyncConfig::new(), Some(&limits)).is_err());
         }
     }
 
@@ -686,6 +853,17 @@ mod tests {
             match cli {
                 Cli::Run { datastore_path, .. } => {
                     assert_eq!(datastore_path, Some(PathBuf::from("/tmp/nx")));
+                }
+            }
+        }
+
+        #[test]
+        fn config_path_parsed() {
+            let cli =
+                Cli::try_parse_from(["nx", "run", "x.wasm", "--config", "numax.toml"]).unwrap();
+            match cli {
+                Cli::Run { config, .. } => {
+                    assert_eq!(config, Some(PathBuf::from("numax.toml")));
                 }
             }
         }

--- a/crates/nx-cli/src/main.rs
+++ b/crates/nx-cli/src/main.rs
@@ -4,9 +4,9 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use anyhow::{Result, bail};
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 use nx_core::runtime::{DEFAULT_SHUTDOWN_TIMEOUT, Runtime, RuntimeConfig};
-use nx_core::{SyncConfig, TlsConfig};
+use nx_core::{ObservabilityConfig, SyncConfig, TlsConfig};
 use serde::Deserialize;
 use tracing::{info, warn};
 
@@ -54,6 +54,18 @@ enum Cli {
         /// Enable verbose logging
         #[arg(short, long)]
         verbose: bool,
+
+        /// Logging level (trace, debug, info, warn, error).
+        #[arg(long, value_name = "LEVEL")]
+        log_level: Option<String>,
+
+        /// Logging format.
+        #[arg(long, value_enum, value_name = "FORMAT")]
+        log_format: Option<LogFormat>,
+
+        /// Enable the observability HTTP endpoint (e.g. "127.0.0.1:9100").
+        #[arg(long, value_name = "ADDR")]
+        observability_listen: Option<String>,
 
         /// Path to this node's TLS certificate (PEM)
         #[arg(long, value_name = "PATH")]
@@ -104,24 +116,25 @@ async fn real_main() -> Result<()> {
             print_gcounter,
             shutdown_timeout,
             verbose,
+            log_level,
+            log_format,
+            observability_listen,
             tls_cert,
             tls_key,
             tls_ca,
             allowed_peers,
             tls_insecure,
         } => {
+            let file_config = load_run_config(config.as_ref())?;
+
             // Setup logging
-            let log_level = if verbose { "debug" } else { "info" };
-            tracing_subscriber::fmt()
-                .with_env_filter(
-                    tracing_subscriber::EnvFilter::try_from_default_env()
-                        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new(log_level)),
-                )
-                .init();
+            let log_level =
+                resolve_log_level(verbose, log_level, file_config.observability.as_ref())?;
+            let log_format = resolve_log_format(log_format, file_config.observability.as_ref());
+            init_logging(&log_level, log_format);
 
             // Validate TLS flag combinations
             validate_tls_flags(&tls_cert, &tls_key, &tls_ca, &allowed_peers, tls_insecure)?;
-            let file_config = load_run_config(config.as_ref())?;
 
             // Build TlsConfig (if any TLS-related flag was provided)
             let tls = build_tls_config(tls_cert, tls_key, tls_ca, allowed_peers, tls_insecure);
@@ -133,6 +146,10 @@ async fn real_main() -> Result<()> {
             validate_settle_mode(&sync, settle_for)?;
             validate_wait_before_run(&sync, wait_before_run)?;
             validate_print_gcounter(&sync, &print_gcounter)?;
+            let observability = build_observability_config(
+                observability_listen,
+                file_config.observability.as_ref(),
+            );
 
             // Read the wasm module
             let bytes = fs::read(&module)?;
@@ -151,9 +168,11 @@ async fn real_main() -> Result<()> {
                 );
                 cfg.sync = Some(s);
             }
+            cfg.observability = observability;
 
             let mut rt = Runtime::new(cfg)?;
             let run_result: Result<()> = async {
+                rt.start_observability().await?;
                 rt.start_sync().await?;
                 if let Some(duration) = wait_before_run {
                     rt.wait_before_run(duration).await?;
@@ -187,9 +206,17 @@ async fn real_main() -> Result<()> {
     Ok(())
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, ValueEnum)]
+#[serde(rename_all = "lowercase")]
+enum LogFormat {
+    Text,
+    Json,
+}
+
 #[derive(Debug, Default, Deserialize)]
 struct RunFileConfig {
     limits: Option<LimitsFileConfig>,
+    observability: Option<ObservabilityFileConfig>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -200,6 +227,13 @@ struct LimitsFileConfig {
     socket_timeout_secs: Option<u64>,
 }
 
+#[derive(Debug, Deserialize)]
+struct ObservabilityFileConfig {
+    listen: Option<String>,
+    log_level: Option<String>,
+    log_format: Option<LogFormat>,
+}
+
 fn load_run_config(path: Option<&PathBuf>) -> Result<RunFileConfig> {
     let Some(path) = path else {
         return Ok(RunFileConfig::default());
@@ -207,6 +241,63 @@ fn load_run_config(path: Option<&PathBuf>) -> Result<RunFileConfig> {
 
     let text = fs::read_to_string(path)?;
     toml::from_str(&text).map_err(Into::into)
+}
+
+fn init_logging(log_level: &str, log_format: LogFormat) {
+    match log_format {
+        LogFormat::Text => tracing_subscriber::fmt()
+            .with_env_filter(
+                tracing_subscriber::EnvFilter::try_from_default_env()
+                    .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new(log_level)),
+            )
+            .init(),
+        LogFormat::Json => tracing_subscriber::fmt()
+            .json()
+            .with_env_filter(
+                tracing_subscriber::EnvFilter::try_from_default_env()
+                    .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new(log_level)),
+            )
+            .init(),
+    }
+}
+
+fn resolve_log_level(
+    verbose: bool,
+    cli_log_level: Option<String>,
+    observability: Option<&ObservabilityFileConfig>,
+) -> Result<String> {
+    let level = cli_log_level
+        .or_else(|| observability.and_then(|cfg| cfg.log_level.clone()))
+        .unwrap_or_else(|| {
+            if verbose {
+                "debug".to_string()
+            } else {
+                "info".to_string()
+            }
+        });
+
+    match level.as_str() {
+        "trace" | "debug" | "info" | "warn" | "error" => Ok(level),
+        _ => bail!("log level must be one of trace, debug, info, warn, error"),
+    }
+}
+
+fn resolve_log_format(
+    cli_log_format: Option<LogFormat>,
+    observability: Option<&ObservabilityFileConfig>,
+) -> LogFormat {
+    cli_log_format
+        .or_else(|| observability.and_then(|cfg| cfg.log_format))
+        .unwrap_or(LogFormat::Text)
+}
+
+fn build_observability_config(
+    listen: Option<String>,
+    observability: Option<&ObservabilityFileConfig>,
+) -> Option<ObservabilityConfig> {
+    listen
+        .or_else(|| observability.and_then(|cfg| cfg.listen.clone()))
+        .map(ObservabilityConfig::new)
 }
 
 fn apply_limit_config(
@@ -518,6 +609,24 @@ mod tests {
         }
 
         #[test]
+        fn parses_observability_toml() {
+            let cfg: RunFileConfig = toml::from_str(
+                r#"
+                [observability]
+                listen = "127.0.0.1:9100"
+                log_level = "debug"
+                log_format = "json"
+                "#,
+            )
+            .unwrap();
+
+            let observability = cfg.observability.unwrap();
+            assert_eq!(observability.listen.as_deref(), Some("127.0.0.1:9100"));
+            assert_eq!(observability.log_level.as_deref(), Some("debug"));
+            assert_eq!(observability.log_format, Some(LogFormat::Json));
+        }
+
+        #[test]
         fn applies_limits_to_sync_config() {
             let limits = LimitsFileConfig {
                 max_peers: Some(8),
@@ -544,6 +653,54 @@ mod tests {
             };
 
             assert!(apply_limit_config(SyncConfig::new(), Some(&limits)).is_err());
+        }
+
+        #[test]
+        fn builds_observability_from_file_config() {
+            let cfg = ObservabilityFileConfig {
+                listen: Some("127.0.0.1:9100".into()),
+                log_level: None,
+                log_format: None,
+            };
+
+            let observability = build_observability_config(None, Some(&cfg)).unwrap();
+
+            assert_eq!(observability.listen_addr, "127.0.0.1:9100");
+        }
+
+        #[test]
+        fn cli_observability_listen_overrides_file_config() {
+            let cfg = ObservabilityFileConfig {
+                listen: Some("127.0.0.1:9100".into()),
+                log_level: None,
+                log_format: None,
+            };
+
+            let observability =
+                build_observability_config(Some("127.0.0.1:9200".into()), Some(&cfg)).unwrap();
+
+            assert_eq!(observability.listen_addr, "127.0.0.1:9200");
+        }
+
+        #[test]
+        fn resolves_log_level_from_cli_then_file_then_verbose() {
+            let cfg = ObservabilityFileConfig {
+                listen: None,
+                log_level: Some("warn".into()),
+                log_format: None,
+            };
+
+            assert_eq!(
+                resolve_log_level(false, Some("debug".into()), Some(&cfg)).unwrap(),
+                "debug"
+            );
+            assert_eq!(resolve_log_level(false, None, Some(&cfg)).unwrap(), "warn");
+            assert_eq!(resolve_log_level(true, None, None).unwrap(), "debug");
+        }
+
+        #[test]
+        fn rejects_invalid_log_level() {
+            assert!(resolve_log_level(false, Some("loud".into()), None).is_err());
         }
     }
 
@@ -874,6 +1031,34 @@ mod tests {
             match cli {
                 Cli::Run { config, .. } => {
                     assert_eq!(config, Some(PathBuf::from("numax.toml")));
+                }
+            }
+        }
+
+        #[test]
+        fn observability_flags_parsed() {
+            let cli = Cli::try_parse_from([
+                "nx",
+                "run",
+                "x.wasm",
+                "--observability-listen",
+                "127.0.0.1:9100",
+                "--log-level",
+                "debug",
+                "--log-format",
+                "json",
+            ])
+            .unwrap();
+            match cli {
+                Cli::Run {
+                    observability_listen,
+                    log_level,
+                    log_format,
+                    ..
+                } => {
+                    assert_eq!(observability_listen.as_deref(), Some("127.0.0.1:9100"));
+                    assert_eq!(log_level.as_deref(), Some("debug"));
+                    assert_eq!(log_format, Some(LogFormat::Json));
                 }
             }
         }

--- a/crates/nx-cli/src/main.rs
+++ b/crates/nx-cli/src/main.rs
@@ -149,7 +149,7 @@ async fn real_main() -> Result<()> {
             let observability = build_observability_config(
                 observability_listen,
                 file_config.observability.as_ref(),
-            );
+            )?;
 
             // Read the wasm module
             let bytes = fs::read(&module)?;
@@ -232,6 +232,7 @@ struct ObservabilityFileConfig {
     listen: Option<String>,
     log_level: Option<String>,
     log_format: Option<LogFormat>,
+    request_timeout_secs: Option<u64>,
 }
 
 fn load_run_config(path: Option<&PathBuf>) -> Result<RunFileConfig> {
@@ -294,10 +295,21 @@ fn resolve_log_format(
 fn build_observability_config(
     listen: Option<String>,
     observability: Option<&ObservabilityFileConfig>,
-) -> Option<ObservabilityConfig> {
-    listen
-        .or_else(|| observability.and_then(|cfg| cfg.listen.clone()))
-        .map(ObservabilityConfig::new)
+) -> Result<Option<ObservabilityConfig>> {
+    let Some(listen_addr) = listen.or_else(|| observability.and_then(|cfg| cfg.listen.clone()))
+    else {
+        return Ok(None);
+    };
+
+    let mut config = ObservabilityConfig::new(listen_addr);
+    if let Some(request_timeout_secs) = observability.and_then(|cfg| cfg.request_timeout_secs) {
+        if request_timeout_secs == 0 {
+            bail!("observability.request_timeout_secs must be greater than zero");
+        }
+        config = config.with_request_timeout(Duration::from_secs(request_timeout_secs));
+    }
+
+    Ok(Some(config))
 }
 
 fn apply_limit_config(
@@ -616,6 +628,7 @@ mod tests {
                 listen = "127.0.0.1:9100"
                 log_level = "debug"
                 log_format = "json"
+                request_timeout_secs = 7
                 "#,
             )
             .unwrap();
@@ -624,6 +637,7 @@ mod tests {
             assert_eq!(observability.listen.as_deref(), Some("127.0.0.1:9100"));
             assert_eq!(observability.log_level.as_deref(), Some("debug"));
             assert_eq!(observability.log_format, Some(LogFormat::Json));
+            assert_eq!(observability.request_timeout_secs, Some(7));
         }
 
         #[test]
@@ -661,11 +675,15 @@ mod tests {
                 listen: Some("127.0.0.1:9100".into()),
                 log_level: None,
                 log_format: None,
+                request_timeout_secs: Some(7),
             };
 
-            let observability = build_observability_config(None, Some(&cfg)).unwrap();
+            let observability = build_observability_config(None, Some(&cfg))
+                .unwrap()
+                .unwrap();
 
             assert_eq!(observability.listen_addr, "127.0.0.1:9100");
+            assert_eq!(observability.request_timeout, Duration::from_secs(7));
         }
 
         #[test]
@@ -674,12 +692,27 @@ mod tests {
                 listen: Some("127.0.0.1:9100".into()),
                 log_level: None,
                 log_format: None,
+                request_timeout_secs: None,
             };
 
             let observability =
-                build_observability_config(Some("127.0.0.1:9200".into()), Some(&cfg)).unwrap();
+                build_observability_config(Some("127.0.0.1:9200".into()), Some(&cfg))
+                    .unwrap()
+                    .unwrap();
 
             assert_eq!(observability.listen_addr, "127.0.0.1:9200");
+        }
+
+        #[test]
+        fn rejects_empty_observability_timeout() {
+            let cfg = ObservabilityFileConfig {
+                listen: Some("127.0.0.1:9100".into()),
+                log_level: None,
+                log_format: None,
+                request_timeout_secs: Some(0),
+            };
+
+            assert!(build_observability_config(None, Some(&cfg)).is_err());
         }
 
         #[test]
@@ -688,6 +721,7 @@ mod tests {
                 listen: None,
                 log_level: Some("warn".into()),
                 log_format: None,
+                request_timeout_secs: None,
             };
 
             assert_eq!(

--- a/crates/nx-core/Cargo.toml
+++ b/crates/nx-core/Cargo.toml
@@ -10,5 +10,5 @@ wasmtime-wasi = "43.0.1"
 nx-store = { path = "../nx-store" }
 nx-sync = { path = "../nx-sync" }
 nx-net = { path = "../nx-net" }
-tokio = { version = "1", features = ["signal", "sync", "time"] }
+tokio = { version = "1", features = ["io-util", "net", "signal", "sync", "time"] }
 tracing = "0.1"

--- a/crates/nx-core/src/host_api/crdt.rs
+++ b/crates/nx-core/src/host_api/crdt.rs
@@ -77,6 +77,15 @@ async fn crdt_gcounter_inc_impl(
         None => return ERR_SYNC_DISABLED,
     };
 
+    let op_tx = handle.op_sender();
+    let op_permit = match op_tx.try_reserve() {
+        Ok(permit) => permit,
+        Err(e) => {
+            tracing::warn!(error = %e, "crdt_gcounter_inc: broadcast queue full");
+            return ERR_INTERNAL;
+        }
+    };
+
     // Apply locally and materialize the value before exposing the new state.
     {
         let counters_arc = handle.counters();
@@ -93,12 +102,8 @@ async fn crdt_gcounter_inc_impl(
         counters.insert(key.clone(), counter);
     }
 
-    // Enqueue the Op for broadcast. Bounded-channel backpressure is
-
     let op = Op::gcounter_increment(handle.node_id().clone(), key, delta);
-    if let Err(e) = handle.op_sender().send(op).await {
-        tracing::warn!(error = %e, "crdt_gcounter_inc: broadcast channel closed");
-    }
+    op_permit.send(op);
 
     0
 }

--- a/crates/nx-core/src/host_api/crdt.rs
+++ b/crates/nx-core/src/host_api/crdt.rs
@@ -81,6 +81,7 @@ async fn crdt_gcounter_inc_impl(
     let op_permit = match op_tx.try_reserve() {
         Ok(permit) => permit,
         Err(e) => {
+            handle.metrics().record_sync_error();
             tracing::warn!(error = %e, "crdt_gcounter_inc: broadcast queue full");
             return ERR_INTERNAL;
         }
@@ -95,6 +96,7 @@ async fn crdt_gcounter_inc_impl(
         let total = counter.value();
 
         if let Err(e) = materialize_gcounter_value(&handle.store(), &key, total) {
+            handle.metrics().record_sync_error();
             tracing::warn!(error = %e, "crdt_gcounter_inc: failed to materialize counter");
             return ERR_INTERNAL;
         }

--- a/crates/nx-core/src/host_api/crdt.rs
+++ b/crates/nx-core/src/host_api/crdt.rs
@@ -103,7 +103,9 @@ async fn crdt_gcounter_inc_impl(
     }
 
     let op = Op::gcounter_increment(handle.node_id().clone(), key, delta);
+    tracing::debug!(op_id = %op.id, "queued local GCounter increment");
     op_permit.send(op);
+    handle.metrics().record_ops(1);
 
     0
 }

--- a/crates/nx-core/src/lib.rs
+++ b/crates/nx-core/src/lib.rs
@@ -1,7 +1,9 @@
 pub mod host_api;
+pub mod observability;
 pub mod runtime;
 pub mod sync_config;
 pub mod sync_manager;
 
 pub use nx_net::TlsConfig;
+pub use observability::ObservabilityConfig;
 pub use sync_config::SyncConfig;

--- a/crates/nx-core/src/observability.rs
+++ b/crates/nx-core/src/observability.rs
@@ -9,7 +9,10 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
+use tokio::time::timeout;
 use tracing::{debug, warn};
+
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[derive(Debug, Clone)]
 pub struct ObservabilityConfig {
@@ -140,7 +143,9 @@ async fn handle_connection(
     store: Arc<NxStore>,
 ) -> Result<()> {
     let mut buf = [0u8; 1024];
-    let n = stream.read(&mut buf).await?;
+    let n = timeout(REQUEST_TIMEOUT, stream.read(&mut buf))
+        .await
+        .map_err(|_| anyhow!("observability request timed out"))??;
     let request =
         std::str::from_utf8(&buf[..n]).map_err(|e| anyhow!("invalid HTTP request: {e}"))?;
     let path = request
@@ -175,8 +180,12 @@ async fn handle_connection(
         "HTTP/1.1 {status}\r\ncontent-type: {content_type}\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
         body.len()
     );
-    stream.write_all(response.as_bytes()).await?;
-    stream.flush().await?;
+    timeout(REQUEST_TIMEOUT, stream.write_all(response.as_bytes()))
+        .await
+        .map_err(|_| anyhow!("observability response write timed out"))??;
+    timeout(REQUEST_TIMEOUT, stream.flush())
+        .await
+        .map_err(|_| anyhow!("observability response flush timed out"))??;
     Ok(())
 }
 

--- a/crates/nx-core/src/observability.rs
+++ b/crates/nx-core/src/observability.rs
@@ -1,0 +1,275 @@
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+use std::time::Duration;
+
+use anyhow::{Result, anyhow};
+use nx_store::Store as NxStore;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::watch;
+use tokio::task::JoinHandle;
+use tracing::{debug, warn};
+
+#[derive(Debug, Clone)]
+pub struct ObservabilityConfig {
+    pub listen_addr: String,
+}
+
+impl ObservabilityConfig {
+    pub fn new(listen_addr: impl Into<String>) -> Self {
+        Self {
+            listen_addr: listen_addr.into(),
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct RuntimeMetrics {
+    ops_total: AtomicU64,
+    peers_connected: AtomicUsize,
+    sync_latency_ms: AtomicU64,
+    ready: AtomicBool,
+}
+
+impl RuntimeMetrics {
+    pub fn record_ops(&self, count: u64) {
+        self.ops_total.fetch_add(count, Ordering::Relaxed);
+    }
+
+    pub fn set_peers_connected(&self, count: usize) {
+        self.peers_connected.store(count, Ordering::Relaxed);
+    }
+
+    pub fn record_sync_latency(&self, duration: Duration) {
+        self.sync_latency_ms
+            .store(duration.as_millis() as u64, Ordering::Relaxed);
+    }
+
+    pub fn set_ready(&self, ready: bool) {
+        self.ready.store(ready, Ordering::Relaxed);
+    }
+
+    fn snapshot(&self, store: &NxStore) -> MetricsSnapshot {
+        let store_stats = match store.stats() {
+            Ok(stats) => stats,
+            Err(e) => {
+                warn!(error = %e, "failed to read store stats");
+                nx_store::StoreStats { keys: 0, bytes: 0 }
+            }
+        };
+
+        MetricsSnapshot {
+            ops_total: self.ops_total.load(Ordering::Relaxed),
+            peers_connected: self.peers_connected.load(Ordering::Relaxed),
+            sync_latency_ms: self.sync_latency_ms.load(Ordering::Relaxed),
+            store_keys: store_stats.keys,
+            store_bytes: store_stats.bytes,
+        }
+    }
+
+    fn is_ready(&self) -> bool {
+        self.ready.load(Ordering::Relaxed)
+    }
+}
+
+struct MetricsSnapshot {
+    ops_total: u64,
+    peers_connected: usize,
+    sync_latency_ms: u64,
+    store_keys: u64,
+    store_bytes: u64,
+}
+
+pub struct ObservabilityServer {
+    shutdown_tx: watch::Sender<bool>,
+    task: JoinHandle<()>,
+}
+
+impl ObservabilityServer {
+    pub async fn shutdown(self) {
+        let _ = self.shutdown_tx.send(true);
+        if let Err(e) = self.task.await {
+            warn!(error = %e, "observability server failed during shutdown");
+        }
+    }
+}
+
+pub async fn start_server(
+    config: ObservabilityConfig,
+    metrics: Arc<RuntimeMetrics>,
+    store: Arc<NxStore>,
+) -> Result<(SocketAddr, ObservabilityServer)> {
+    let listener = TcpListener::bind(&config.listen_addr).await?;
+    let bound_addr = listener.local_addr()?;
+    let (shutdown_tx, mut shutdown_rx) = watch::channel(false);
+
+    let task = tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                _ = shutdown_rx.changed() => {
+                    if *shutdown_rx.borrow() {
+                        debug!("observability server shutdown requested");
+                        break;
+                    }
+                }
+                accepted = listener.accept() => {
+                    match accepted {
+                        Ok((stream, _addr)) => {
+                            let metrics = Arc::clone(&metrics);
+                            let store = Arc::clone(&store);
+                            tokio::spawn(async move {
+                                if let Err(e) = handle_connection(stream, metrics, store).await {
+                                    debug!(error = %e, "observability request failed");
+                                }
+                            });
+                        }
+                        Err(e) => warn!(error = %e, "observability accept failed"),
+                    }
+                }
+            }
+        }
+    });
+
+    Ok((bound_addr, ObservabilityServer { shutdown_tx, task }))
+}
+
+async fn handle_connection(
+    mut stream: TcpStream,
+    metrics: Arc<RuntimeMetrics>,
+    store: Arc<NxStore>,
+) -> Result<()> {
+    let mut buf = [0u8; 1024];
+    let n = stream.read(&mut buf).await?;
+    let request =
+        std::str::from_utf8(&buf[..n]).map_err(|e| anyhow!("invalid HTTP request: {e}"))?;
+    let path = request
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().nth(1))
+        .unwrap_or("/");
+
+    let (status, content_type, body) = match path {
+        "/health" => ("200 OK", "text/plain; charset=utf-8", "ok\n".to_string()),
+        "/ready" if metrics.is_ready() => {
+            ("200 OK", "text/plain; charset=utf-8", "ready\n".to_string())
+        }
+        "/ready" => (
+            "503 Service Unavailable",
+            "text/plain; charset=utf-8",
+            "not ready\n".to_string(),
+        ),
+        "/metrics" => (
+            "200 OK",
+            "text/plain; version=0.0.4; charset=utf-8",
+            render_metrics(metrics.snapshot(&store)),
+        ),
+        _ => (
+            "404 Not Found",
+            "text/plain; charset=utf-8",
+            "not found\n".to_string(),
+        ),
+    };
+
+    let response = format!(
+        "HTTP/1.1 {status}\r\ncontent-type: {content_type}\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+        body.len()
+    );
+    stream.write_all(response.as_bytes()).await?;
+    stream.flush().await?;
+    Ok(())
+}
+
+fn render_metrics(snapshot: MetricsSnapshot) -> String {
+    format!(
+        "# HELP numax_ops_total Operations processed\n\
+         # TYPE numax_ops_total counter\n\
+         numax_ops_total {}\n\
+         # HELP numax_peers_connected Active peers\n\
+         # TYPE numax_peers_connected gauge\n\
+         numax_peers_connected {}\n\
+         # HELP numax_sync_latency_ms Last sync latency in milliseconds\n\
+         # TYPE numax_sync_latency_ms gauge\n\
+         numax_sync_latency_ms {}\n\
+         # HELP numax_store_keys Keys in the local store\n\
+         # TYPE numax_store_keys gauge\n\
+         numax_store_keys {}\n\
+         # HELP numax_store_bytes Bytes used by local store keys and values\n\
+         # TYPE numax_store_bytes gauge\n\
+         numax_store_bytes {}\n",
+        snapshot.ops_total,
+        snapshot.peers_connected,
+        snapshot.sync_latency_ms,
+        snapshot.store_keys,
+        snapshot.store_bytes
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_store() -> Arc<NxStore> {
+        let mut path = std::env::temp_dir();
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        path.push(format!("numax-observability-test-{nanos}"));
+        Arc::new(NxStore::open(path).unwrap())
+    }
+
+    #[test]
+    fn metrics_are_rendered_in_prometheus_format() {
+        let snapshot = MetricsSnapshot {
+            ops_total: 7,
+            peers_connected: 2,
+            sync_latency_ms: 15,
+            store_keys: 3,
+            store_bytes: 42,
+        };
+        let rendered = render_metrics(snapshot);
+
+        assert!(rendered.contains("numax_ops_total 7"));
+        assert!(rendered.contains("numax_peers_connected 2"));
+        assert!(rendered.contains("numax_sync_latency_ms 15"));
+        assert!(rendered.contains("numax_store_keys 3"));
+        assert!(rendered.contains("numax_store_bytes 42"));
+    }
+
+    #[tokio::test]
+    async fn observability_server_serves_health_ready_and_metrics() {
+        let metrics = Arc::new(RuntimeMetrics::default());
+        metrics.set_ready(true);
+        metrics.record_ops(2);
+        let store = temp_store();
+        store.set(b"a", b"b").unwrap();
+        let (addr, server) = start_server(
+            ObservabilityConfig::new("127.0.0.1:0"),
+            Arc::clone(&metrics),
+            Arc::clone(&store),
+        )
+        .await
+        .unwrap();
+
+        assert!(request(addr, "/health").await.contains("ok"));
+        assert!(request(addr, "/ready").await.contains("ready"));
+        assert!(
+            request(addr, "/metrics")
+                .await
+                .contains("numax_ops_total 2")
+        );
+
+        server.shutdown().await;
+    }
+
+    async fn request(addr: SocketAddr, path: &str) -> String {
+        let mut stream = TcpStream::connect(addr).await.unwrap();
+        let request = format!("GET {path} HTTP/1.1\r\nhost: localhost\r\n\r\n");
+        stream.write_all(request.as_bytes()).await.unwrap();
+        let mut buf = Vec::new();
+        stream.read_to_end(&mut buf).await.unwrap();
+        String::from_utf8(buf).unwrap()
+    }
+}

--- a/crates/nx-core/src/observability.rs
+++ b/crates/nx-core/src/observability.rs
@@ -12,18 +12,25 @@ use tokio::task::JoinHandle;
 use tokio::time::timeout;
 use tracing::{debug, warn};
 
-const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+pub const DEFAULT_OBSERVABILITY_REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[derive(Debug, Clone)]
 pub struct ObservabilityConfig {
     pub listen_addr: String,
+    pub request_timeout: Duration,
 }
 
 impl ObservabilityConfig {
     pub fn new(listen_addr: impl Into<String>) -> Self {
         Self {
             listen_addr: listen_addr.into(),
+            request_timeout: DEFAULT_OBSERVABILITY_REQUEST_TIMEOUT,
         }
+    }
+
+    pub fn with_request_timeout(mut self, request_timeout: Duration) -> Self {
+        self.request_timeout = request_timeout;
+        self
     }
 }
 
@@ -32,6 +39,13 @@ pub struct RuntimeMetrics {
     ops_total: AtomicU64,
     peers_connected: AtomicUsize,
     sync_latency_ms: AtomicU64,
+    sync_errors_total: AtomicU64,
+    observability_requests_total: AtomicU64,
+    observability_errors_total: AtomicU64,
+    peer_connects_total: AtomicU64,
+    peer_disconnects_total: AtomicU64,
+    broadcast_batches_total: AtomicU64,
+    broadcast_ops_total: AtomicU64,
     ready: AtomicBool,
 }
 
@@ -47,6 +61,34 @@ impl RuntimeMetrics {
     pub fn record_sync_latency(&self, duration: Duration) {
         self.sync_latency_ms
             .store(duration.as_millis() as u64, Ordering::Relaxed);
+    }
+
+    pub fn record_sync_error(&self) {
+        self.sync_errors_total.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_observability_request(&self) {
+        self.observability_requests_total
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_observability_error(&self) {
+        self.observability_errors_total
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_peer_connect(&self) {
+        self.peer_connects_total.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_peer_disconnect(&self) {
+        self.peer_disconnects_total.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_broadcast_batch(&self, ops: usize) {
+        self.broadcast_batches_total.fetch_add(1, Ordering::Relaxed);
+        self.broadcast_ops_total
+            .fetch_add(ops as u64, Ordering::Relaxed);
     }
 
     pub fn set_ready(&self, ready: bool) {
@@ -66,6 +108,13 @@ impl RuntimeMetrics {
             ops_total: self.ops_total.load(Ordering::Relaxed),
             peers_connected: self.peers_connected.load(Ordering::Relaxed),
             sync_latency_ms: self.sync_latency_ms.load(Ordering::Relaxed),
+            sync_errors_total: self.sync_errors_total.load(Ordering::Relaxed),
+            observability_requests_total: self.observability_requests_total.load(Ordering::Relaxed),
+            observability_errors_total: self.observability_errors_total.load(Ordering::Relaxed),
+            peer_connects_total: self.peer_connects_total.load(Ordering::Relaxed),
+            peer_disconnects_total: self.peer_disconnects_total.load(Ordering::Relaxed),
+            broadcast_batches_total: self.broadcast_batches_total.load(Ordering::Relaxed),
+            broadcast_ops_total: self.broadcast_ops_total.load(Ordering::Relaxed),
             store_keys: store_stats.keys,
             store_bytes: store_stats.bytes,
         }
@@ -80,6 +129,13 @@ struct MetricsSnapshot {
     ops_total: u64,
     peers_connected: usize,
     sync_latency_ms: u64,
+    sync_errors_total: u64,
+    observability_requests_total: u64,
+    observability_errors_total: u64,
+    peer_connects_total: u64,
+    peer_disconnects_total: u64,
+    broadcast_batches_total: u64,
+    broadcast_ops_total: u64,
     store_keys: u64,
     store_bytes: u64,
 }
@@ -105,6 +161,7 @@ pub async fn start_server(
 ) -> Result<(SocketAddr, ObservabilityServer)> {
     let listener = TcpListener::bind(&config.listen_addr).await?;
     let bound_addr = listener.local_addr()?;
+    let request_timeout = config.request_timeout;
     let (shutdown_tx, mut shutdown_rx) = watch::channel(false);
 
     let task = tokio::spawn(async move {
@@ -122,7 +179,9 @@ pub async fn start_server(
                             let metrics = Arc::clone(&metrics);
                             let store = Arc::clone(&store);
                             tokio::spawn(async move {
-                                if let Err(e) = handle_connection(stream, metrics, store).await {
+                                let metrics_for_error = Arc::clone(&metrics);
+                                if let Err(e) = handle_connection(stream, metrics, store, request_timeout).await {
+                                    metrics_for_error.record_observability_error();
                                     debug!(error = %e, "observability request failed");
                                 }
                             });
@@ -141,9 +200,12 @@ async fn handle_connection(
     mut stream: TcpStream,
     metrics: Arc<RuntimeMetrics>,
     store: Arc<NxStore>,
+    request_timeout: Duration,
 ) -> Result<()> {
+    metrics.record_observability_request();
+
     let mut buf = [0u8; 1024];
-    let n = timeout(REQUEST_TIMEOUT, stream.read(&mut buf))
+    let n = timeout(request_timeout, stream.read(&mut buf))
         .await
         .map_err(|_| anyhow!("observability request timed out"))??;
     let request =
@@ -180,10 +242,10 @@ async fn handle_connection(
         "HTTP/1.1 {status}\r\ncontent-type: {content_type}\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
         body.len()
     );
-    timeout(REQUEST_TIMEOUT, stream.write_all(response.as_bytes()))
+    timeout(request_timeout, stream.write_all(response.as_bytes()))
         .await
         .map_err(|_| anyhow!("observability response write timed out"))??;
-    timeout(REQUEST_TIMEOUT, stream.flush())
+    timeout(request_timeout, stream.flush())
         .await
         .map_err(|_| anyhow!("observability response flush timed out"))??;
     Ok(())
@@ -200,6 +262,27 @@ fn render_metrics(snapshot: MetricsSnapshot) -> String {
          # HELP numax_sync_latency_ms Last sync latency in milliseconds\n\
          # TYPE numax_sync_latency_ms gauge\n\
          numax_sync_latency_ms {}\n\
+         # HELP numax_sync_errors_total Sync errors\n\
+         # TYPE numax_sync_errors_total counter\n\
+         numax_sync_errors_total {}\n\
+         # HELP numax_observability_requests_total Observability requests\n\
+         # TYPE numax_observability_requests_total counter\n\
+         numax_observability_requests_total {}\n\
+         # HELP numax_observability_errors_total Observability request errors\n\
+         # TYPE numax_observability_errors_total counter\n\
+         numax_observability_errors_total {}\n\
+         # HELP numax_peer_connects_total Peer connections observed\n\
+         # TYPE numax_peer_connects_total counter\n\
+         numax_peer_connects_total {}\n\
+         # HELP numax_peer_disconnects_total Peer disconnections observed\n\
+         # TYPE numax_peer_disconnects_total counter\n\
+         numax_peer_disconnects_total {}\n\
+         # HELP numax_broadcast_batches_total Broadcast batches sent\n\
+         # TYPE numax_broadcast_batches_total counter\n\
+         numax_broadcast_batches_total {}\n\
+         # HELP numax_broadcast_ops_total Broadcast ops sent\n\
+         # TYPE numax_broadcast_ops_total counter\n\
+         numax_broadcast_ops_total {}\n\
          # HELP numax_store_keys Keys in the local store\n\
          # TYPE numax_store_keys gauge\n\
          numax_store_keys {}\n\
@@ -209,6 +292,13 @@ fn render_metrics(snapshot: MetricsSnapshot) -> String {
         snapshot.ops_total,
         snapshot.peers_connected,
         snapshot.sync_latency_ms,
+        snapshot.sync_errors_total,
+        snapshot.observability_requests_total,
+        snapshot.observability_errors_total,
+        snapshot.peer_connects_total,
+        snapshot.peer_disconnects_total,
+        snapshot.broadcast_batches_total,
+        snapshot.broadcast_ops_total,
         snapshot.store_keys,
         snapshot.store_bytes
     )
@@ -235,6 +325,13 @@ mod tests {
             ops_total: 7,
             peers_connected: 2,
             sync_latency_ms: 15,
+            sync_errors_total: 1,
+            observability_requests_total: 9,
+            observability_errors_total: 1,
+            peer_connects_total: 3,
+            peer_disconnects_total: 2,
+            broadcast_batches_total: 4,
+            broadcast_ops_total: 8,
             store_keys: 3,
             store_bytes: 42,
         };
@@ -243,6 +340,13 @@ mod tests {
         assert!(rendered.contains("numax_ops_total 7"));
         assert!(rendered.contains("numax_peers_connected 2"));
         assert!(rendered.contains("numax_sync_latency_ms 15"));
+        assert!(rendered.contains("numax_sync_errors_total 1"));
+        assert!(rendered.contains("numax_observability_requests_total 9"));
+        assert!(rendered.contains("numax_observability_errors_total 1"));
+        assert!(rendered.contains("numax_peer_connects_total 3"));
+        assert!(rendered.contains("numax_peer_disconnects_total 2"));
+        assert!(rendered.contains("numax_broadcast_batches_total 4"));
+        assert!(rendered.contains("numax_broadcast_ops_total 8"));
         assert!(rendered.contains("numax_store_keys 3"));
         assert!(rendered.contains("numax_store_bytes 42"));
     }
@@ -264,11 +368,71 @@ mod tests {
 
         assert!(request(addr, "/health").await.contains("ok"));
         assert!(request(addr, "/ready").await.contains("ready"));
-        assert!(
-            request(addr, "/metrics")
-                .await
-                .contains("numax_ops_total 2")
-        );
+
+        let metrics_response = request(addr, "/metrics").await;
+        assert!(metrics_response.contains("HTTP/1.1 200 OK"));
+        assert!(metrics_response.contains("text/plain; version=0.0.4"));
+        assert!(metrics_response.contains("numax_ops_total 2"));
+        assert!(metrics_response.contains("numax_observability_requests_total 3"));
+
+        server.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn ready_returns_503_before_runtime_is_ready() {
+        let metrics = Arc::new(RuntimeMetrics::default());
+        let store = temp_store();
+        let (addr, server) = start_server(
+            ObservabilityConfig::new("127.0.0.1:0"),
+            Arc::clone(&metrics),
+            Arc::clone(&store),
+        )
+        .await
+        .unwrap();
+
+        let response = request(addr, "/ready").await;
+
+        assert!(response.contains("HTTP/1.1 503 Service Unavailable"));
+        assert!(response.contains("not ready"));
+
+        server.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn unknown_path_returns_404() {
+        let metrics = Arc::new(RuntimeMetrics::default());
+        let store = temp_store();
+        let (addr, server) = start_server(
+            ObservabilityConfig::new("127.0.0.1:0"),
+            Arc::clone(&metrics),
+            Arc::clone(&store),
+        )
+        .await
+        .unwrap();
+
+        let response = request(addr, "/missing").await;
+
+        assert!(response.contains("HTTP/1.1 404 Not Found"));
+        assert!(response.contains("not found"));
+
+        server.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn idle_observability_connection_times_out() {
+        let metrics = Arc::new(RuntimeMetrics::default());
+        let store = temp_store();
+        let config =
+            ObservabilityConfig::new("127.0.0.1:0").with_request_timeout(Duration::from_millis(25));
+        let (addr, server) = start_server(config, Arc::clone(&metrics), Arc::clone(&store))
+            .await
+            .unwrap();
+
+        let _stream = TcpStream::connect(addr).await.unwrap();
+        tokio::time::sleep(Duration::from_millis(75)).await;
+
+        let metrics_response = request(addr, "/metrics").await;
+        assert!(metrics_response.contains("numax_observability_errors_total 1"));
 
         server.shutdown().await;
     }

--- a/crates/nx-core/src/observability.rs
+++ b/crates/nx-core/src/observability.rs
@@ -186,7 +186,10 @@ pub async fn start_server(
                                 }
                             });
                         }
-                        Err(e) => warn!(error = %e, "observability accept failed"),
+                        Err(e) => {
+                            metrics.record_observability_error();
+                            warn!(error = %e, "observability accept failed");
+                        }
                     }
                 }
             }

--- a/crates/nx-core/src/runtime.rs
+++ b/crates/nx-core/src/runtime.rs
@@ -11,6 +11,9 @@ use nx_store::Store as NxStore;
 use nx_sync::NodeId;
 
 use crate::host_api;
+use crate::observability::{
+    ObservabilityConfig, ObservabilityServer, RuntimeMetrics, start_server,
+};
 use crate::sync_config::SyncConfig;
 use crate::sync_manager::{SyncHandle, SyncManager};
 
@@ -37,6 +40,9 @@ pub struct RuntimeConfig {
 
     /// config sync (None = sync disabled).
     pub sync: Option<SyncConfig>,
+
+    /// Observability HTTP endpoint (None = disabled).
+    pub observability: Option<ObservabilityConfig>,
 }
 
 impl Default for RuntimeConfig {
@@ -46,6 +52,7 @@ impl Default for RuntimeConfig {
             max_memory_bytes: None,
             datastore_path: PathBuf::from("./nx-data"),
             sync: None,
+            observability: None,
         }
     }
 }
@@ -62,9 +69,11 @@ pub struct Runtime {
     linker: Linker<HostState>,
     config: RuntimeConfig,
     store: Arc<NxStore>,
+    metrics: Arc<RuntimeMetrics>,
 
     sync_manager: Option<SyncManager>,
     sync_handle: Option<SyncHandle>,
+    observability_server: Option<ObservabilityServer>,
 }
 
 impl Runtime {
@@ -99,11 +108,18 @@ impl Runtime {
         let store = NxStore::open(&config.datastore_path)
             .map_err(|e| anyhow!("Failed to open datastore: {e}"))?;
         let store = Arc::new(store);
+        let metrics = Arc::new(RuntimeMetrics::default());
+        metrics.set_ready(config.sync.is_none());
 
         // Initialize SyncManager if configured, and derive its handle up-front so every HostState built afterwards sees the same op channel.
         let (sync_manager, sync_handle) = if let Some(ref sync_config) = config.sync {
             let node_id = NodeId::generate();
-            let manager = SyncManager::new(node_id, sync_config.clone(), Arc::clone(&store));
+            let manager = SyncManager::new(
+                node_id,
+                sync_config.clone(),
+                Arc::clone(&store),
+                Arc::clone(&metrics),
+            );
             let handle = manager.handle();
             (Some(manager), Some(handle))
         } else {
@@ -115,9 +131,27 @@ impl Runtime {
             linker,
             config,
             store,
+            metrics,
             sync_manager,
             sync_handle,
+            observability_server: None,
         })
+    }
+
+    /// Start the optional observability HTTP endpoint.
+    pub async fn start_observability(&mut self) -> Result<Option<std::net::SocketAddr>> {
+        let Some(config) = self.config.observability.clone() else {
+            return Ok(None);
+        };
+        if self.observability_server.is_some() {
+            return Ok(None);
+        }
+
+        let (addr, server) =
+            start_server(config, Arc::clone(&self.metrics), Arc::clone(&self.store)).await?;
+        self.observability_server = Some(server);
+        tracing::info!(addr = %addr, "observability endpoint started");
+        Ok(Some(addr))
     }
 
     /// Start sync networking
@@ -130,6 +164,7 @@ impl Runtime {
             .start()
             .await
             .map_err(|e| anyhow!("sync manager failed to start: {e}"))?;
+        self.metrics.set_ready(true);
         tracing::info!(
             node_id = %manager.node_id(),
             "sync manager started"
@@ -150,6 +185,8 @@ impl Runtime {
     }
 
     async fn shutdown_inner(&mut self) -> Result<()> {
+        self.metrics.set_ready(false);
+
         if let Some(manager) = self.sync_manager.as_mut() {
             manager
                 .shutdown()
@@ -162,6 +199,11 @@ impl Runtime {
         self.store
             .flush()
             .map_err(|e| anyhow!("failed to flush datastore: {e}"))?;
+
+        if let Some(server) = self.observability_server.take() {
+            server.shutdown().await;
+        }
+
         tracing::info!("runtime shutdown complete");
         Ok(())
     }

--- a/crates/nx-core/src/runtime.rs
+++ b/crates/nx-core/src/runtime.rs
@@ -18,6 +18,7 @@ use crate::sync_config::SyncConfig;
 use crate::sync_manager::{SyncHandle, SyncManager};
 
 pub const DEFAULT_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(30);
+const NODE_ID_STORE_KEY: &[u8] = b"__nx/runtime/node_id";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ShutdownSignal {
@@ -113,7 +114,7 @@ impl Runtime {
 
         // Initialize SyncManager if configured, and derive its handle up-front so every HostState built afterwards sees the same op channel.
         let (sync_manager, sync_handle) = if let Some(ref sync_config) = config.sync {
-            let node_id = NodeId::generate();
+            let node_id = load_or_create_node_id(&store)?;
             let manager = SyncManager::new(
                 node_id,
                 sync_config.clone(),
@@ -339,6 +340,22 @@ impl Runtime {
     }
 }
 
+fn load_or_create_node_id(store: &NxStore) -> Result<NodeId> {
+    if let Some(bytes) = store.get(NODE_ID_STORE_KEY)? {
+        let id = String::from_utf8(bytes)
+            .map_err(|e| anyhow!("stored runtime node id is not valid UTF-8: {e}"))?;
+        if id.is_empty() {
+            return Err(anyhow!("stored runtime node id is empty"));
+        }
+        return Ok(NodeId::new(id));
+    }
+
+    let node_id = NodeId::generate();
+    store.set(NODE_ID_STORE_KEY, node_id.as_str().as_bytes())?;
+    store.flush()?;
+    Ok(node_id)
+}
+
 #[cfg(unix)]
 async fn wait_for_shutdown_signal() -> ShutdownSignal {
     use tokio::signal::unix::{SignalKind, signal};
@@ -520,5 +537,31 @@ mod tests {
             .unwrap();
 
         assert_eq!(runtime.store.get(b"key").unwrap(), Some(b"value".to_vec()));
+    }
+
+    #[test]
+    fn sync_runtime_reuses_persisted_node_id() {
+        let datastore_path = temp_datastore_path("numax-runtime-node-id-test");
+        let config = RuntimeConfig {
+            datastore_path: datastore_path.clone(),
+            sync: Some(SyncConfig::new().with_listen_addr("127.0.0.1:0")),
+            ..RuntimeConfig::default()
+        };
+
+        let first = Runtime::new(config).unwrap();
+        let first_node_id = first.sync_manager.as_ref().unwrap().node_id().clone();
+        drop(first);
+
+        let second = Runtime::new(RuntimeConfig {
+            datastore_path,
+            sync: Some(SyncConfig::new().with_listen_addr("127.0.0.1:0")),
+            ..RuntimeConfig::default()
+        })
+        .unwrap();
+
+        assert_eq!(
+            second.sync_manager.as_ref().unwrap().node_id(),
+            &first_node_id
+        );
     }
 }

--- a/crates/nx-core/src/sync_config.rs
+++ b/crates/nx-core/src/sync_config.rs
@@ -1,7 +1,13 @@
 use nx_net::TlsConfig;
 
+/// Default maximum number of simultaneously connected peers.
+pub const DEFAULT_MAX_PEERS: usize = nx_net::DEFAULT_MAX_PEERS;
+
+/// Default maximum number of locally-produced ops waiting for broadcast.
+pub const DEFAULT_QUEUED_OPS_LIMIT: usize = 10_000;
+
 /// Sync configuration for the runtime.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct SyncConfig {
     /// Initial peer addresses (e.g. ["127.0.0.1:9001"]).
     pub peers: Vec<String>,
@@ -11,6 +17,24 @@ pub struct SyncConfig {
 
     /// Optional TLS/mTLS configuration for peer connections.
     pub tls: Option<TlsConfig>,
+
+    /// Maximum number of simultaneously connected peers.
+    pub max_peers: usize,
+
+    /// Maximum number of locally-produced ops waiting for broadcast.
+    pub queued_ops_limit: usize,
+}
+
+impl Default for SyncConfig {
+    fn default() -> Self {
+        Self {
+            peers: Vec::new(),
+            listen_addr: None,
+            tls: None,
+            max_peers: DEFAULT_MAX_PEERS,
+            queued_ops_limit: DEFAULT_QUEUED_OPS_LIMIT,
+        }
+    }
 }
 
 impl SyncConfig {
@@ -33,6 +57,16 @@ impl SyncConfig {
         self
     }
 
+    pub fn with_max_peers(mut self, max_peers: usize) -> Self {
+        self.max_peers = max_peers;
+        self
+    }
+
+    pub fn with_queued_ops_limit(mut self, queued_ops_limit: usize) -> Self {
+        self.queued_ops_limit = queued_ops_limit;
+        self
+    }
+
     /// Sync is enabled iff we have a bound listen address.
     pub fn is_enabled(&self) -> bool {
         self.listen_addr.is_some()
@@ -47,6 +81,8 @@ mod tests {
     fn test_is_enabled_requires_listen() {
         let cfg = SyncConfig::new();
         assert!(!cfg.is_enabled());
+        assert_eq!(cfg.max_peers, DEFAULT_MAX_PEERS);
+        assert_eq!(cfg.queued_ops_limit, DEFAULT_QUEUED_OPS_LIMIT);
 
         let cfg = SyncConfig::new().with_listen_addr("0.0.0.0:9000");
         assert!(cfg.is_enabled());
@@ -63,5 +99,15 @@ mod tests {
         let cfg = SyncConfig::new().with_tls(TlsConfig::insecure_dev());
         assert!(cfg.tls.is_some());
         assert!(cfg.tls.as_ref().unwrap().insecure);
+    }
+
+    #[test]
+    fn test_limits_are_configurable() {
+        let cfg = SyncConfig::new()
+            .with_max_peers(8)
+            .with_queued_ops_limit(256);
+
+        assert_eq!(cfg.max_peers, 8);
+        assert_eq!(cfg.queued_ops_limit, 256);
     }
 }

--- a/crates/nx-core/src/sync_config.rs
+++ b/crates/nx-core/src/sync_config.rs
@@ -1,10 +1,17 @@
 use nx_net::TlsConfig;
+use std::time::Duration;
 
 /// Default maximum number of simultaneously connected peers.
 pub const DEFAULT_MAX_PEERS: usize = nx_net::DEFAULT_MAX_PEERS;
 
 /// Default maximum number of locally-produced ops waiting for broadcast.
 pub const DEFAULT_QUEUED_OPS_LIMIT: usize = 10_000;
+
+/// Default maximum accepted wire message size.
+pub const DEFAULT_MAX_MESSAGE_SIZE: usize = nx_net::DEFAULT_MAX_MESSAGE_SIZE;
+
+/// Default timeout for socket reads and writes.
+pub const DEFAULT_SOCKET_TIMEOUT: Duration = nx_net::DEFAULT_SOCKET_TIMEOUT;
 
 /// Sync configuration for the runtime.
 #[derive(Debug, Clone)]
@@ -23,6 +30,12 @@ pub struct SyncConfig {
 
     /// Maximum number of locally-produced ops waiting for broadcast.
     pub queued_ops_limit: usize,
+
+    /// Maximum accepted wire message size.
+    pub max_message_size: usize,
+
+    /// Timeout for socket reads and writes.
+    pub socket_timeout: Duration,
 }
 
 impl Default for SyncConfig {
@@ -33,6 +46,8 @@ impl Default for SyncConfig {
             tls: None,
             max_peers: DEFAULT_MAX_PEERS,
             queued_ops_limit: DEFAULT_QUEUED_OPS_LIMIT,
+            max_message_size: DEFAULT_MAX_MESSAGE_SIZE,
+            socket_timeout: DEFAULT_SOCKET_TIMEOUT,
         }
     }
 }
@@ -67,6 +82,16 @@ impl SyncConfig {
         self
     }
 
+    pub fn with_max_message_size(mut self, max_message_size: usize) -> Self {
+        self.max_message_size = max_message_size;
+        self
+    }
+
+    pub fn with_socket_timeout(mut self, socket_timeout: Duration) -> Self {
+        self.socket_timeout = socket_timeout;
+        self
+    }
+
     /// Sync is enabled iff we have a bound listen address.
     pub fn is_enabled(&self) -> bool {
         self.listen_addr.is_some()
@@ -83,6 +108,8 @@ mod tests {
         assert!(!cfg.is_enabled());
         assert_eq!(cfg.max_peers, DEFAULT_MAX_PEERS);
         assert_eq!(cfg.queued_ops_limit, DEFAULT_QUEUED_OPS_LIMIT);
+        assert_eq!(cfg.max_message_size, DEFAULT_MAX_MESSAGE_SIZE);
+        assert_eq!(cfg.socket_timeout, DEFAULT_SOCKET_TIMEOUT);
 
         let cfg = SyncConfig::new().with_listen_addr("0.0.0.0:9000");
         assert!(cfg.is_enabled());
@@ -105,9 +132,13 @@ mod tests {
     fn test_limits_are_configurable() {
         let cfg = SyncConfig::new()
             .with_max_peers(8)
-            .with_queued_ops_limit(256);
+            .with_queued_ops_limit(256)
+            .with_max_message_size(1024)
+            .with_socket_timeout(Duration::from_secs(5));
 
         assert_eq!(cfg.max_peers, 8);
         assert_eq!(cfg.queued_ops_limit, 256);
+        assert_eq!(cfg.max_message_size, 1024);
+        assert_eq!(cfg.socket_timeout, Duration::from_secs(5));
     }
 }

--- a/crates/nx-core/src/sync_manager.rs
+++ b/crates/nx-core/src/sync_manager.rs
@@ -8,6 +8,7 @@ use tokio::sync::{RwLock, mpsc, watch};
 use tokio::task::JoinHandle;
 use tracing::{debug, error, info, warn};
 
+use crate::observability::RuntimeMetrics;
 use crate::sync_config::SyncConfig;
 
 /// Upper bound on how many ops we coalesce into a single PushOps message.
@@ -21,6 +22,7 @@ pub struct SyncHandle {
     op_tx: mpsc::Sender<Op>,
     counters: Arc<RwLock<HashMap<String, GCounter>>>,
     store: Arc<NxStore>,
+    metrics: Arc<RuntimeMetrics>,
 }
 
 impl SyncHandle {
@@ -43,6 +45,11 @@ impl SyncHandle {
     pub fn store(&self) -> Arc<NxStore> {
         Arc::clone(&self.store)
     }
+
+    /// Shared runtime metrics.
+    pub fn metrics(&self) -> Arc<RuntimeMetrics> {
+        Arc::clone(&self.metrics)
+    }
 }
 
 pub struct SyncManager {
@@ -61,6 +68,9 @@ pub struct SyncManager {
 
     /// Store used to materialize replicated values.
     store: Arc<NxStore>,
+
+    /// Shared runtime metrics.
+    metrics: Arc<RuntimeMetrics>,
 
     /// OpId
     seen_ops: Arc<RwLock<HashSet<String>>>,
@@ -83,7 +93,12 @@ pub struct SyncManager {
 
 impl SyncManager {
     /// new SyncManager.
-    pub fn new(node_id: NodeId, config: SyncConfig, store: Arc<NxStore>) -> Self {
+    pub fn new(
+        node_id: NodeId,
+        config: SyncConfig,
+        store: Arc<NxStore>,
+        metrics: Arc<RuntimeMetrics>,
+    ) -> Self {
         let (op_tx, op_rx) = mpsc::channel(config.queued_ops_limit.max(1));
         let (shutdown_tx, _shutdown_rx) = watch::channel(false);
         let mut counters = HashMap::new();
@@ -99,6 +114,7 @@ impl SyncManager {
             node: None,
             counters,
             store,
+            metrics,
             seen_ops: Arc::new(RwLock::new(HashSet::new())),
             op_tx,
             op_rx: Some(op_rx),
@@ -130,6 +146,7 @@ impl SyncManager {
             op_tx: self.op_tx.clone(),
             counters: Arc::clone(&self.counters),
             store: Arc::clone(&self.store),
+            metrics: Arc::clone(&self.metrics),
         }
     }
 
@@ -174,6 +191,7 @@ impl SyncManager {
         let counters = Arc::clone(&self.counters);
         let seen_ops = Arc::clone(&self.seen_ops);
         let store = Arc::clone(&self.store);
+        let metrics = Arc::clone(&self.metrics);
         let mut shutdown_rx = self.shutdown_tx.subscribe();
         self.event_task = Some(tokio::spawn(async move {
             loop {
@@ -181,7 +199,7 @@ impl SyncManager {
                     _ = shutdown_rx.changed() => {
                         if *shutdown_rx.borrow() {
                             debug!("event loop shutdown requested");
-                            drain_node_events(&mut event_rx, &counters, &seen_ops, &store).await;
+                            drain_node_events(&mut event_rx, &counters, &seen_ops, &store, &metrics).await;
                             break;
                         }
                     }
@@ -189,7 +207,7 @@ impl SyncManager {
                         let Some(event) = event else {
                             break;
                         };
-                        handle_node_event(event, &counters, &seen_ops, &store).await;
+                        handle_node_event(event, &counters, &seen_ops, &store, &metrics).await;
                     }
                 }
             }
@@ -205,6 +223,7 @@ impl SyncManager {
             Arc::clone(&node),
             op_rx,
             self.shutdown_tx.subscribe(),
+            Arc::clone(&self.metrics),
         ));
 
         Ok(())
@@ -252,6 +271,7 @@ impl SyncManager {
         if let Some(node) = self.node.as_ref() {
             node.shutdown().await;
         }
+        self.metrics.set_peers_connected(0);
 
         if let Some(task) = self.event_task.take()
             && let Err(e) = task.await
@@ -269,6 +289,7 @@ fn spawn_broadcast_loop(
     node: Arc<Node>,
     mut op_rx: mpsc::Receiver<Op>,
     mut shutdown_rx: watch::Receiver<bool>,
+    metrics: Arc<RuntimeMetrics>,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
         loop {
@@ -276,7 +297,7 @@ fn spawn_broadcast_loop(
                 _ = shutdown_rx.changed() => {
                     if *shutdown_rx.borrow() {
                         debug!("broadcast loop shutdown requested");
-                        drain_broadcast_queue(&node, &mut op_rx).await;
+                        drain_broadcast_queue(&node, &mut op_rx, &metrics).await;
                         break;
                     }
                 }
@@ -284,7 +305,7 @@ fn spawn_broadcast_loop(
                     let Some(first) = op else {
                         break;
                     };
-                    broadcast_batch(&node, &mut op_rx, first).await;
+                    broadcast_batch(&node, &mut op_rx, first, &metrics).await;
                 }
             }
         }
@@ -292,7 +313,12 @@ fn spawn_broadcast_loop(
     })
 }
 
-async fn broadcast_batch(node: &Arc<Node>, op_rx: &mut mpsc::Receiver<Op>, first: Op) {
+async fn broadcast_batch(
+    node: &Arc<Node>,
+    op_rx: &mut mpsc::Receiver<Op>,
+    first: Op,
+    metrics: &Arc<RuntimeMetrics>,
+) {
     let mut batch = Vec::with_capacity(BROADCAST_BATCH_MAX);
     batch.push(first);
 
@@ -305,16 +331,22 @@ async fn broadcast_batch(node: &Arc<Node>, op_rx: &mut mpsc::Receiver<Op>, first
     }
 
     let count = batch.len();
+    let started = std::time::Instant::now();
     if let Err(e) = node.broadcast_ops(batch).await {
         warn!(error = %e, count, "broadcast failed; ops dropped for this round");
     } else {
+        metrics.record_sync_latency(started.elapsed());
         debug!(count, "broadcast batch sent");
     }
 }
 
-async fn drain_broadcast_queue(node: &Arc<Node>, op_rx: &mut mpsc::Receiver<Op>) {
+async fn drain_broadcast_queue(
+    node: &Arc<Node>,
+    op_rx: &mut mpsc::Receiver<Op>,
+    metrics: &Arc<RuntimeMetrics>,
+) {
     while let Ok(first) = op_rx.try_recv() {
-        broadcast_batch(node, op_rx, first).await;
+        broadcast_batch(node, op_rx, first, metrics).await;
     }
 }
 
@@ -323,9 +355,10 @@ async fn drain_node_events(
     counters: &Arc<RwLock<HashMap<String, GCounter>>>,
     seen_ops: &Arc<RwLock<HashSet<String>>>,
     store: &Arc<NxStore>,
+    metrics: &Arc<RuntimeMetrics>,
 ) {
     while let Ok(event) = event_rx.try_recv() {
-        handle_node_event(event, counters, seen_ops, store).await;
+        handle_node_event(event, counters, seen_ops, store, metrics).await;
     }
 }
 
@@ -334,20 +367,29 @@ async fn handle_node_event(
     counters: &Arc<RwLock<HashMap<String, GCounter>>>,
     seen_ops: &Arc<RwLock<HashSet<String>>>,
     store: &Arc<NxStore>,
+    metrics: &Arc<RuntimeMetrics>,
 ) {
     match event {
         NodeEvent::OpsReceived { from, ops } => {
             debug!(from = %from, count = ops.len(), "received ops from peer");
             for op in ops {
-                if let Err(e) = apply_remote_op(&op, counters, seen_ops, store).await {
+                if let Err(e) = apply_remote_op(&op, counters, seen_ops, store, metrics).await {
                     error!(error = %e, "failed to apply remote op");
                 }
             }
         }
-        NodeEvent::PeerConnected { node_id } => {
+        NodeEvent::PeerConnected {
+            node_id,
+            peers_connected,
+        } => {
+            metrics.set_peers_connected(peers_connected);
             info!(peer = %node_id, "peer connected");
         }
-        NodeEvent::PeerDisconnected { node_id } => {
+        NodeEvent::PeerDisconnected {
+            node_id,
+            peers_connected,
+        } => {
+            metrics.set_peers_connected(peers_connected);
             info!(peer = %node_id, "peer disconnected");
         }
     }
@@ -430,6 +472,7 @@ async fn apply_remote_op(
     counters: &Arc<RwLock<HashMap<String, GCounter>>>,
     seen_ops: &Arc<RwLock<HashSet<String>>>,
     store: &Arc<NxStore>,
+    metrics: &Arc<RuntimeMetrics>,
 ) -> anyhow::Result<()> {
     // Deduplication
     {
@@ -451,7 +494,8 @@ async fn apply_remote_op(
             materialize_gcounter_value(store, key, total)?;
             counters.insert(key.clone(), counter);
 
-            debug!(key = %key, from = %op.origin, increment = %increment, total, "applied remote increment");
+            metrics.record_ops(1);
+            debug!(op_id = %op.id, key = %key, from = %op.origin, increment = %increment, total, "applied remote increment");
         }
     }
 
@@ -478,6 +522,10 @@ mod tests {
             .as_nanos();
         path.push(format!("numax-core-sync-test-{nanos}"));
         Arc::new(NxStore::open(path).unwrap())
+    }
+
+    fn metrics() -> Arc<RuntimeMetrics> {
+        Arc::new(RuntimeMetrics::default())
     }
 
     fn free_addr() -> String {
@@ -527,7 +575,8 @@ mod tests {
     async fn started_manager(addr: String) -> (SyncManager, SyncHandle, Arc<NxStore>) {
         let store = temp_store();
         let config = SyncConfig::new().with_listen_addr(addr);
-        let mut manager = SyncManager::new(NodeId::generate(), config, Arc::clone(&store));
+        let mut manager =
+            SyncManager::new(NodeId::generate(), config, Arc::clone(&store), metrics());
         let handle = manager.handle();
         manager.start().await.unwrap();
         (manager, handle, store)
@@ -541,7 +590,7 @@ mod tests {
         let origin = NodeId::new("remote-a");
         let op = Op::gcounter_increment(origin, "counter:visits", 3);
 
-        apply_remote_op(&op, &counters, &seen_ops, &store)
+        apply_remote_op(&op, &counters, &seen_ops, &store, &metrics())
             .await
             .unwrap();
 
@@ -561,10 +610,10 @@ mod tests {
         let origin = NodeId::new("remote-a");
         let op = Op::gcounter_increment(origin, "counter:visits", 3);
 
-        apply_remote_op(&op, &counters, &seen_ops, &store)
+        apply_remote_op(&op, &counters, &seen_ops, &store, &metrics())
             .await
             .unwrap();
-        apply_remote_op(&op, &counters, &seen_ops, &store)
+        apply_remote_op(&op, &counters, &seen_ops, &store, &metrics())
             .await
             .unwrap();
 
@@ -583,7 +632,7 @@ mod tests {
 
         let node_id = NodeId::new("local-node");
         let config = SyncConfig::new();
-        let manager = SyncManager::new(node_id.clone(), config, Arc::clone(&store));
+        let manager = SyncManager::new(node_id.clone(), config, Arc::clone(&store), metrics());
 
         assert_eq!(manager.get_counter_value("counter:visits").await, 42);
 
@@ -651,7 +700,7 @@ mod tests {
     async fn manager_uses_configured_queued_ops_limit() {
         let store = temp_store();
         let config = SyncConfig::new().with_queued_ops_limit(256);
-        let manager = SyncManager::new(NodeId::generate(), config, Arc::clone(&store));
+        let manager = SyncManager::new(NodeId::generate(), config, Arc::clone(&store), metrics());
 
         assert_eq!(manager.op_sender().max_capacity(), 256);
     }
@@ -660,7 +709,7 @@ mod tests {
     async fn manager_normalizes_empty_queued_ops_limit() {
         let store = temp_store();
         let config = SyncConfig::new().with_queued_ops_limit(0);
-        let manager = SyncManager::new(NodeId::generate(), config, Arc::clone(&store));
+        let manager = SyncManager::new(NodeId::generate(), config, Arc::clone(&store), metrics());
 
         assert_eq!(manager.op_sender().max_capacity(), 1);
     }

--- a/crates/nx-core/src/sync_manager.rs
+++ b/crates/nx-core/src/sync_manager.rs
@@ -333,8 +333,10 @@ async fn broadcast_batch(
     let count = batch.len();
     let started = std::time::Instant::now();
     if let Err(e) = node.broadcast_ops(batch).await {
+        metrics.record_sync_error();
         warn!(error = %e, count, "broadcast failed; ops dropped for this round");
     } else {
+        metrics.record_broadcast_batch(count);
         metrics.record_sync_latency(started.elapsed());
         debug!(count, "broadcast batch sent");
     }
@@ -374,6 +376,7 @@ async fn handle_node_event(
             debug!(from = %from, count = ops.len(), "received ops from peer");
             for op in ops {
                 if let Err(e) = apply_remote_op(&op, counters, seen_ops, store, metrics).await {
+                    metrics.record_sync_error();
                     error!(error = %e, "failed to apply remote op");
                 }
             }
@@ -382,6 +385,7 @@ async fn handle_node_event(
             node_id,
             peers_connected,
         } => {
+            metrics.record_peer_connect();
             metrics.set_peers_connected(peers_connected);
             info!(peer = %node_id, "peer connected");
         }
@@ -389,6 +393,7 @@ async fn handle_node_event(
             node_id,
             peers_connected,
         } => {
+            metrics.record_peer_disconnect();
             metrics.set_peers_connected(peers_connected);
             info!(peer = %node_id, "peer disconnected");
         }

--- a/crates/nx-core/src/sync_manager.rs
+++ b/crates/nx-core/src/sync_manager.rs
@@ -84,7 +84,7 @@ pub struct SyncManager {
 impl SyncManager {
     /// new SyncManager.
     pub fn new(node_id: NodeId, config: SyncConfig, store: Arc<NxStore>) -> Self {
-        let (op_tx, op_rx) = mpsc::channel(100);
+        let (op_tx, op_rx) = mpsc::channel(config.queued_ops_limit.max(1));
         let (shutdown_tx, _shutdown_rx) = watch::channel(false);
         let mut counters = HashMap::new();
 
@@ -145,7 +145,8 @@ impl SyncManager {
 
         // Build the network node.
         let mut node_config = NodeConfig::new(self.node_id.clone(), &listen_addr)
-            .with_peers(self.config.peers.clone());
+            .with_peers(self.config.peers.clone())
+            .with_max_peers(self.config.max_peers);
 
         if let Some(tls) = self.config.tls.clone() {
             node_config = node_config.with_tls(tls);
@@ -642,6 +643,24 @@ mod tests {
 
         wait_for_counter(&manager_b, key, 1).await;
         assert_eq!(read_materialized(&store_b, key), 1);
+    }
+
+    #[tokio::test]
+    async fn manager_uses_configured_queued_ops_limit() {
+        let store = temp_store();
+        let config = SyncConfig::new().with_queued_ops_limit(256);
+        let manager = SyncManager::new(NodeId::generate(), config, Arc::clone(&store));
+
+        assert_eq!(manager.op_sender().max_capacity(), 256);
+    }
+
+    #[tokio::test]
+    async fn manager_normalizes_empty_queued_ops_limit() {
+        let store = temp_store();
+        let config = SyncConfig::new().with_queued_ops_limit(0);
+        let manager = SyncManager::new(NodeId::generate(), config, Arc::clone(&store));
+
+        assert_eq!(manager.op_sender().max_capacity(), 1);
     }
 
     #[test]

--- a/crates/nx-core/src/sync_manager.rs
+++ b/crates/nx-core/src/sync_manager.rs
@@ -249,11 +249,6 @@ impl SyncManager {
         }
     }
 
-    /// Broadcast of pending operations, this method can be used for forced flush
-    pub async fn broadcast_pending(&self) -> anyhow::Result<()> {
-        Ok(())
-    }
-
     /// Returns the current value of a GCounter.
     pub async fn get_counter_value(&self, key: &str) -> u64 {
         let counters = self.counters.read().await;

--- a/crates/nx-core/src/sync_manager.rs
+++ b/crates/nx-core/src/sync_manager.rs
@@ -146,7 +146,9 @@ impl SyncManager {
         // Build the network node.
         let mut node_config = NodeConfig::new(self.node_id.clone(), &listen_addr)
             .with_peers(self.config.peers.clone())
-            .with_max_peers(self.config.max_peers);
+            .with_max_peers(self.config.max_peers)
+            .with_max_message_size(self.config.max_message_size)
+            .with_socket_timeout(self.config.socket_timeout);
 
         if let Some(tls) = self.config.tls.clone() {
             node_config = node_config.with_tls(tls);

--- a/crates/nx-core/src/sync_manager.rs
+++ b/crates/nx-core/src/sync_manager.rs
@@ -179,6 +179,7 @@ impl SyncManager {
         // Connect to initial peers.
         for peer_addr in &self.config.peers {
             if let Err(e) = node.connect_to_peer(peer_addr).await {
+                self.metrics.record_sync_error();
                 warn!(peer = %peer_addr, error = %e, "failed to connect to peer");
             }
         }
@@ -242,6 +243,7 @@ impl SyncManager {
     pub async fn reconnect_configured_peers(&self) {
         for peer_addr in &self.config.peers {
             if let Err(e) = self.connect_to_peer(peer_addr).await {
+                self.metrics.record_sync_error();
                 debug!(peer = %peer_addr, error = %e, "configured peer reconnect failed");
             }
         }
@@ -334,7 +336,7 @@ async fn broadcast_batch(
     let started = std::time::Instant::now();
     if let Err(e) = node.broadcast_ops(batch).await {
         metrics.record_sync_error();
-        warn!(error = %e, count, "broadcast failed; ops dropped for this round");
+        warn!(error = %e, count, "broadcast partially failed; ops dropped for failed peers");
     } else {
         metrics.record_broadcast_batch(count);
         metrics.record_sync_latency(started.elapsed());

--- a/crates/nx-net/src/error.rs
+++ b/crates/nx-net/src/error.rs
@@ -19,6 +19,9 @@ pub enum NetError {
     #[error("invalid message: {0}")]
     InvalidMessage(String),
 
+    #[error("message too large: {len} > {limit}")]
+    MessageTooLarge { len: usize, limit: usize },
+
     #[error("timeout")]
     Timeout,
 

--- a/crates/nx-net/src/error.rs
+++ b/crates/nx-net/src/error.rs
@@ -31,6 +31,9 @@ pub enum NetError {
     #[error("peer not allowed: {0}")]
     PeerNotAllowed(String),
 
+    #[error("peer connection limit reached: {0}")]
+    PeerLimitReached(usize),
+
     #[error("node ID mismatch: expected {expected}, got {got}")]
     NodeIdMismatch { expected: String, got: String },
 }

--- a/crates/nx-net/src/lib.rs
+++ b/crates/nx-net/src/lib.rs
@@ -6,7 +6,10 @@ mod tls;
 
 pub use error::{NetError, NetResult};
 pub use message::{Message, MessageKind};
-pub use node::{DEFAULT_MAX_PEERS, Node, NodeConfig, NodeEvent};
+pub use node::{
+    DEFAULT_MAX_MESSAGE_SIZE, DEFAULT_MAX_PEERS, DEFAULT_SOCKET_TIMEOUT, Node, NodeConfig,
+    NodeEvent,
+};
 pub use peer::{PeerId, PeerInfo};
 pub use tls::{
     NetStream, NodeId, TestPki, TlsConfig, derive_node_id, generate_ca, generate_self_signed,

--- a/crates/nx-net/src/lib.rs
+++ b/crates/nx-net/src/lib.rs
@@ -6,7 +6,7 @@ mod tls;
 
 pub use error::{NetError, NetResult};
 pub use message::{Message, MessageKind};
-pub use node::{Node, NodeConfig, NodeEvent};
+pub use node::{DEFAULT_MAX_PEERS, Node, NodeConfig, NodeEvent};
 pub use peer::{PeerId, PeerInfo};
 pub use tls::{
     NetStream, NodeId, TestPki, TlsConfig, derive_node_id, generate_ca, generate_self_signed,

--- a/crates/nx-net/src/node.rs
+++ b/crates/nx-net/src/node.rs
@@ -112,7 +112,7 @@ pub enum NodeEvent {
 struct PeerConnection {
     info: PeerInfo,
     state: PeerState,
-    writer: Option<tokio::io::WriteHalf<crate::tls::NetStream>>,
+    writer: Option<Arc<tokio::sync::Mutex<tokio::io::WriteHalf<crate::tls::NetStream>>>>,
 }
 
 /// node
@@ -313,7 +313,7 @@ impl Node {
                 PeerConnection {
                     info: PeerInfo::new(addr).with_node_id(peer_node_id.clone()),
                     state: PeerState::Connected,
-                    writer: Some(writer),
+                    writer: Some(Arc::new(tokio::sync::Mutex::new(writer))),
                 },
             );
         }
@@ -365,15 +365,29 @@ impl Node {
         let msg = Message::push_ops(ops);
         let bytes = msg.to_bytes()?;
 
-        let mut peers = self.peers.write().await;
+        let writers = {
+            let peers = self.peers.read().await;
+            peers
+                .iter()
+                .filter_map(|(addr, conn)| {
+                    (conn.state == PeerState::Connected)
+                        .then(|| {
+                            conn.writer
+                                .as_ref()
+                                .map(|writer| (addr.clone(), Arc::clone(writer)))
+                        })
+                        .flatten()
+                })
+                .collect::<Vec<_>>()
+        };
 
-        for (addr, conn) in peers.iter_mut() {
-            if conn.state == PeerState::Connected
-                && let Some(ref mut writer) = conn.writer
-                && let Err(e) = write_bytes(writer, &bytes, self.config.socket_timeout).await
-            {
+        for (addr, writer) in writers {
+            let mut writer = writer.lock().await;
+            if let Err(e) = write_bytes(&mut *writer, &bytes, self.config.socket_timeout).await {
                 warn!(%addr, error = %e, "failed to send ops");
-                conn.state = PeerState::Failed;
+                if let Some(conn) = self.peers.write().await.get_mut(&addr) {
+                    conn.state = PeerState::Failed;
+                }
             }
         }
 
@@ -482,7 +496,7 @@ async fn handle_incoming(
             PeerConnection {
                 info: PeerInfo::new(&addr).with_node_id(peer_node_id.clone()),
                 state: PeerState::Connected,
-                writer: Some(writer),
+                writer: Some(Arc::new(tokio::sync::Mutex::new(writer))),
             },
         );
     }

--- a/crates/nx-net/src/node.rs
+++ b/crates/nx-net/src/node.rs
@@ -5,7 +5,8 @@ use std::time::Duration;
 use nx_sync::{NodeId, Op};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
-use tokio::sync::{RwLock, mpsc, watch};
+use tokio::sync::{Mutex, OwnedSemaphorePermit, RwLock, Semaphore, mpsc, watch};
+use tokio::task::JoinHandle;
 use tokio::time::timeout;
 use tracing::{debug, error, info, warn};
 
@@ -119,6 +120,7 @@ struct PeerConnection {
     info: PeerInfo,
     state: PeerState,
     writer: Option<Arc<tokio::sync::Mutex<tokio::io::WriteHalf<crate::tls::NetStream>>>>,
+    _slot: OwnedSemaphorePermit,
 }
 
 /// node
@@ -128,6 +130,8 @@ pub struct Node {
     event_tx: mpsc::Sender<NodeEvent>,
     event_rx: Option<mpsc::Receiver<NodeEvent>>,
     shutdown_tx: watch::Sender<bool>,
+    connection_slots: Arc<Semaphore>,
+    tasks: Arc<Mutex<Vec<JoinHandle<()>>>>,
 }
 
 impl Node {
@@ -135,6 +139,7 @@ impl Node {
     pub fn new(config: NodeConfig) -> Self {
         let (event_tx, event_rx) = mpsc::channel(100);
         let (shutdown_tx, _shutdown_rx) = watch::channel(false);
+        let max_peers = config.max_peers;
 
         Self {
             config,
@@ -142,6 +147,8 @@ impl Node {
             event_tx,
             event_rx: Some(event_rx),
             shutdown_tx,
+            connection_slots: Arc::new(Semaphore::new(max_peers)),
+            tasks: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
@@ -163,6 +170,8 @@ impl Node {
         let node_id = self.config.node_id.clone();
         let event_tx = self.event_tx.clone();
         let tls = self.config.tls.clone();
+        let connection_slots = Arc::clone(&self.connection_slots);
+        let tasks = Arc::clone(&self.tasks);
         let limits = NodeLimits {
             max_peers: self.config.max_peers,
             max_message_size: self.config.max_message_size,
@@ -170,7 +179,7 @@ impl Node {
         };
         let mut shutdown_rx = self.shutdown_tx.subscribe();
 
-        tokio::spawn(async move {
+        let listener_task = tokio::spawn(async move {
             loop {
                 tokio::select! {
                     _ = shutdown_rx.changed() => {
@@ -183,13 +192,20 @@ impl Node {
                         match accepted {
                             Ok((stream, addr)) => {
                                 info!(%addr, "incoming connection");
+                                let slot = match Arc::clone(&connection_slots).try_acquire_owned() {
+                                    Ok(slot) => slot,
+                                    Err(_) => {
+                                        warn!(%addr, limit = limits.max_peers, "rejecting incoming connection: peer limit reached");
+                                        continue;
+                                    }
+                                };
                                 let peers = Arc::clone(&peers);
                                 let node_id = node_id.clone();
                                 let event_tx = event_tx.clone();
                                 let tls = tls.clone();
                                 let limits = limits;
 
-                                tokio::spawn(async move {
+                                let task = tokio::spawn(async move {
                                     if let Err(e) = handle_incoming(
                                         stream,
                                         addr.to_string(),
@@ -198,12 +214,14 @@ impl Node {
                                         peers,
                                         event_tx,
                                         limits,
+                                        slot,
                                     )
                                     .await
                                     {
                                         error!(%addr, error = %e, "connection error");
                                     }
                                 });
+                                tasks.lock().await.push(task);
                             }
                             Err(e) => {
                                 error!(error = %e, "accept error");
@@ -213,6 +231,7 @@ impl Node {
                 }
             }
         });
+        self.tasks.lock().await.push(listener_task);
 
         Ok(bound_addr)
     }
@@ -220,6 +239,9 @@ impl Node {
     /// Conncet to a peer
     pub async fn connect_to_peer(&self, addr: &str) -> NetResult<()> {
         self.ensure_peer_slot_available().await?;
+        let slot = Arc::clone(&self.connection_slots)
+            .try_acquire_owned()
+            .map_err(|_| NetError::PeerLimitReached(self.config.max_peers))?;
 
         let tcp = TcpStream::connect(addr)
             .await
@@ -320,6 +342,7 @@ impl Node {
                     info: PeerInfo::new(addr).with_node_id(peer_node_id.clone()),
                     state: PeerState::Connected,
                     writer: Some(Arc::new(tokio::sync::Mutex::new(writer))),
+                    _slot: slot,
                 },
             );
             connected_peer_count(&peers)
@@ -341,7 +364,7 @@ impl Node {
         let max_message_size = self.config.max_message_size;
         let socket_timeout = self.config.socket_timeout;
 
-        tokio::spawn(async move {
+        let task = tokio::spawn(async move {
             if let Err(e) = read_loop(
                 reader,
                 peer_node_id.clone(),
@@ -372,6 +395,7 @@ impl Node {
                     .await;
             }
         });
+        self.tasks.lock().await.push(task);
 
         Ok(())
     }
@@ -446,9 +470,17 @@ impl Node {
     /// Close outbound peer connections by dropping their writers.
     pub async fn shutdown(&self) {
         let _ = self.shutdown_tx.send(true);
-        let mut peers = self.peers.write().await;
-        let count = peers.len();
-        peers.clear();
+        let count = {
+            let mut peers = self.peers.write().await;
+            let count = peers.len();
+            peers.clear();
+            count
+        };
+        let mut tasks = self.tasks.lock().await;
+        for task in tasks.drain(..) {
+            task.abort();
+            let _ = task.await;
+        }
         debug!(count, "node peer connections closed");
     }
 }
@@ -462,6 +494,7 @@ async fn handle_incoming(
     peers: Arc<RwLock<HashMap<String, PeerConnection>>>,
     event_tx: mpsc::Sender<NodeEvent>,
     limits: NodeLimits,
+    slot: OwnedSemaphorePermit,
 ) -> NetResult<()> {
     let stream: NetStream = match tls {
         Some(ref tls_cfg) => tls_cfg.accept_stream(stream).await?,
@@ -535,6 +568,7 @@ async fn handle_incoming(
                 info: PeerInfo::new(&addr).with_node_id(peer_node_id.clone()),
                 state: PeerState::Connected,
                 writer: Some(Arc::new(tokio::sync::Mutex::new(writer))),
+                _slot: slot,
             },
         );
         connected_peer_count(&peers)
@@ -705,6 +739,10 @@ async fn read_message<R: AsyncReadExt + Unpin>(
 mod tests {
     use super::*;
 
+    fn test_slot() -> OwnedSemaphorePermit {
+        Arc::new(Semaphore::new(1)).try_acquire_owned().unwrap()
+    }
+
     #[tokio::test]
     async fn test_node_config() {
         let config = NodeConfig::new(NodeId::new("test"), "127.0.0.1:9000")
@@ -733,6 +771,7 @@ mod tests {
                 info: PeerInfo::new("127.0.0.1:9001"),
                 state: PeerState::Connected,
                 writer: None,
+                _slot: test_slot(),
             },
         );
 
@@ -750,6 +789,7 @@ mod tests {
                 info: PeerInfo::new("127.0.0.1:9001"),
                 state: PeerState::Connected,
                 writer: None,
+                _slot: test_slot(),
             },
         );
 
@@ -767,6 +807,7 @@ mod tests {
                     info: PeerInfo::new("127.0.0.1:9001").with_node_id(NodeId::new("peer-a")),
                     state: PeerState::Connected,
                     writer: None,
+                    _slot: test_slot(),
                 },
             );
             peers.insert(
@@ -775,6 +816,7 @@ mod tests {
                     info: PeerInfo::new("127.0.0.1:9002").with_node_id(NodeId::new("peer-b")),
                     state: PeerState::Connected,
                     writer: None,
+                    _slot: test_slot(),
                 },
             );
         }
@@ -823,6 +865,31 @@ mod tests {
         .unwrap_err();
 
         assert!(matches!(err, NetError::Timeout));
+    }
+
+    #[tokio::test]
+    async fn incoming_idle_handshake_consumes_peer_slot() {
+        let config = NodeConfig::new(NodeId::new("test"), "127.0.0.1:0")
+            .with_max_peers(1)
+            .with_socket_timeout(Duration::from_secs(5));
+        let node = Node::new(config);
+        let addr = node.start_listener().await.unwrap();
+
+        let first = TcpStream::connect(addr).await.unwrap();
+        tokio::time::sleep(Duration::from_millis(25)).await;
+
+        assert_eq!(node.connection_slots.available_permits(), 0);
+        assert_eq!(node.connected_peer_count().await, 0);
+
+        let second = TcpStream::connect(addr).await.unwrap();
+        tokio::time::sleep(Duration::from_millis(25)).await;
+
+        assert_eq!(node.connection_slots.available_permits(), 0);
+        assert_eq!(node.connected_peer_count().await, 0);
+
+        drop(second);
+        drop(first);
+        node.shutdown().await;
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/crates/nx-net/src/node.rs
+++ b/crates/nx-net/src/node.rs
@@ -101,10 +101,16 @@ pub enum NodeEvent {
     OpsReceived { from: NodeId, ops: Vec<Op> },
 
     /// Peer connected.
-    PeerConnected { node_id: NodeId },
+    PeerConnected {
+        node_id: NodeId,
+        peers_connected: usize,
+    },
 
     /// Peer disconnected.
-    PeerDisconnected { node_id: NodeId },
+    PeerDisconnected {
+        node_id: NodeId,
+        peers_connected: usize,
+    },
 }
 
 #[allow(dead_code)]
@@ -305,7 +311,7 @@ impl Node {
         }
 
         // Save connection
-        {
+        let peers_connected = {
             let mut peers = self.peers.write().await;
             ensure_peer_slot_available(&peers, self.config.max_peers, Some(addr))?;
             peers.insert(
@@ -316,13 +322,15 @@ impl Node {
                     writer: Some(Arc::new(tokio::sync::Mutex::new(writer))),
                 },
             );
-        }
+            connected_peer_count(&peers)
+        };
 
         // Notify Event
         let _ = self
             .event_tx
             .send(NodeEvent::PeerConnected {
                 node_id: peer_node_id.clone(),
+                peers_connected,
             })
             .await;
 
@@ -347,12 +355,16 @@ impl Node {
             }
 
             // Cleanup
-            let mut peers = peers.write().await;
-            peers.remove(&addr_owned);
+            let peers_connected = {
+                let mut peers = peers.write().await;
+                peers.remove(&addr_owned);
+                connected_peer_count(&peers)
+            };
 
             let _ = event_tx
                 .send(NodeEvent::PeerDisconnected {
                     node_id: peer_node_id,
+                    peers_connected,
                 })
                 .await;
         });
@@ -488,7 +500,7 @@ async fn handle_incoming(
     let ack = Message::hello_ack(our_node_id);
     write_message(&mut writer, &ack, limits.socket_timeout).await?;
 
-    {
+    let peers_connected = {
         let mut peers = peers.write().await;
         ensure_peer_slot_available(&peers, limits.max_peers, Some(&addr))?;
         peers.insert(
@@ -499,7 +511,8 @@ async fn handle_incoming(
                 writer: Some(Arc::new(tokio::sync::Mutex::new(writer))),
             },
         );
-    }
+        connected_peer_count(&peers)
+    };
 
     info!(peer = %peer_node_id, "incoming peer connected");
 
@@ -507,31 +520,34 @@ async fn handle_incoming(
     let _ = event_tx
         .send(NodeEvent::PeerConnected {
             node_id: peer_node_id.clone(),
+            peers_connected,
         })
         .await;
 
     // Read Loop
-    read_loop(
+    let read_result = read_loop(
         reader,
         peer_node_id.clone(),
         event_tx.clone(),
         limits.max_message_size,
         limits.socket_timeout,
     )
-    .await?;
+    .await;
 
-    {
+    let peers_connected = {
         let mut peers = peers.write().await;
         peers.remove(&addr);
-    }
+        connected_peer_count(&peers)
+    };
 
     let _ = event_tx
         .send(NodeEvent::PeerDisconnected {
             node_id: peer_node_id,
+            peers_connected,
         })
         .await;
 
-    Ok(())
+    read_result
 }
 
 fn connected_peer_count(peers: &HashMap<String, PeerConnection>) -> usize {

--- a/crates/nx-net/src/node.rs
+++ b/crates/nx-net/src/node.rs
@@ -355,18 +355,22 @@ impl Node {
             }
 
             // Cleanup
-            let peers_connected = {
+            let disconnected = {
                 let mut peers = peers.write().await;
-                peers.remove(&addr_owned);
-                connected_peer_count(&peers)
+                peers.remove(&addr_owned).and_then(|removed| {
+                    (removed.state == PeerState::Connected)
+                        .then(|| (peer_node_id.clone(), connected_peer_count(&peers)))
+                })
             };
 
-            let _ = event_tx
-                .send(NodeEvent::PeerDisconnected {
-                    node_id: peer_node_id,
-                    peers_connected,
-                })
-                .await;
+            if let Some((node_id, peers_connected)) = disconnected {
+                let _ = event_tx
+                    .send(NodeEvent::PeerDisconnected {
+                        node_id,
+                        peers_connected,
+                    })
+                    .await;
+            }
         });
 
         Ok(())
@@ -550,18 +554,23 @@ async fn handle_incoming(
     )
     .await;
 
-    let peers_connected = {
+    let disconnected = {
         let mut peers = peers.write().await;
-        peers.remove(&addr);
-        connected_peer_count(&peers)
+        let Some(removed) = peers.remove(&addr) else {
+            return read_result;
+        };
+        (removed.state == PeerState::Connected)
+            .then(|| (peer_node_id.clone(), connected_peer_count(&peers)))
     };
 
-    let _ = event_tx
-        .send(NodeEvent::PeerDisconnected {
-            node_id: peer_node_id,
-            peers_connected,
-        })
-        .await;
+    if let Some((node_id, peers_connected)) = disconnected {
+        let _ = event_tx
+            .send(NodeEvent::PeerDisconnected {
+                node_id,
+                peers_connected,
+            })
+            .await;
+    }
 
     read_result
 }

--- a/crates/nx-net/src/node.rs
+++ b/crates/nx-net/src/node.rs
@@ -12,6 +12,9 @@ use crate::message::{Message, MessageKind, PROTOCOL_VERSION};
 use crate::peer::{PeerInfo, PeerState};
 use crate::tls::{NetStream, TlsConfig};
 
+/// Default maximum number of simultaneously connected peers.
+pub const DEFAULT_MAX_PEERS: usize = 64;
+
 /// Node configuration.
 #[derive(Debug, Clone)]
 pub struct NodeConfig {
@@ -26,6 +29,9 @@ pub struct NodeConfig {
 
     /// Optional TLS/mTLS configuration.
     pub tls: Option<TlsConfig>,
+
+    /// Maximum number of simultaneously connected peers.
+    pub max_peers: usize,
 }
 
 impl NodeConfig {
@@ -35,6 +41,7 @@ impl NodeConfig {
             listen_addr: listen_addr.into(),
             initial_peers: Vec::new(),
             tls: None,
+            max_peers: DEFAULT_MAX_PEERS,
         }
     }
 
@@ -45,6 +52,11 @@ impl NodeConfig {
 
     pub fn with_tls(mut self, tls: TlsConfig) -> Self {
         self.tls = Some(tls);
+        self
+    }
+
+    pub fn with_max_peers(mut self, max_peers: usize) -> Self {
+        self.max_peers = max_peers;
         self
     }
 }
@@ -112,6 +124,7 @@ impl Node {
         let node_id = self.config.node_id.clone();
         let event_tx = self.event_tx.clone();
         let tls = self.config.tls.clone();
+        let max_peers = self.config.max_peers;
         let mut shutdown_rx = self.shutdown_tx.subscribe();
 
         tokio::spawn(async move {
@@ -131,6 +144,7 @@ impl Node {
                                 let node_id = node_id.clone();
                                 let event_tx = event_tx.clone();
                                 let tls = tls.clone();
+                                let max_peers = max_peers;
 
                                 tokio::spawn(async move {
                                     if let Err(e) = handle_incoming(
@@ -140,6 +154,7 @@ impl Node {
                                         node_id,
                                         peers,
                                         event_tx,
+                                        max_peers,
                                     )
                                     .await
                                     {
@@ -161,6 +176,8 @@ impl Node {
 
     /// Conncet to a peer
     pub async fn connect_to_peer(&self, addr: &str) -> NetResult<()> {
+        self.ensure_peer_slot_available().await?;
+
         let tcp = TcpStream::connect(addr)
             .await
             .map_err(|e| NetError::ConnectionFailed(format!("{}: {}", addr, e)))?;
@@ -248,6 +265,7 @@ impl Node {
         // Save connection
         {
             let mut peers = self.peers.write().await;
+            ensure_peer_slot_available(&peers, self.config.max_peers, Some(addr))?;
             peers.insert(
                 addr.to_string(),
                 PeerConnection {
@@ -313,10 +331,12 @@ impl Node {
     /// Returns the number of currently connected peers.
     pub async fn connected_peer_count(&self) -> usize {
         let peers = self.peers.read().await;
-        peers
-            .values()
-            .filter(|c| c.state == PeerState::Connected)
-            .count()
+        connected_peer_count(&peers)
+    }
+
+    async fn ensure_peer_slot_available(&self) -> NetResult<()> {
+        let peers = self.peers.read().await;
+        ensure_peer_slot_available(&peers, self.config.max_peers, None)
     }
 
     /// Close outbound peer connections by dropping their writers.
@@ -337,6 +357,7 @@ async fn handle_incoming(
     our_node_id: NodeId,
     peers: Arc<RwLock<HashMap<String, PeerConnection>>>,
     event_tx: mpsc::Sender<NodeEvent>,
+    max_peers: usize,
 ) -> NetResult<()> {
     let stream: NetStream = match tls {
         Some(ref tls_cfg) => tls_cfg.accept_stream(stream).await?,
@@ -399,6 +420,7 @@ async fn handle_incoming(
 
     {
         let mut peers = peers.write().await;
+        ensure_peer_slot_available(&peers, max_peers, Some(&addr))?;
         peers.insert(
             addr.clone(),
             PeerConnection {
@@ -431,6 +453,30 @@ async fn handle_incoming(
             node_id: peer_node_id,
         })
         .await;
+
+    Ok(())
+}
+
+fn connected_peer_count(peers: &HashMap<String, PeerConnection>) -> usize {
+    peers
+        .values()
+        .filter(|c| c.state == PeerState::Connected)
+        .count()
+}
+
+fn ensure_peer_slot_available(
+    peers: &HashMap<String, PeerConnection>,
+    max_peers: usize,
+    replacing_addr: Option<&str>,
+) -> NetResult<()> {
+    if replacing_addr.is_some_and(|addr| peers.contains_key(addr)) {
+        return Ok(());
+    }
+
+    let count = connected_peer_count(peers);
+    if count >= max_peers {
+        return Err(NetError::PeerLimitReached(max_peers));
+    }
 
     Ok(())
 }
@@ -512,5 +558,45 @@ mod tests {
 
         assert_eq!(config.listen_addr, "127.0.0.1:9000");
         assert_eq!(config.initial_peers.len(), 1);
+        assert_eq!(config.max_peers, DEFAULT_MAX_PEERS);
+    }
+
+    #[test]
+    fn node_config_allows_custom_peer_limit() {
+        let config = NodeConfig::new(NodeId::new("test"), "127.0.0.1:9000").with_max_peers(2);
+
+        assert_eq!(config.max_peers, 2);
+    }
+
+    #[test]
+    fn peer_slot_limit_rejects_new_peer_when_full() {
+        let mut peers = HashMap::new();
+        peers.insert(
+            "127.0.0.1:9001".to_string(),
+            PeerConnection {
+                info: PeerInfo::new("127.0.0.1:9001"),
+                state: PeerState::Connected,
+                writer: None,
+            },
+        );
+
+        let err = ensure_peer_slot_available(&peers, 1, None).unwrap_err();
+
+        assert!(matches!(err, NetError::PeerLimitReached(1)));
+    }
+
+    #[test]
+    fn peer_slot_limit_allows_replacing_same_addr() {
+        let mut peers = HashMap::new();
+        peers.insert(
+            "127.0.0.1:9001".to_string(),
+            PeerConnection {
+                info: PeerInfo::new("127.0.0.1:9001"),
+                state: PeerState::Connected,
+                writer: None,
+            },
+        );
+
+        ensure_peer_slot_available(&peers, 1, Some("127.0.0.1:9001")).unwrap();
     }
 }

--- a/crates/nx-net/src/node.rs
+++ b/crates/nx-net/src/node.rs
@@ -1,10 +1,12 @@
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 
 use nx_sync::{NodeId, Op};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::{RwLock, mpsc, watch};
+use tokio::time::timeout;
 use tracing::{debug, error, info, warn};
 
 use crate::error::{NetError, NetResult};
@@ -14,6 +16,19 @@ use crate::tls::{NetStream, TlsConfig};
 
 /// Default maximum number of simultaneously connected peers.
 pub const DEFAULT_MAX_PEERS: usize = 64;
+
+/// Default maximum accepted wire message size.
+pub const DEFAULT_MAX_MESSAGE_SIZE: usize = 16 * 1024 * 1024;
+
+/// Default timeout for socket reads and writes.
+pub const DEFAULT_SOCKET_TIMEOUT: Duration = Duration::from_secs(30);
+
+#[derive(Debug, Clone, Copy)]
+struct NodeLimits {
+    max_peers: usize,
+    max_message_size: usize,
+    socket_timeout: Duration,
+}
 
 /// Node configuration.
 #[derive(Debug, Clone)]
@@ -32,6 +47,12 @@ pub struct NodeConfig {
 
     /// Maximum number of simultaneously connected peers.
     pub max_peers: usize,
+
+    /// Maximum accepted wire message size.
+    pub max_message_size: usize,
+
+    /// Timeout for socket reads and writes.
+    pub socket_timeout: Duration,
 }
 
 impl NodeConfig {
@@ -42,6 +63,8 @@ impl NodeConfig {
             initial_peers: Vec::new(),
             tls: None,
             max_peers: DEFAULT_MAX_PEERS,
+            max_message_size: DEFAULT_MAX_MESSAGE_SIZE,
+            socket_timeout: DEFAULT_SOCKET_TIMEOUT,
         }
     }
 
@@ -57,6 +80,16 @@ impl NodeConfig {
 
     pub fn with_max_peers(mut self, max_peers: usize) -> Self {
         self.max_peers = max_peers;
+        self
+    }
+
+    pub fn with_max_message_size(mut self, max_message_size: usize) -> Self {
+        self.max_message_size = max_message_size;
+        self
+    }
+
+    pub fn with_socket_timeout(mut self, socket_timeout: Duration) -> Self {
+        self.socket_timeout = socket_timeout;
         self
     }
 }
@@ -124,7 +157,11 @@ impl Node {
         let node_id = self.config.node_id.clone();
         let event_tx = self.event_tx.clone();
         let tls = self.config.tls.clone();
-        let max_peers = self.config.max_peers;
+        let limits = NodeLimits {
+            max_peers: self.config.max_peers,
+            max_message_size: self.config.max_message_size,
+            socket_timeout: self.config.socket_timeout,
+        };
         let mut shutdown_rx = self.shutdown_tx.subscribe();
 
         tokio::spawn(async move {
@@ -144,7 +181,7 @@ impl Node {
                                 let node_id = node_id.clone();
                                 let event_tx = event_tx.clone();
                                 let tls = tls.clone();
-                                let max_peers = max_peers;
+                                let limits = limits;
 
                                 tokio::spawn(async move {
                                     if let Err(e) = handle_incoming(
@@ -154,7 +191,7 @@ impl Node {
                                         node_id,
                                         peers,
                                         event_tx,
-                                        max_peers,
+                                        limits,
                                     )
                                     .await
                                     {
@@ -208,10 +245,15 @@ impl Node {
 
         // Send HELLO
         let hello = Message::hello(self.config.node_id.clone());
-        write_message(&mut writer, &hello).await?;
+        write_message(&mut writer, &hello, self.config.socket_timeout).await?;
 
         // Wait HELLO_ACK
-        let response = read_message(&mut reader).await?;
+        let response = read_message(
+            &mut reader,
+            self.config.max_message_size,
+            self.config.socket_timeout,
+        )
+        .await?;
         let peer_node_id = match response.kind {
             MessageKind::HelloAck { node_id, version } => {
                 if version != PROTOCOL_VERSION {
@@ -288,9 +330,19 @@ impl Node {
         let peers = Arc::clone(&self.peers);
         let event_tx = self.event_tx.clone();
         let addr_owned = addr.to_string();
+        let max_message_size = self.config.max_message_size;
+        let socket_timeout = self.config.socket_timeout;
 
         tokio::spawn(async move {
-            if let Err(e) = read_loop(reader, peer_node_id.clone(), event_tx.clone()).await {
+            if let Err(e) = read_loop(
+                reader,
+                peer_node_id.clone(),
+                event_tx.clone(),
+                max_message_size,
+                socket_timeout,
+            )
+            .await
+            {
                 debug!(peer = %peer_node_id, error = %e, "read loop ended");
             }
 
@@ -318,7 +370,7 @@ impl Node {
         for (addr, conn) in peers.iter_mut() {
             if conn.state == PeerState::Connected
                 && let Some(ref mut writer) = conn.writer
-                && let Err(e) = writer.write_all(&bytes).await
+                && let Err(e) = write_bytes(writer, &bytes, self.config.socket_timeout).await
             {
                 warn!(%addr, error = %e, "failed to send ops");
                 conn.state = PeerState::Failed;
@@ -357,7 +409,7 @@ async fn handle_incoming(
     our_node_id: NodeId,
     peers: Arc<RwLock<HashMap<String, PeerConnection>>>,
     event_tx: mpsc::Sender<NodeEvent>,
-    max_peers: usize,
+    limits: NodeLimits,
 ) -> NetResult<()> {
     let stream: NetStream = match tls {
         Some(ref tls_cfg) => tls_cfg.accept_stream(stream).await?,
@@ -370,7 +422,7 @@ async fn handle_incoming(
     let (mut reader, mut writer) = tokio::io::split(stream);
 
     // Wait for HELLO
-    let msg = read_message(&mut reader).await?;
+    let msg = read_message(&mut reader, limits.max_message_size, limits.socket_timeout).await?;
     let peer_node_id = match msg.kind {
         MessageKind::Hello { node_id, version } => {
             if version != PROTOCOL_VERSION {
@@ -414,13 +466,17 @@ async fn handle_incoming(
         }
     }
 
-    // Send HELLO_ACK
+    {
+        let peers = peers.read().await;
+        ensure_peer_slot_available(&peers, limits.max_peers, Some(&addr))?;
+    }
+
     let ack = Message::hello_ack(our_node_id);
-    write_message(&mut writer, &ack).await?;
+    write_message(&mut writer, &ack, limits.socket_timeout).await?;
 
     {
         let mut peers = peers.write().await;
-        ensure_peer_slot_available(&peers, max_peers, Some(&addr))?;
+        ensure_peer_slot_available(&peers, limits.max_peers, Some(&addr))?;
         peers.insert(
             addr.clone(),
             PeerConnection {
@@ -441,7 +497,14 @@ async fn handle_incoming(
         .await;
 
     // Read Loop
-    read_loop(reader, peer_node_id.clone(), event_tx.clone()).await?;
+    read_loop(
+        reader,
+        peer_node_id.clone(),
+        event_tx.clone(),
+        limits.max_message_size,
+        limits.socket_timeout,
+    )
+    .await?;
 
     {
         let mut peers = peers.write().await;
@@ -486,9 +549,11 @@ async fn read_loop(
     mut reader: tokio::io::ReadHalf<NetStream>,
     peer_node_id: NodeId,
     event_tx: mpsc::Sender<NodeEvent>,
+    max_message_size: usize,
+    socket_timeout: Duration,
 ) -> NetResult<()> {
     loop {
-        let msg = match read_message(&mut reader).await {
+        let msg = match read_message(&mut reader, max_message_size, socket_timeout).await {
             Ok(m) => m,
             Err(NetError::Io(e)) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
                 debug!(peer = %peer_node_id, "peer disconnected");
@@ -521,28 +586,56 @@ async fn read_loop(
 }
 
 /// Writes a message to a stream.
-async fn write_message<W: AsyncWriteExt + Unpin>(writer: &mut W, msg: &Message) -> NetResult<()> {
+async fn write_message<W: AsyncWriteExt + Unpin>(
+    writer: &mut W,
+    msg: &Message,
+    socket_timeout: Duration,
+) -> NetResult<()> {
     let bytes = msg.to_bytes()?;
-    writer.write_all(&bytes).await?;
-    writer.flush().await?;
+    write_bytes(writer, &bytes, socket_timeout).await?;
+    Ok(())
+}
+
+async fn write_bytes<W: AsyncWriteExt + Unpin>(
+    writer: &mut W,
+    bytes: &[u8],
+    socket_timeout: Duration,
+) -> NetResult<()> {
+    timeout(socket_timeout, writer.write_all(bytes))
+        .await
+        .map_err(|_| NetError::Timeout)??;
+    timeout(socket_timeout, writer.flush())
+        .await
+        .map_err(|_| NetError::Timeout)??;
     Ok(())
 }
 
 /// Reads a message from a stream.
-async fn read_message<R: AsyncReadExt + Unpin>(reader: &mut R) -> NetResult<Message> {
+async fn read_message<R: AsyncReadExt + Unpin>(
+    reader: &mut R,
+    max_message_size: usize,
+    socket_timeout: Duration,
+) -> NetResult<Message> {
     // Read length (4 bytes)
     let mut len_buf = [0u8; 4];
-    reader.read_exact(&mut len_buf).await?;
+    timeout(socket_timeout, reader.read_exact(&mut len_buf))
+        .await
+        .map_err(|_| NetError::Timeout)??;
     let len = u32::from_be_bytes(len_buf) as usize;
 
     // Sanity check
-    if len > 10 * 1024 * 1024 {
-        return Err(NetError::InvalidMessage("message too large".into()));
+    if len > max_message_size {
+        return Err(NetError::MessageTooLarge {
+            len,
+            limit: max_message_size,
+        });
     }
 
     // Read payload
     let mut buf = vec![0u8; len];
-    reader.read_exact(&mut buf).await?;
+    timeout(socket_timeout, reader.read_exact(&mut buf))
+        .await
+        .map_err(|_| NetError::Timeout)??;
 
     Message::from_bytes(&buf).map_err(|e| e.into())
 }
@@ -559,6 +652,8 @@ mod tests {
         assert_eq!(config.listen_addr, "127.0.0.1:9000");
         assert_eq!(config.initial_peers.len(), 1);
         assert_eq!(config.max_peers, DEFAULT_MAX_PEERS);
+        assert_eq!(config.max_message_size, DEFAULT_MAX_MESSAGE_SIZE);
+        assert_eq!(config.socket_timeout, DEFAULT_SOCKET_TIMEOUT);
     }
 
     #[test]
@@ -598,5 +693,70 @@ mod tests {
         );
 
         ensure_peer_slot_available(&peers, 1, Some("127.0.0.1:9001")).unwrap();
+    }
+
+    #[test]
+    fn node_config_allows_custom_wire_limits() {
+        let config = NodeConfig::new(NodeId::new("test"), "127.0.0.1:9000")
+            .with_max_message_size(1024)
+            .with_socket_timeout(Duration::from_secs(3));
+
+        assert_eq!(config.max_message_size, 1024);
+        assert_eq!(config.socket_timeout, Duration::from_secs(3));
+    }
+
+    #[tokio::test]
+    async fn read_message_rejects_payload_over_configured_limit() {
+        let (mut client, mut server) = tokio::io::duplex(64);
+        client.write_all(&8u32.to_be_bytes()).await.unwrap();
+
+        let err = read_message(&mut server, 4, DEFAULT_SOCKET_TIMEOUT)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            NetError::MessageTooLarge { len: 8, limit: 4 }
+        ));
+    }
+
+    #[tokio::test]
+    async fn read_message_times_out_waiting_for_length() {
+        let (_client, mut server) = tokio::io::duplex(64);
+
+        let err = read_message(
+            &mut server,
+            DEFAULT_MAX_MESSAGE_SIZE,
+            Duration::from_millis(1),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(err, NetError::Timeout));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    #[ignore = "stress test: opens 1000 local TCP connections"]
+    async fn thousand_simultaneous_connections_do_not_crash() {
+        let config = NodeConfig::new(NodeId::new("stress-node"), "127.0.0.1:0")
+            .with_max_peers(DEFAULT_MAX_PEERS)
+            .with_socket_timeout(Duration::from_millis(100));
+        let node = Node::new(config);
+        let addr = node.start_listener().await.unwrap();
+
+        let mut tasks = Vec::with_capacity(1000);
+        for _ in 0..1000 {
+            tasks.push(tokio::spawn(async move { TcpStream::connect(addr).await }));
+        }
+
+        let mut connected = 0usize;
+        for task in tasks {
+            if task.await.unwrap().is_ok() {
+                connected += 1;
+            }
+        }
+
+        assert!(connected > 0, "stress test did not open any connection");
+        node.shutdown().await;
     }
 }

--- a/crates/nx-net/src/node.rs
+++ b/crates/nx-net/src/node.rs
@@ -397,10 +397,12 @@ impl Node {
                 .collect::<Vec<_>>()
         };
 
+        let mut failed = Vec::new();
         for (addr, writer) in writers {
             let mut writer = writer.lock().await;
             if let Err(e) = write_bytes(&mut *writer, &bytes, self.config.socket_timeout).await {
                 warn!(%addr, error = %e, "failed to send ops");
+                failed.push(addr.clone());
                 if let Some((node_id, peers_connected)) = self.mark_peer_failed(&addr).await {
                     let _ = self
                         .event_tx
@@ -411,6 +413,10 @@ impl Node {
                         .await;
                 }
             }
+        }
+
+        if !failed.is_empty() {
+            return Err(NetError::PeerDisconnected(failed.join(",")));
         }
 
         Ok(())

--- a/crates/nx-net/src/node.rs
+++ b/crates/nx-net/src/node.rs
@@ -34,6 +34,16 @@ struct NodeLimits {
     socket_timeout: Duration,
 }
 
+struct IncomingContext {
+    tls: Option<TlsConfig>,
+    our_node_id: NodeId,
+    peers: Arc<RwLock<HashMap<String, PeerConnection>>>,
+    event_tx: mpsc::Sender<NodeEvent>,
+    limits: NodeLimits,
+    slot: OwnedSemaphorePermit,
+    shutdown_rx: watch::Receiver<bool>,
+}
+
 /// Node configuration.
 #[derive(Debug, Clone)]
 pub struct NodeConfig {
@@ -211,18 +221,18 @@ impl Node {
                                 let shutdown_rx = shutdown_tx.subscribe();
 
                                 let task = tokio::spawn(async move {
-                                    if let Err(e) = handle_incoming(
-                                        stream,
-                                        addr.to_string(),
+                                    let context = IncomingContext {
                                         tls,
-                                        node_id,
+                                        our_node_id: node_id,
                                         peers,
                                         event_tx,
                                         limits,
                                         slot,
                                         shutdown_rx,
-                                    )
-                                    .await
+                                    };
+
+                                    if let Err(e) =
+                                        handle_incoming(stream, addr.to_string(), context).await
                                     {
                                         error!(%addr, error = %e, "connection error");
                                     }
@@ -512,14 +522,18 @@ impl Node {
 async fn handle_incoming(
     stream: TcpStream,
     addr: String,
-    tls: Option<TlsConfig>,
-    our_node_id: NodeId,
-    peers: Arc<RwLock<HashMap<String, PeerConnection>>>,
-    event_tx: mpsc::Sender<NodeEvent>,
-    limits: NodeLimits,
-    slot: OwnedSemaphorePermit,
-    shutdown_rx: watch::Receiver<bool>,
+    context: IncomingContext,
 ) -> NetResult<()> {
+    let IncomingContext {
+        tls,
+        our_node_id,
+        peers,
+        event_tx,
+        limits,
+        slot,
+        shutdown_rx,
+    } = context;
+
     let stream: NetStream = match tls {
         Some(ref tls_cfg) => tls_cfg.accept_stream(stream).await?,
         None => NetStream::Plain(stream),

--- a/crates/nx-net/src/node.rs
+++ b/crates/nx-net/src/node.rs
@@ -397,8 +397,14 @@ impl Node {
             let mut writer = writer.lock().await;
             if let Err(e) = write_bytes(&mut *writer, &bytes, self.config.socket_timeout).await {
                 warn!(%addr, error = %e, "failed to send ops");
-                if let Some(conn) = self.peers.write().await.get_mut(&addr) {
-                    conn.state = PeerState::Failed;
+                if let Some((node_id, peers_connected)) = self.mark_peer_failed(&addr).await {
+                    let _ = self
+                        .event_tx
+                        .send(NodeEvent::PeerDisconnected {
+                            node_id,
+                            peers_connected,
+                        })
+                        .await;
                 }
             }
         }
@@ -415,6 +421,16 @@ impl Node {
     async fn ensure_peer_slot_available(&self) -> NetResult<()> {
         let peers = self.peers.read().await;
         ensure_peer_slot_available(&peers, self.config.max_peers, None)
+    }
+
+    async fn mark_peer_failed(&self, addr: &str) -> Option<(NodeId, usize)> {
+        let mut peers = self.peers.write().await;
+        let node_id = {
+            let conn = peers.get_mut(addr)?;
+            conn.state = PeerState::Failed;
+            conn.info.node_id.clone()?
+        };
+        Some((node_id, connected_peer_count(&peers)))
     }
 
     /// Close outbound peer connections by dropping their writers.
@@ -723,6 +739,35 @@ mod tests {
         );
 
         ensure_peer_slot_available(&peers, 1, Some("127.0.0.1:9001")).unwrap();
+    }
+
+    #[tokio::test]
+    async fn mark_peer_failed_returns_updated_connected_count() {
+        let node = Node::new(NodeConfig::new(NodeId::new("test"), "127.0.0.1:9000"));
+        {
+            let mut peers = node.peers.write().await;
+            peers.insert(
+                "127.0.0.1:9001".to_string(),
+                PeerConnection {
+                    info: PeerInfo::new("127.0.0.1:9001").with_node_id(NodeId::new("peer-a")),
+                    state: PeerState::Connected,
+                    writer: None,
+                },
+            );
+            peers.insert(
+                "127.0.0.1:9002".to_string(),
+                PeerConnection {
+                    info: PeerInfo::new("127.0.0.1:9002").with_node_id(NodeId::new("peer-b")),
+                    state: PeerState::Connected,
+                    writer: None,
+                },
+            );
+        }
+
+        let (node_id, connected) = node.mark_peer_failed("127.0.0.1:9001").await.unwrap();
+
+        assert_eq!(node_id, NodeId::new("peer-a"));
+        assert_eq!(connected, 1);
     }
 
     #[test]

--- a/crates/nx-net/src/node.rs
+++ b/crates/nx-net/src/node.rs
@@ -24,6 +24,9 @@ pub const DEFAULT_MAX_MESSAGE_SIZE: usize = 16 * 1024 * 1024;
 /// Default timeout for socket reads and writes.
 pub const DEFAULT_SOCKET_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Time allowed for network tasks to finish cooperatively after shutdown.
+const TASK_SHUTDOWN_GRACE: Duration = Duration::from_secs(3);
+
 #[derive(Debug, Clone, Copy)]
 struct NodeLimits {
     max_peers: usize,
@@ -178,6 +181,7 @@ impl Node {
             socket_timeout: self.config.socket_timeout,
         };
         let mut shutdown_rx = self.shutdown_tx.subscribe();
+        let shutdown_tx = self.shutdown_tx.clone();
 
         let listener_task = tokio::spawn(async move {
             loop {
@@ -204,6 +208,7 @@ impl Node {
                                 let event_tx = event_tx.clone();
                                 let tls = tls.clone();
                                 let limits = limits;
+                                let shutdown_rx = shutdown_tx.subscribe();
 
                                 let task = tokio::spawn(async move {
                                     if let Err(e) = handle_incoming(
@@ -215,6 +220,7 @@ impl Node {
                                         event_tx,
                                         limits,
                                         slot,
+                                        shutdown_rx,
                                     )
                                     .await
                                     {
@@ -363,6 +369,7 @@ impl Node {
         let addr_owned = addr.to_string();
         let max_message_size = self.config.max_message_size;
         let socket_timeout = self.config.socket_timeout;
+        let shutdown_rx = self.shutdown_tx.subscribe();
 
         let task = tokio::spawn(async move {
             if let Err(e) = read_loop(
@@ -371,6 +378,7 @@ impl Node {
                 event_tx.clone(),
                 max_message_size,
                 socket_timeout,
+                shutdown_rx,
             )
             .await
             {
@@ -470,17 +478,32 @@ impl Node {
     /// Close outbound peer connections by dropping their writers.
     pub async fn shutdown(&self) {
         let _ = self.shutdown_tx.send(true);
+
+        let mut tasks = {
+            let mut tasks = self.tasks.lock().await;
+            std::mem::take(&mut *tasks)
+        };
+
+        for mut task in tasks.drain(..) {
+            match timeout(TASK_SHUTDOWN_GRACE, &mut task).await {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => {
+                    debug!(error = %e, "network task ended during shutdown");
+                }
+                Err(_) => {
+                    warn!("network task did not finish cooperatively; aborting");
+                    task.abort();
+                    let _ = task.await;
+                }
+            }
+        }
+
         let count = {
             let mut peers = self.peers.write().await;
             let count = peers.len();
             peers.clear();
             count
         };
-        let mut tasks = self.tasks.lock().await;
-        for task in tasks.drain(..) {
-            task.abort();
-            let _ = task.await;
-        }
         debug!(count, "node peer connections closed");
     }
 }
@@ -495,6 +518,7 @@ async fn handle_incoming(
     event_tx: mpsc::Sender<NodeEvent>,
     limits: NodeLimits,
     slot: OwnedSemaphorePermit,
+    shutdown_rx: watch::Receiver<bool>,
 ) -> NetResult<()> {
     let stream: NetStream = match tls {
         Some(ref tls_cfg) => tls_cfg.accept_stream(stream).await?,
@@ -591,6 +615,7 @@ async fn handle_incoming(
         event_tx.clone(),
         limits.max_message_size,
         limits.socket_timeout,
+        shutdown_rx,
     )
     .await;
 
@@ -646,15 +671,28 @@ async fn read_loop(
     event_tx: mpsc::Sender<NodeEvent>,
     max_message_size: usize,
     socket_timeout: Duration,
+    mut shutdown_rx: watch::Receiver<bool>,
 ) -> NetResult<()> {
     loop {
-        let msg = match read_message(&mut reader, max_message_size, socket_timeout).await {
-            Ok(m) => m,
-            Err(NetError::Io(e)) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
-                debug!(peer = %peer_node_id, "peer disconnected");
-                break;
+        let msg = tokio::select! {
+            _ = shutdown_rx.changed() => {
+                if *shutdown_rx.borrow() {
+                    debug!(peer = %peer_node_id, "read loop shutdown requested");
+                    break;
+                }
+                continue;
             }
-            Err(e) => return Err(e),
+
+            msg = read_message(&mut reader, max_message_size, socket_timeout) => {
+                match msg {
+                    Ok(m) => m,
+                    Err(NetError::Io(e)) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
+                        debug!(peer = %peer_node_id, "peer disconnected");
+                        break;
+                    }
+                    Err(e) => return Err(e),
+                }
+            }
         };
 
         match msg.kind {
@@ -890,6 +928,55 @@ mod tests {
         drop(second);
         drop(first);
         node.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn active_peer_shutdown_does_not_wait_for_socket_timeout() {
+        let node_a = Node::new(
+            NodeConfig::new(NodeId::new("node-a"), "127.0.0.1:0")
+                .with_socket_timeout(Duration::from_secs(5)),
+        );
+        let addr_a = node_a.start_listener().await.unwrap();
+
+        let mut node_b = Node::new(
+            NodeConfig::new(NodeId::new("node-b"), "127.0.0.1:0")
+                .with_socket_timeout(Duration::from_secs(5)),
+        );
+        let mut events_b = node_b.take_event_receiver().unwrap();
+        node_b.connect_to_peer(&addr_a.to_string()).await.unwrap();
+
+        let connected = timeout(Duration::from_secs(1), async {
+            loop {
+                if let Some(NodeEvent::PeerConnected { .. }) = events_b.recv().await {
+                    break;
+                }
+            }
+        })
+        .await;
+        assert!(connected.is_ok(), "peer did not connect");
+
+        let started = std::time::Instant::now();
+        node_b.shutdown().await;
+
+        assert!(
+            started.elapsed() < Duration::from_secs(1),
+            "shutdown waited for socket timeout instead of cooperative signal"
+        );
+
+        let disconnected = timeout(Duration::from_secs(1), async {
+            loop {
+                if let Some(NodeEvent::PeerDisconnected { .. }) = events_b.recv().await {
+                    break;
+                }
+            }
+        })
+        .await;
+        assert!(
+            disconnected.is_ok(),
+            "peer disconnect event was not emitted"
+        );
+
+        node_a.shutdown().await;
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/crates/nx-store/src/lib.rs
+++ b/crates/nx-store/src/lib.rs
@@ -2,7 +2,7 @@ mod error;
 mod store;
 
 pub use error::StoreError;
-pub use store::Store;
+pub use store::{Store, StoreStats};
 
 #[cfg(test)]
 mod tests {
@@ -65,5 +65,19 @@ mod tests {
         assert_eq!(store.get(b"key1").unwrap(), Some(b"value1".to_vec()));
         assert_eq!(store.get(b"key2").unwrap(), Some(b"value2".to_vec()));
         assert_eq!(store.get(b"key3").unwrap(), Some(b"value3".to_vec()));
+    }
+
+    #[test]
+    fn test_stats_counts_keys_and_bytes() {
+        let dir = tempdir().unwrap();
+        let store = Store::open(dir.path()).unwrap();
+
+        store.set(b"a", b"one").unwrap();
+        store.set(b"bb", b"two").unwrap();
+
+        let stats = store.stats().unwrap();
+
+        assert_eq!(stats.keys, 2);
+        assert_eq!(stats.bytes, 9);
     }
 }

--- a/crates/nx-store/src/store.rs
+++ b/crates/nx-store/src/store.rs
@@ -8,6 +8,12 @@ pub struct Store {
     db: sled::Db,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StoreStats {
+    pub keys: u64,
+    pub bytes: u64,
+}
+
 impl Store {
     pub fn open(path: impl AsRef<Path>) -> Result<Self, StoreError> {
         let path = path.as_ref();
@@ -47,6 +53,18 @@ impl Store {
     pub fn flush(&self) -> Result<(), StoreError> {
         self.db.flush()?;
         Ok(())
+    }
+
+    pub fn stats(&self) -> Result<StoreStats, StoreError> {
+        let mut stats = StoreStats { keys: 0, bytes: 0 };
+
+        for item in self.db.iter() {
+            let (key, value) = item?;
+            stats.keys += 1;
+            stats.bytes += key.len() as u64 + value.len() as u64;
+        }
+
+        Ok(stats)
     }
 
     #[allow(clippy::type_complexity)]

--- a/examples/distributed_counter/README.md
+++ b/examples/distributed_counter/README.md
@@ -56,6 +56,9 @@ counter:visits = 2
 
 ## Notes
 
+- The same run can use a TOML config file with `--config ./numax.toml`.
+  Today the implemented section is `[limits]`: `max_peers`,
+  `queued_ops_limit`, `max_message_size`, and `socket_timeout_secs`.
 - No `--sync-prefix` flag exists anymore: replication is driven by the API
   surface (`nx_sdk::crdt::*`), not by key prefix. Everything written via
   `nx_sdk::db::*` is purely local.

--- a/examples/distributed_counter/README.md
+++ b/examples/distributed_counter/README.md
@@ -57,8 +57,10 @@ counter:visits = 2
 ## Notes
 
 - The same run can use a TOML config file with `--config ./numax.toml`.
-  Today the implemented section is `[limits]`: `max_peers`,
-  `queued_ops_limit`, `max_message_size`, and `socket_timeout_secs`.
+  Today the implemented sections are `[limits]` and `[observability]`.
+  Limits cover `max_peers`, `queued_ops_limit`, `max_message_size`, and
+  `socket_timeout_secs`; observability can enable `/metrics`, `/health` and
+  `/ready`.
 - No `--sync-prefix` flag exists anymore: replication is driven by the API
   surface (`nx_sdk::crdt::*`), not by key prefix. Everything written via
   `nx_sdk::db::*` is purely local.
@@ -71,4 +73,5 @@ counter:visits = 2
 - Without `--settle-for`, a sync-enabled runtime stays alive until it receives
   SIGINT/SIGTERM/SIGHUP.
 - The `-v` flag enables verbose logs to observe lifecycle, broadcast and apply
-  paths.
+  paths. Use `--log-format json` for structured logs, and
+  `--observability-listen 127.0.0.1:9300` to expose the local metrics endpoint.

--- a/examples/hello_sdk/README.md
+++ b/examples/hello_sdk/README.md
@@ -1,0 +1,26 @@
+# Hello SDK Example
+
+Smallest Numax SDK example.
+
+It calls `nx_sdk::log`, so the guest talks to the host through the SDK instead
+of raw imports.
+
+## Build
+
+```bash
+cd examples/hello_sdk
+cargo build --release --target wasm32-unknown-unknown
+```
+
+## Run
+
+```bash
+nx run target/wasm32-unknown-unknown/release/hello_sdk.wasm
+```
+
+You should see:
+
+```text
+Hello Numax via SDK
+```
+

--- a/examples/hello_wasi/README.md
+++ b/examples/hello_wasi/README.md
@@ -1,0 +1,21 @@
+# Hello WASI Example
+
+Minimal WASI module running on Numax.
+
+It uses standard output and reads the WASI argument list provided by the host.
+
+## Build
+
+```bash
+cd examples/hello_wasi
+cargo build --release --target wasm32-wasip1
+```
+
+## Run
+
+```bash
+nx run target/wasm32-wasip1/release/hello_wasi.wasm
+```
+
+You should see a hello message and the arguments visible to the WASI guest.
+

--- a/examples/hello_wasm/README.md
+++ b/examples/hello_wasm/README.md
@@ -1,0 +1,25 @@
+# Hello WASM Example
+
+Minimal raw WebAssembly guest for Numax.
+
+It imports `nx.host_log` directly and exposes a `run` entrypoint.
+
+## Build
+
+```bash
+cd examples/hello_wasm
+cargo build --release --target wasm32-unknown-unknown
+```
+
+## Run
+
+```bash
+nx run target/wasm32-unknown-unknown/release/hello_wasm.wasm
+```
+
+You should see:
+
+```text
+Hello from WASM by NumaX !!
+```
+

--- a/examples/kv_counter/README.md
+++ b/examples/kv_counter/README.md
@@ -1,0 +1,24 @@
+# KV Counter Example
+
+Persistent local counter using Numax's key-value host API through the SDK.
+
+This example is intentionally local-only: it uses `nx_sdk::db::*`, not CRDT
+replication.
+
+## Build
+
+```bash
+cd examples/kv_counter
+cargo build --release --target wasm32-unknown-unknown
+```
+
+## Run
+
+```bash
+nx run target/wasm32-unknown-unknown/release/kv_counter.wasm \
+    --datastore-path ./counter-data
+```
+
+Run it more than once with the same datastore. The printed value should grow by
+one each time.
+

--- a/examples/kv_roundtrip/README.md
+++ b/examples/kv_roundtrip/README.md
@@ -1,0 +1,24 @@
+# KV Roundtrip Example
+
+Raw host API example for Numax's local key-value store.
+
+It calls `db_set`, `db_get`, `db_delete` and `host_log` directly, without using
+the SDK.
+
+## Build
+
+```bash
+cd examples/kv_roundtrip
+cargo build --release --target wasm32-unknown-unknown
+```
+
+## Run
+
+```bash
+nx run target/wasm32-unknown-unknown/release/kv_roundtrip.wasm \
+    --datastore-path ./kv-data
+```
+
+You should see the module set `hello = world`, read it back, delete it and then
+confirm it is gone.
+

--- a/examples/kv_sdk_roundtrip/README.md
+++ b/examples/kv_sdk_roundtrip/README.md
@@ -1,0 +1,22 @@
+# KV SDK Roundtrip Example
+
+SDK version of the local key-value roundtrip.
+
+It uses `nx_sdk::db` to set, read and delete one local key.
+
+## Build
+
+```bash
+cd examples/kv_sdk_roundtrip
+cargo build --release --target wasm32-unknown-unknown
+```
+
+## Run
+
+```bash
+nx run target/wasm32-unknown-unknown/release/kv_sdk_roundtrip.wasm \
+    --datastore-path ./kv-data
+```
+
+You should see the value read back and then removed.
+

--- a/examples/vote_tally_tls/README.md
+++ b/examples/vote_tally_tls/README.md
@@ -159,6 +159,9 @@ vote:tally:yes = 3
 
 - mTLS is enabled by `--tls-cert`, `--tls-key`, and `--tls-ca`.
 - The allowlist admits only the three certificate-derived NodeIds.
+- `--config ./numax.toml` can provide the implemented `[limits]` section:
+  `max_peers`, `queued_ops_limit`, `max_message_size`, and
+  `socket_timeout_secs`.
 - The guest never writes votes through `nx_sdk::db::*`; replicated state goes
   through `nx_sdk::crdt::gcounter`.
 - `--wait-before-run` gives the three TLS handshakes time to complete before

--- a/examples/vote_tally_tls/README.md
+++ b/examples/vote_tally_tls/README.md
@@ -159,9 +159,10 @@ vote:tally:yes = 3
 
 - mTLS is enabled by `--tls-cert`, `--tls-key`, and `--tls-ca`.
 - The allowlist admits only the three certificate-derived NodeIds.
-- `--config ./numax.toml` can provide the implemented `[limits]` section:
-  `max_peers`, `queued_ops_limit`, `max_message_size`, and
-  `socket_timeout_secs`.
+- `--config ./numax.toml` can provide the implemented `[limits]` and
+  `[observability]` sections.
+- `--log-format json` enables structured logs. `--observability-listen
+  127.0.0.1:9300` exposes `/metrics`, `/health` and `/ready` for one node.
 - The guest never writes votes through `nx_sdk::db::*`; replicated state goes
   through `nx_sdk::crdt::gcounter`.
 - `--wait-before-run` gives the three TLS handshakes time to complete before


### PR DESCRIPTION
Hi !  The v0.1.0-alpha.3 version concludes Phase 8 and Phase 9: the runtime now has hard limits under load and tells you exactly what it's doing while it runs.

What changed ?

The runtime enforces a peer connection limit, a queued ops limit, a message
size limit and socket timeouts — overload is rejected gracefully, not absorbed.
Structured logs are now emitted with configurable levels and a correlation ID
to trace operations end-to-end.
A Prometheus-compatible /metrics endpoint exposes 10 live runtime metrics:
ops, peers, sync latency, store size, errors and more.
/health and /ready probes reflect actual runtime state — /ready returns 503
until the runtime is fully up.
All new paths are covered by tests, including timeout bounds and unknown routes.

Why it matters ? 

alpha.2 proved you could run two nodes and watch them converge.
alpha.3 answers the next honest question: what happens when things get busy?
Backpressure without observability is a black box under pressure.
Observability without backpressure is a window into a runtime that can fall over.
They belong in the same release.

What is next
v0.1.0-alpha.4 is already planned and will continue the hardening path and more !!

Thank you so much everyone !!