### PR TITLE
Add minimal C++ guest example

### DIFF
--- a/examples/guest_cpp/.gitignore
+++ b/examples/guest_cpp/.gitignore
@@ -1,0 +1,4 @@
+# ignore the generated .wasm file
+# since other modules under example/ doesnt commit the .wasm 
+# but rather generates it post-build under the target/ dir which is ignored anyways 
+*.wasm

--- a/examples/guest_cpp/README.md
+++ b/examples/guest_cpp/README.md
@@ -1,0 +1,101 @@
+# Guest example in C++
+
+Basic C++ example which compiles to WASM and performs a simple logging + DB-write style example
+
+> Note: This example intentionally keeps the guest minimal and avoids libc / stdlib usage to make the ABI interaction easier to inspect and reason about.
+
+## C++ ABI Note
+
+This example intentionally does not use `extern "C"`.
+
+Instead, the guest relies on:
+
+- `import_name(...)`
+- `import_module(...)`
+- `export_name(...)`
+
+to explicitly control the generated WebAssembly symbol names.
+
+### Note
+
+on inspection of the .wasm binary,  the **internal** compiler-generated symbol names are transformed by the C++ compilation process
+while the **exported** WebAssembly ABI symbols remain stable due to the explicit `export_name(...)` attribute as seen below
+
+```wasm
+  (import "nx" "host_log_v2" (func $host_log_v2_char_const*__int_ (type $t0)))
+  (import "nx" "db_set" (func $db_set_char_const*__int__char_const*__int_ (type $t1)))
+  (func $run__ (export "run") (type $t2)
+```
+
+here the exported function "run" is actually internally compiled as "run__" however on exporting to WebAssembly ABI it exports "run" once again which is an interesting note.
+
+> Note: Even though C++ internally mangles symbol names, the exported/imported WASM ABI remains stable.
+> This is because the WebAssembly-facing symbols are explicitly defined through attributes (really interesting quirk of the import abi)
+
+## Important
+
+- Host functions are imported manually through the `nx` namespace.
+- Strings are passed as raw pointers + lengths.
+- The example uses `-nostdlib` for a minimal WASM module.
+- `--allow-undefined` is required because Numax provides imports at runtime.
+
+hence after the .wasm binary inspection, it means that explicit WASM import/export attributes **can** stabilize ABI names even without `extern "C"`
+
+## Requirements
+
+- WASI SDK / clang in path
+- A built `nx` runtime
+
+The runtime can be built from the repository root with:
+
+```bash
+cargo build --release
+```
+
+## Build
+
+### Windows
+
+```bash
+cd /examples/guest_cpp
+./build.bat
+```
+
+### Linux / macOS
+
+```bash
+cd /examples/guest_cpp
+chmod +x build.sh
+./build.sh
+```
+
+This generates:
+
+```bash
+guest.wasm
+```
+
+In the guest_cpp directory
+
+## Run
+
+From the repository root:
+
+### Run on Windows
+
+```bash
+.\target\release\nx.exe run .\examples\guest_cpp\guest.wasm
+```
+
+### Run on MacOS/Linux
+
+```bash
+./target/release/nx run ./examples/guest_cpp/guest.wasm
+```
+
+## output
+
+```bash
+[guest] Hello from C++ guest!
+[guest] db_set ok
+```

--- a/examples/guest_cpp/build.bat
+++ b/examples/guest_cpp/build.bat
@@ -1,6 +1,6 @@
 @echo off
 
-echo Building guest_c WASM module
+echo Building guest_cpp WASM module
 
 clang++ ^
   --target=wasm32-wasip1 ^

--- a/examples/guest_cpp/build.bat
+++ b/examples/guest_cpp/build.bat
@@ -1,0 +1,24 @@
+@echo off
+
+echo Building guest_c WASM module
+
+clang++ ^
+  --target=wasm32-wasip1 ^
+  -O3 ^
+  -nostdlib ^
+  -Wl,--no-entry ^
+  -Wl,--export=run ^
+  -Wl,--allow-undefined ^
+  -o guest.wasm ^
+  src\guest.cpp
+
+IF %ERRORLEVEL% NEQ 0 (
+    echo.
+    echo build failed.
+    echo contains compiler errors
+    exit /b %ERRORLEVEL%
+)
+
+echo.
+echo Build complete:
+echo guest.wasm

--- a/examples/guest_cpp/build.sh
+++ b/examples/guest_cpp/build.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -e
+
+if ! command -v clang >/dev/null 2>&1; then
+    echo "[error] clang not found in PATH"
+    exit 1
+fi
+
+echo "Building guest_c WASM module"
+
+clang++ \
+  --target=wasm32-wasip1 \
+  -O3 \
+  -nostdlib \
+  -Wl,--no-entry \
+  -Wl,--export=run \
+  -Wl,--allow-undefined \
+  -o guest.wasm \
+  src/guest.cpp
+
+echo
+echo "Build complete:"
+echo "guest.wasm"

--- a/examples/guest_cpp/build.sh
+++ b/examples/guest_cpp/build.sh
@@ -2,12 +2,12 @@
 
 set -e
 
-if ! command -v clang >/dev/null 2>&1; then
-    echo "[error] clang not found in PATH"
+if ! command -v clang++ >/dev/null 2>&1; then
+    echo "[error] clang++ not found in PATH"
     exit 1
 fi
 
-echo "Building guest_c WASM module"
+echo "Building guest_cpp WASM module"
 
 clang++ \
   --target=wasm32-wasip1 \

--- a/examples/guest_cpp/src/guest.cpp
+++ b/examples/guest_cpp/src/guest.cpp
@@ -1,0 +1,38 @@
+/*
+ * import `host_log_v2` from the `nx` namespace.
+ * strings are passed as: (pointer, length)
+ * signature: (u32, u32) -> i32
+ */
+__attribute__((import_module("nx")))
+__attribute__((import_name("host_log_v2")))
+extern int host_log_v2(const char* ptr, int len);
+
+/*
+ * IMPORTANT: import `db_set` from the `nx` namespace.
+ * writes a key/value pair into the embedded datastore.
+ */
+__attribute__((import_module("nx")))
+__attribute__((import_name("db_set")))
+extern int db_set(
+    const char* key_ptr,
+    int key_len,
+    const char* val_ptr,
+    int val_len
+);
+
+/*
+ * exported guest entrypoint expected by Numax.
+ */
+__attribute__((export_name("run")))
+void run() {
+    const char msg[] = "Hello from C++ guest!";
+    host_log_v2(msg, sizeof(msg) - 1);
+
+    const char key[] = "hello";
+    const char val[] = "numax-cpp";
+
+    db_set(key, sizeof(key) - 1, val, sizeof(val) - 1);
+
+    const char done[] = "db_set ok";
+    host_log_v2(done, sizeof(done) - 1);
+}


### PR DESCRIPTION
# Summary

Adds a minimal non-Rust guest example written in C++ and compiled to WebAssembly.

The example:

* exports `run`
* imports host functions from the `nx` namespace
* demonstrates logging + datastore interaction
* includes Windows + Linux/macOS build scripts
* documents build/run instructions and ABI behavior

closes #52 

## Files added

new directory `examples/guest_cpp`
* `src/guest.cpp`
* `build.bat`
* `build.sh`
* README containing:
  * build instructions
  * run instructions
  * some notable quirks

## Notes

One interesting observation during implementation was that explicit WebAssembly-facing attributes:

* `import_name(...)`
* `import_module(...)`
* `export_name(...)`

were sufficient to stabilize ABI-facing symbol names even without `extern "C"` (ive documented this inside the README as well, just wanted to bring this to note)

i also inspected the of the generated `.wasm` module via wasm2wat and it showed that internal compiler-generated C++ symbol names are still transformed, while the exported/imported WebAssembly ABI symbols remain stable due to the explicit attributes.

