### PR TITLE
v0.1.0-alpha.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,6 +188,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1493,6 +1502,7 @@ dependencies = [
 name = "nx-net"
 version = "0.1.0"
 dependencies = [
+ "bincode",
  "hex",
  "nx-sync",
  "rcgen",

--- a/HOST_API.md
+++ b/HOST_API.md
@@ -111,10 +111,12 @@ fn db_delete(key_ptr: u32, key_len: u32) -> i32
 ### CRDT
 
 CRDT functions operate on replicated data types. In the current implementation,
-GCounter state is held in the runtime sync manager's in-memory registry and
-the current total is materialized to sled after each local or remote update.
-Operations are broadcast to peers when sync is enabled. On startup, the runtime
-hydrates the in-memory GCounter registry from the materialized sled values.
+GCounter state is held in the runtime sync manager's in-memory registry,
+persisted as durable CRDT state/op-log metadata, and materialized to sled after
+each local or remote update. Operations are broadcast to peers when sync is
+enabled and recovered through periodic anti-entropy after reconnects or missed
+pushes. On startup, the runtime hydrates the in-memory GCounter registry from
+durable CRDT state/op-log data, with materialized totals retained as a fallback.
 
 #### `crdt_gcounter_inc`
 
@@ -295,7 +297,9 @@ pub extern "C" fn run() {
 - [x] `crdt_gcounter_inc` - Increment GCounter
 - [x] `crdt_gcounter_value` - Read GCounter value
 - [x] Durable GCounter materialization in sled
-- [x] Startup hydration from materialized GCounter values
+- [x] Durable GCounter CRDT state/op-log metadata
+- [x] Startup hydration from durable CRDT state/op-log data
+- [x] Bounded OpId dedup metadata persisted across restart
 - [ ] `crdt_set_add` - Add element to ORSet
 - [ ] `crdt_set_remove` - Remove element from ORSet
 - [ ] `crdt_set_contains` - Check membership

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Three things, and only three:
 
 You write a WASM module. numax runs it. The state is there. Sync just happens.
 
-> **Status:** `v0.1.0-alpha.3` - public technical preview.
+> **Status:** `v0.1.0-alpha.4` - public technical preview.
 > It works, it's tested, it's honest about what's missing. See [`ROADMAP.md`](./ROADMAP.md).
 
 ---

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -332,9 +332,9 @@ HTTP endpoint over Tokio.
 - [x] Peer rotation (replace dead peers)
 - [x] Periodic anti-entropy (pull every N seconds)
 - [x] Op deduplication (bounded set of OpIds)
-- [ ] Durable CRDT state or op log, so restart/reconnect can recover full
+- [x] Durable CRDT state or op log, so restart/reconnect can recover full
       CRDT state rather than only materialized totals.
-- [ ] Startup hydration from durable CRDT state/op log.
+- [x] Startup hydration from durable CRDT state/op log.
 - [ ] Persist dedup metadata, or otherwise prevent duplicate remote ops after
       restart.
 - [ ] Test: intermittent network (10% packet loss)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -328,7 +328,7 @@ HTTP endpoint over Tokio.
 **Goal**: Robust operation with an unstable network
 
 - [x] Automatic reconnect with exponential backoff
-- [ ] Peer health tracking (mark dead after N timeouts)
+- [x] Peer health tracking (mark dead after N timeouts)
 - [ ] Peer rotation (replace dead peers)
 - [ ] Periodic anti-entropy (pull every N seconds)
 - [ ] Op deduplication (bloom filter or set of OpIds)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -337,8 +337,8 @@ HTTP endpoint over Tokio.
 - [x] Startup hydration from durable CRDT state/op log.
 - [x] Persist dedup metadata, or otherwise prevent duplicate remote ops after
       restart.
-- [ ] Test: intermittent network (10% packet loss)
-- [ ] Test: node dies and comes back → converges
+- [x] Test: intermittent network (10% packet loss)
+- [x] Test: node dies and comes back → converges
 - [x] Test: duplicate op after restart does not double count
 
 ---

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Numax Roadmap
 
-> **Current release**: `v0.1.0-alpha.3` - developer preview.
+> **Current release**: `v0.1.0-alpha.4` - developer preview.
 > **Final goal `v0.1.0`**: production-ready runtime for non-critical workloads.
 > **Status**: alpha for feedback; production hardening still in progress.
 
@@ -45,8 +45,26 @@ Includes:
   and `/ready`.
 
 Known limitations:
-- Durable full CRDT state/op-log recovery, automatic reconnect and anti-entropy
-  remain tracked in Phase 10.
+- Durable full CRDT state/op-log recovery, automatic reconnect, anti-entropy
+  and dual-mode wire serialization remain tracked in later phases.
+- API and wire format may change before `v0.1.0`.
+
+### v0.1.0-alpha.4 ✅
+**Purpose**: network resilience and dual-mode serialization preview.
+
+Includes:
+- Everything in `v0.1.0-alpha.3`.
+- Phase 10 network resilience: automatic reconnect with exponential backoff,
+  peer health tracking and rotation, periodic anti-entropy, bounded op
+  deduplication, durable CRDT state/op-log hydration and duplicate protection
+  across restart.
+- Phase 11 dual-mode wire serialization: bincode for production, JSON for
+  `--debug-protocol`, format negotiation in `Hello`/`HelloAck`, protocol
+  version `2`, and serialization benchmark coverage.
+
+Known limitations:
+- K-fanout gossip remains intentionally minimal; peers are still configured
+  explicitly.
 - API and wire format may change before `v0.1.0`.
 
 ### v0.1.0 🎯
@@ -463,8 +481,8 @@ criterion remains tracked in Phase 7 as lifecycle/settle/hydration.
 - [x] Phase 7 (Graceful shutdown) complete
 - [x] Phase 8 (Backpressure) complete
 - [x] Phase 9 (Observability) at least logging + health
-- [ ] Phase 10 (Resilience) at least reconnect + dedup + durable CRDT recovery
-- [ ] Phase 11 (Serialization) JSON + bincode working
+- [x] Phase 10 (Resilience) at least reconnect + dedup + durable CRDT recovery
+- [x] Phase 11 (Serialization) JSON + bincode working
 - [ ] Phase 12 (Host API) at least db_scan, time_now, random_bytes
 - [ ] Phase 13 (Load testing) at least the 3-nodes-1h scenario
 - [ ] All tests pass
@@ -491,6 +509,16 @@ criterion remains tracked in Phase 7 as lifecycle/settle/hydration.
 - [x] Phase 7 graceful lifecycle hardening complete
 - [x] Phase 8 backpressure complete
 - [x] Phase 9 minimal observability complete
+- [x] `cargo test` passes
+- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
+- [x] Known limitations documented in the roadmap
+
+---
+
+## v0.1.0-alpha.4 Release Criteria
+
+- [x] Phase 10 network resilience complete
+- [x] Phase 11 dual-mode serialization complete
 - [x] `cargo test` passes
 - [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
 - [x] Known limitations documented in the roadmap

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -327,7 +327,7 @@ HTTP endpoint over Tokio.
 ### Phase 10: Network Resilience 🌐
 **Goal**: Robust operation with an unstable network
 
-- [ ] Automatic reconnect with exponential backoff
+- [x] Automatic reconnect with exponential backoff
 - [ ] Peer health tracking (mark dead after N timeouts)
 - [ ] Peer rotation (replace dead peers)
 - [ ] Periodic anti-entropy (pull every N seconds)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -351,12 +351,12 @@ HTTP endpoint over Tokio.
 - bincode: compact (~50% size), fast (~10x faster parse)
 
 **Tasks**:
-- [ ] Add `bincode` to dependencies
-- [ ] `SerializationFormat` enum with a 1-byte header on the wire
-- [ ] CLI flag `--debug-protocol`
-- [ ] Format negotiation in Hello/HelloAck
-- [ ] Test: roundtrip for both formats
-- [ ] Benchmark: JSON vs bincode (size, speed)
+- [x] Add `bincode` to dependencies
+- [x] `SerializationFormat` enum with a 1-byte header on the wire
+- [x] CLI flag `--debug-protocol`
+- [x] Format negotiation in Hello/HelloAck
+- [x] Test: roundtrip for both formats
+- [x] Benchmark: JSON vs bincode (size, speed)
 
 **Libraries**: `bincode`, `serde` (already present)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -335,11 +335,11 @@ HTTP endpoint over Tokio.
 - [x] Durable CRDT state or op log, so restart/reconnect can recover full
       CRDT state rather than only materialized totals.
 - [x] Startup hydration from durable CRDT state/op log.
-- [ ] Persist dedup metadata, or otherwise prevent duplicate remote ops after
+- [x] Persist dedup metadata, or otherwise prevent duplicate remote ops after
       restart.
 - [ ] Test: intermittent network (10% packet loss)
 - [ ] Test: node dies and comes back → converges
-- [ ] Test: duplicate op after restart does not double count
+- [x] Test: duplicate op after restart does not double count
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -329,7 +329,7 @@ HTTP endpoint over Tokio.
 
 - [x] Automatic reconnect with exponential backoff
 - [x] Peer health tracking (mark dead after N timeouts)
-- [ ] Peer rotation (replace dead peers)
+- [x] Peer rotation (replace dead peers)
 - [ ] Periodic anti-entropy (pull every N seconds)
 - [ ] Op deduplication (bloom filter or set of OpIds)
 - [ ] Durable CRDT state or op log, so restart/reconnect can recover full

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -330,7 +330,7 @@ HTTP endpoint over Tokio.
 - [x] Automatic reconnect with exponential backoff
 - [x] Peer health tracking (mark dead after N timeouts)
 - [x] Peer rotation (replace dead peers)
-- [ ] Periodic anti-entropy (pull every N seconds)
+- [x] Periodic anti-entropy (pull every N seconds)
 - [ ] Op deduplication (bloom filter or set of OpIds)
 - [ ] Durable CRDT state or op log, so restart/reconnect can recover full
       CRDT state rather than only materialized totals.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -331,7 +331,7 @@ HTTP endpoint over Tokio.
 - [x] Peer health tracking (mark dead after N timeouts)
 - [x] Peer rotation (replace dead peers)
 - [x] Periodic anti-entropy (pull every N seconds)
-- [ ] Op deduplication (bloom filter or set of OpIds)
+- [x] Op deduplication (bounded set of OpIds)
 - [ ] Durable CRDT state or op log, so restart/reconnect can recover full
       CRDT state rather than only materialized totals.
 - [ ] Startup hydration from durable CRDT state/op log.

--- a/WHITEPAPER.md
+++ b/WHITEPAPER.md
@@ -1,7 +1,7 @@
 # Numax Runtime - Technical Whitepaper
 
 > **Note**
-> This whitepaper is aligned with **v0.1.0-alpha.3**, the current public technical preview of Numax.
+> This whitepaper is aligned with **v0.1.0-alpha.4**, the current public technical preview of Numax.
 > Compared to previous drafts, most of the `TODO`s have been resolved based on the code present in the repository. What remains open is explicitly labeled as *(Planned)* and tracked in the roadmap.
 >
 > **Status labels (consistent with the code):**
@@ -9,7 +9,7 @@
 > - **(Prototype)**: partially present; internal wiring or critical paths already verified, but not yet production-ready.
 > - **(Planned)**: foreseen in the roadmap, not yet implemented.
 >
-> **Version reference**: `v0.1.0-alpha.3` - technical preview, API and wire format may change before the stable v0.1.0.
+> **Version reference**: `v0.1.0-alpha.4` - technical preview, API and wire format may change before the stable v0.1.0.
 >
 > > 📍 **Reference roadmap:** the phases cited in this document (Phase 7, Phase 8, …) are defined in [`ROADMAP.md`](./ROADMAP.md).
 > Whenever you read *Phase N*, you can consult the roadmap for details, completion criteria and progress status :)
@@ -189,7 +189,7 @@ CI today verifies compilation and test execution on:
 - **State**: each node maintains a persistent local key/value store based on sled. *(Implemented)*
 - **Sync**: a portion of the state can be replicated between nodes via CRDT + gossip. *(Prototype)*
 - **Consistency**: the system aims for eventual consistency; in the absence of new writes and with sufficient connectivity, all nodes converge on the same state. *(Prototype)*
-- **Fallible network**: disconnections and reconnections are normal conditions; the roadmap includes explicit mechanisms to recover missing deltas (anti-entropy). *(Planned, Phase 10)*
+- **Fallible network**: disconnections and reconnections are normal conditions; automatic reconnect, peer health tracking, peer rotation and anti-entropy are implemented for configured peers. *(Prototype)*
 
 ### 4.4 Security model & threat model
 
@@ -374,7 +374,7 @@ pub struct Op {
 }
 ```
 
-Operations are serializable for transport over the network (today JSON length-prefixed; dual-mode JSON/bincode planned in Phase 11).
+Operations are serializable for transport over the network. The current wire protocol is length-prefixed and format-tagged: bincode is the default production format, while JSON remains available through `--debug-protocol`.
 
 **GCounter (Grow-only Counter)** *(Implemented)* - the first implemented CRDT, a distributed counter that only supports increments. Each node owns its own "slot" and can only increment that one.
 
@@ -414,7 +414,7 @@ pub fn merge(&mut self, other: &GCounter) {
 - propagates operations to active peers through nx-net,
 - covered by end-to-end E2E tests.
 
-**Hydration** *(Implemented)* - on startup, the runtime rebuilds the in-memory GCounter registry from the values materialized in sled. Durable full CRDT state/op-log recovery remains planned in Phase 10 for stronger restart/reconnect resilience.
+**Hydration** *(Implemented)* - on startup, the runtime rebuilds the in-memory GCounter registry from durable CRDT state/op-log data, with materialized sled totals retained as a fallback. Dedup metadata is also persisted so recent duplicate remote operations after restart do not double count.
 
 **Planned CRDTs (Phase 14):**
 
@@ -432,37 +432,42 @@ Numax Net handles communication between nodes for state synchronization.
 
 **Architecture:** peer-to-peer. Each node can communicate directly with other nodes without a central server. TCP transport, **TLS 1.3 with mTLS** available and recommended.
 
-**Message protocol:** length-prefixed JSON (4 big-endian bytes for length, JSON payload):
+**Message protocol:** length-prefixed, dual-mode serialization. The first four
+bytes are a big-endian payload length. The payload starts with a one-byte
+serialization format tag, followed by either JSON or bincode encoded message
+data. Bincode is the default production format; JSON is selected with
+`--debug-protocol` for inspectability.
 
 ```
-┌──────────────┬─────────────────────────────┐
-│ Length (4B)  │     JSON Payload            │
-│ big-endian   │                             │
-└──────────────┴─────────────────────────────┘
+┌──────────────┬──────────────┬─────────────────────────────┐
+│ Length (4B)  │ Format (1B)  │ JSON or bincode payload      │
+│ big-endian   │              │                             │
+└──────────────┴──────────────┴─────────────────────────────┘
 ```
 
 **Implemented message types:**
 
 | Message | Direction | Description |
 |---------|-----------|-------------|
-| `Hello` | Client → Server | Initial handshake with NodeId and protocol version |
-| `HelloAck` | Server → Client | Handshake confirmation |
+| `Hello` | Client → Server | Initial handshake with NodeId, protocol version, supported formats and preferred format |
+| `HelloAck` | Server → Client | Handshake confirmation with selected serialization format |
 | `PushOps` | Bidirectional | Sends a batch of CRDT operations |
 | `PushOpsAck` | Bidirectional | Confirms reception of operations |
 | `PullSince` | Client → Server | Requests operations after a given OpId |
 | `Ping` | Bidirectional | Keepalive |
 | `Pong` | Bidirectional | Response to Ping |
 
-**Protocol versioning:** version number (`PROTOCOL_VERSION = 1`) exchanged during the handshake. Allows backward-compatible evolution and incompatibility detection.
+**Protocol versioning:** version number (`PROTOCOL_VERSION = 2`) exchanged during the handshake. Version mismatches are rejected during handshake to avoid mixed-version wire ambiguity.
 
 **Current status:**
 
 - TCP + TLS 1.3 + mTLS channel *(Implemented)*;
-- handshake, push/pull and keepalive *(Implemented)*;
+- handshake, push/pull, anti-entropy pull requests and keepalive *(Implemented)*;
 - peer connection limit, queued-op limit, message-size limit and socket read/write timeouts *(Implemented)*;
-- peer-to-peer gossip with K-fanout: architecture defined, full integration in progress *(Prototype)*;
-- full network resilience (reconnect with exponential backoff, automatic anti-entropy, op dedup) *(Planned, Phase 10)*;
-- automatic anti-entropy after long disconnections *(Planned, Phase 10)*.
+- automatic reconnect with exponential backoff, peer health tracking and peer rotation *(Prototype)*;
+- periodic anti-entropy after missed pushes/reconnects *(Prototype)*;
+- bounded OpId deduplication and persisted dedup metadata *(Prototype)*;
+- peer-to-peer gossip with K-fanout: architecture defined, full dynamic discovery/fanout remains future work *(Prototype)*.
 
 ### 5.5 Channel security *(Implemented)*
 
@@ -479,7 +484,7 @@ Numax assumes a hostile network: the transport can be observed, altered or redir
 
 **Dedicated CLI flags:** `--tls-cert`, `--tls-key`, `--tls-ca`, `--allowed-peers`, `--tls-insecure` (the latter only for local development).
 
-**Out of scope for v0.1.0-alpha.3:**
+**Out of scope for v0.1.0-alpha.4:**
 
 - automatic certificate rotation;
 - advanced certificate pinning;
@@ -547,6 +552,12 @@ nx run <module.wasm> \
     --peer 192.168.1.11:9000 \
     --datastore-path ./node-data
 
+# Uses JSON instead of bincode for the sync wire protocol
+nx run <module.wasm> \
+    --listen 0.0.0.0:9000 \
+    --peer 192.168.1.10:9000 \
+    --debug-protocol
+
 # Runs a bounded sync demo and prints a final GCounter value
 nx run <module.wasm> \
     --listen 0.0.0.0:9000 \
@@ -575,6 +586,7 @@ nx run <module.wasm> \
 | `--log-format` | Logging format: `text` or `json` |
 | `--listen` | Address on which to accept peer connections and enable sync |
 | `--peer` | Initial peer address (repeatable) |
+| `--debug-protocol` | Use JSON for the sync wire protocol instead of production bincode |
 | `--wait-before-run` | Bounded pre-run window for peer handshakes |
 | `--settle-for` | Bounded post-run window for PushOps and remote apply |
 | `--print-gcounter` | Print a final host-side GCounter value |
@@ -628,20 +640,24 @@ The model is **peer-to-peer with gossip**:
 
 The approach scales better than full-mesh and remains resilient in the presence of temporary disconnections. Full integration of dynamic fanout is in progress.
 
-### 5.9 Resilience: node down, intermittent network, reconnection *(Planned - Phase 10)*
+### 5.9 Resilience: node down, intermittent network, reconnection *(Prototype - Phase 10)*
 
-The network is considered fallible by nature. The designed countermeasures:
+The network is considered fallible by nature. The implemented countermeasures
+for configured peers are:
 
 When a peer becomes unreachable:
 
 - timeout and retry with **exponential backoff**;
-- marking the peer as down and removing it from the active set;
-- selection of a new peer from discovery to maintain the **K** fanout.
+- peer health tracking with suspect/dead state after repeated failures;
+- peer rotation across configured peers when slots are available.
 
 When a node comes back:
 
 - re-establishment of connections with known peers;
 - **anti-entropy** mechanism (`PullSince`) to recover missing updates;
+- durable CRDT state/op-log hydration on restart;
+- persisted bounded dedup metadata to avoid recent duplicate remote operations
+  after restart;
 - convergence to the same state thanks to CRDT properties.
 
 ---
@@ -694,7 +710,7 @@ Log levels: 0 = trace, 1 = debug, 2 = info, 3 = warn, 4 = error.
 | `crdt_gcounter_inc` | `(key_ptr: u32, key_len: u32, delta: u64) -> i32` | *Implemented* |
 | `crdt_gcounter_value` | `(key_ptr: u32, key_len: u32, out_ptr: u32, out_cap: u32) -> i32` | *Implemented* |
 
-Increment operations are materialized on sled and propagated to peers through the SyncManager. In the absence of sync enabled, the functions return `ERR_SYNC_DISABLED` (-5).
+Increment operations are persisted as CRDT state/op-log metadata, materialized on sled and propagated to peers through the SyncManager. In the absence of sync enabled, the functions return `ERR_SYNC_DISABLED` (-5).
 
 **Extended Host API** - *(Planned, Phase 12)*
 
@@ -710,8 +726,8 @@ Increment operations are materialized on sled and propagated to peers through th
 
 Deployment will consist in shipping a `.wasm` file and a minimal configuration.
 
-The `limits` section below is implemented today. The other deployment sections
-remain planned work.
+The `limits` section below is implemented today. Observability can also be
+configured from file. The other deployment sections remain planned work.
 
 ```toml
 [limits]
@@ -764,7 +780,7 @@ The project includes an automated test suite that covers runtime, store, CRDT, n
 
 ## 8. Use Cases
 
-The use cases below are **concretely achievable today** with the primitives of v0.1.0-alpha.3. They do not describe visions: they describe what the runtime already knows how to do, or will know how to do as soon as the last preview phases are closed.
+The use cases below are **concretely achievable today** with the primitives of v0.1.0-alpha.4. They do not describe visions: they describe what the runtime already knows how to do, or will know how to do as soon as the last preview phases are closed.
 
 ### 8.1 Distributed counters and metrics (example: `distributed_counter`)
 
@@ -830,13 +846,13 @@ Numax is not AI. It is one of the things that AI can, comfortably, run on top of
 
 ## 10. Limitations
 
-v0.1.0-alpha.3 is a technical preview. We recognize its limits, explicitly:
+v0.1.0-alpha.4 is a technical preview. We recognize its limits, explicitly:
 
-- **Anti-entropy is not implemented yet.** Nodes exchange live PushOps, but automatic recovery of missed deltas after long disconnections is Phase 10 work.
-- **K-fanout gossip and full network resilience are in progress.** The architecture is defined; reconnect with backoff, automatic anti-entropy and op dedup are in Phase 10.
+- **Network resilience is still prototype-grade.** Automatic reconnect, peer health tracking, peer rotation, anti-entropy and bounded dedup are implemented for configured peers, but full dynamic discovery and K-fanout gossip remain future work.
+- **Deduplication is bounded.** Recent duplicate remote operations are prevented across restart, but this is not an infinite causal history. Stronger guarantees would require a fuller durable op-log/causal metadata strategy.
 - **TLS/mTLS is implemented, but not yet hardened for all scenarios.** It is solid enough for controlled scenarios (dev, lab, defined deployments); the full hardening (rotation, advanced pinning, extreme hostile scenarios) continues.
 - **Minimal observability.** Structured logs, Prometheus-compatible metrics and health checks are available as an opt-in endpoint; richer dashboards and alerting remain outside the current preview.
-- **Wire format and Host API can change.** Before the stable v0.1.0, we expect non-backward-compatible changes. Dual-mode JSON/bincode serialization is planned in Phase 11.
+- **Wire format and Host API can change.** Before the stable v0.1.0, we expect non-backward-compatible changes. The current wire protocol is versioned (`PROTOCOL_VERSION = 2`) and supports bincode by default with JSON debug mode.
 - **Available CRDTs limited to GCounter.** PNCounter, LWW-Register, ORSet, LWW-Map and RGA will arrive with Phase 14.
 - **It does not replace complex orchestrators.** It is not designed to manage extensive clusters or highly scalable deployments with advanced scheduling.
 - **Not optimized for CPU-bound workloads.** The focus is I/O and coordination, not intensive computation.
@@ -857,11 +873,11 @@ Numax proposes a unified runtime that combines:
 
 The goal is not to replicate the existing ecosystem, but **to reduce the self-imposed complexity** that today dominates distributed systems development, while preserving control over the necessary complexity of one's own domain.
 
-v0.1.0-alpha.3 is a technical preview. What it contains is real, tested, working: WASM runtime, sled store, GCounter CRDT, async SyncManager, TCP networking, TLS 1.3 + mTLS with identity derived from the key, stable host API for database, log and CRDT, lifecycle/backpressure hardening, opt-in observability, multi-OS CI, end-to-end examples.
+v0.1.0-alpha.4 is a technical preview. What it contains is real, tested, working: WASM runtime, sled store, GCounter CRDT, async SyncManager, TCP networking, TLS 1.3 + mTLS with identity derived from the key, stable host API for database, log and CRDT, lifecycle/backpressure hardening, network resilience for configured peers, dual-mode JSON/bincode serialization, opt-in observability, multi-OS CI, end-to-end examples.
 
 What is still missing is declared explicitly and tracked in the roadmap. Subsequent iterations will refine details, practical examples, comparisons and experimental results.
 
-**v0.1.0-alpha.3 is just the beginning.** But it is a beginning built on code, not on promises.
+**v0.1.0-alpha.4 is just the beginning.** But it is a beginning built on code, not on promises.
 
 In closing, I love software and I love numax.
 

--- a/crates/nx-cli/src/main.rs
+++ b/crates/nx-cli/src/main.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use anyhow::{Result, bail};
 use clap::{Parser, ValueEnum};
 use nx_core::runtime::{DEFAULT_SHUTDOWN_TIMEOUT, Runtime, RuntimeConfig};
-use nx_core::{ObservabilityConfig, SyncConfig, TlsConfig};
+use nx_core::{ObservabilityConfig, SerializationFormat, SyncConfig, TlsConfig};
 use serde::Deserialize;
 use tracing::{info, warn};
 
@@ -86,6 +86,10 @@ enum Cli {
         /// Skip TLS certificate verification (DEVELOPMENT ONLY).
         #[arg(long)]
         tls_insecure: bool,
+
+        /// Use JSON for the sync wire protocol instead of bincode.
+        #[arg(long)]
+        debug_protocol: bool,
     },
 }
 
@@ -124,6 +128,7 @@ async fn real_main() -> Result<()> {
             tls_ca,
             allowed_peers,
             tls_insecure,
+            debug_protocol,
         } => {
             let file_config = load_run_config(config.as_ref())?;
 
@@ -140,9 +145,15 @@ async fn real_main() -> Result<()> {
             let tls = build_tls_config(tls_cert, tls_key, tls_ca, allowed_peers, tls_insecure);
 
             // Build SyncConfig (if sync flags were provided)
-            let sync = build_sync_config(listen, peers, tls, file_config.limits.is_some())?
-                .map(|sync| apply_limit_config(sync, file_config.limits.as_ref()))
-                .transpose()?;
+            let sync = build_sync_config(
+                listen,
+                peers,
+                tls,
+                file_config.limits.is_some(),
+                debug_protocol,
+            )?
+            .map(|sync| apply_limit_config(sync, file_config.limits.as_ref()))
+            .transpose()?;
             validate_settle_mode(&sync, settle_for)?;
             validate_wait_before_run(&sync, wait_before_run)?;
             validate_print_gcounter(&sync, &print_gcounter)?;
@@ -164,6 +175,7 @@ async fn real_main() -> Result<()> {
                     listen = ?s.listen_addr,
                     peers = ?s.peers,
                     tls = s.tls.is_some(),
+                    serialization_format = ?s.serialization_format,
                     "sync enabled"
                 );
                 cfg.sync = Some(s);
@@ -503,8 +515,9 @@ fn build_sync_config(
     peers: Vec<String>,
     tls: Option<TlsConfig>,
     force_enabled: bool,
+    debug_protocol: bool,
 ) -> Result<Option<SyncConfig>> {
-    if listen.is_none() && peers.is_empty() && !force_enabled {
+    if listen.is_none() && peers.is_empty() && !force_enabled && !debug_protocol {
         return Ok(None);
     }
 
@@ -524,6 +537,9 @@ fn build_sync_config(
     }
     if let Some(t) = tls {
         cfg = cfg.with_tls(t);
+    }
+    if debug_protocol {
+        cfg = cfg.with_serialization_format(SerializationFormat::Json);
     }
 
     debug_assert!(cfg.is_enabled());
@@ -918,23 +934,24 @@ mod tests {
 
         #[test]
         fn no_flags_is_none() {
-            let r = build_sync_config(None, vec![], None, false).unwrap();
+            let r = build_sync_config(None, vec![], None, false, false).unwrap();
             assert!(r.is_none());
         }
 
         #[test]
         fn listen_alone_is_some() {
-            let cfg = build_sync_config(Some("0.0.0.0:9000".into()), vec![], None, false)
+            let cfg = build_sync_config(Some("0.0.0.0:9000".into()), vec![], None, false, false)
                 .unwrap()
                 .expect("sync should be enabled with --listen alone");
             assert!(cfg.is_enabled());
             assert!(cfg.peers.is_empty());
             assert_eq!(cfg.listen_addr.as_deref(), Some("0.0.0.0:9000"));
+            assert_eq!(cfg.serialization_format, SerializationFormat::Bincode);
         }
 
         #[test]
         fn peer_without_listen_is_error() {
-            let r = build_sync_config(None, vec!["127.0.0.1:9000".into()], None, false);
+            let r = build_sync_config(None, vec!["127.0.0.1:9000".into()], None, false, false);
             assert!(r.is_err(), "peers without --listen must fail loudly");
             let err = r.unwrap_err().to_string();
             assert!(err.contains("requires --listen"), "got: {err}");
@@ -942,10 +959,29 @@ mod tests {
 
         #[test]
         fn limits_config_without_listen_is_error() {
-            let r = build_sync_config(None, vec![], None, true);
+            let r = build_sync_config(None, vec![], None, true, false);
             assert!(r.is_err(), "limits without --listen must fail loudly");
             let err = r.unwrap_err().to_string();
             assert!(err.contains("requires --listen"), "got: {err}");
+        }
+
+        #[test]
+        fn debug_protocol_without_listen_is_error() {
+            let r = build_sync_config(None, vec![], None, false, true);
+            assert!(
+                r.is_err(),
+                "--debug-protocol without --listen must fail loudly"
+            );
+            let err = r.unwrap_err().to_string();
+            assert!(err.contains("requires --listen"), "got: {err}");
+        }
+
+        #[test]
+        fn debug_protocol_uses_json_wire_format() {
+            let cfg = build_sync_config(Some("0.0.0.0:9000".into()), vec![], None, false, true)
+                .unwrap()
+                .unwrap();
+            assert_eq!(cfg.serialization_format, SerializationFormat::Json);
         }
 
         #[test]
@@ -954,6 +990,7 @@ mod tests {
                 Some("0.0.0.0:9000".into()),
                 vec!["a:1".into(), "b:2".into()],
                 None,
+                false,
                 false,
             )
             .unwrap()
@@ -966,7 +1003,7 @@ mod tests {
         #[test]
         fn tls_is_propagated() {
             let tls = Some(TlsConfig::insecure_dev());
-            let cfg = build_sync_config(Some("0.0.0.0:9000".into()), vec![], tls, false)
+            let cfg = build_sync_config(Some("0.0.0.0:9000".into()), vec![], tls, false, false)
                 .unwrap()
                 .unwrap();
             assert!(cfg.tls.is_some());
@@ -1105,6 +1142,14 @@ mod tests {
                 Cli::Run { listen, .. } => {
                     assert_eq!(listen.as_deref(), Some("127.0.0.1:9000"));
                 }
+            }
+        }
+
+        #[test]
+        fn debug_protocol_parsed() {
+            let cli = Cli::try_parse_from(["nx", "run", "x.wasm", "--debug-protocol"]).unwrap();
+            match cli {
+                Cli::Run { debug_protocol, .. } => assert!(debug_protocol),
             }
         }
 

--- a/crates/nx-core/src/host_api/crdt.rs
+++ b/crates/nx-core/src/host_api/crdt.rs
@@ -3,7 +3,7 @@ use nx_sync::{GCounter, Op};
 use wasmtime::{Caller, Linker, Memory};
 
 use crate::runtime::HostState;
-use crate::sync_manager::materialize_gcounter_value;
+use crate::sync_manager::persist_gcounter_state;
 
 // error codes
 const ERR_BUF_TOO_SMALL: i32 = -2;
@@ -87,17 +87,15 @@ async fn crdt_gcounter_inc_impl(
         }
     };
 
-    // Apply locally and materialize the value before exposing the new state.
+    // Apply locally and persist the CRDT state before exposing the new value.
     {
         let counters_arc = handle.counters();
         let mut counters = counters_arc.write().await;
         let mut counter = counters.get(&key).cloned().unwrap_or_else(GCounter::new);
         counter.increment(handle.node_id(), delta);
-        let total = counter.value();
-
-        if let Err(e) = materialize_gcounter_value(&handle.store(), &key, total) {
+        if let Err(e) = persist_gcounter_state(&handle.store(), &key, &counter) {
             handle.metrics().record_sync_error();
-            tracing::warn!(error = %e, "crdt_gcounter_inc: failed to materialize counter");
+            tracing::warn!(error = %e, "crdt_gcounter_inc: failed to persist counter");
             return ERR_INTERNAL;
         }
 

--- a/crates/nx-core/src/lib.rs
+++ b/crates/nx-core/src/lib.rs
@@ -4,6 +4,6 @@ pub mod runtime;
 pub mod sync_config;
 pub mod sync_manager;
 
-pub use nx_net::TlsConfig;
+pub use nx_net::{SerializationFormat, TlsConfig};
 pub use observability::ObservabilityConfig;
 pub use sync_config::SyncConfig;

--- a/crates/nx-core/src/sync_config.rs
+++ b/crates/nx-core/src/sync_config.rs
@@ -13,6 +13,12 @@ pub const DEFAULT_MAX_MESSAGE_SIZE: usize = nx_net::DEFAULT_MAX_MESSAGE_SIZE;
 /// Default timeout for socket reads and writes.
 pub const DEFAULT_SOCKET_TIMEOUT: Duration = nx_net::DEFAULT_SOCKET_TIMEOUT;
 
+/// Default first delay before retrying a failed configured peer connection.
+pub const DEFAULT_RECONNECT_INITIAL_DELAY: Duration = Duration::from_millis(500);
+
+/// Default maximum delay between reconnect attempts for a configured peer.
+pub const DEFAULT_RECONNECT_MAX_DELAY: Duration = Duration::from_secs(30);
+
 /// Sync configuration for the runtime.
 #[derive(Debug, Clone)]
 pub struct SyncConfig {
@@ -36,6 +42,12 @@ pub struct SyncConfig {
 
     /// Timeout for socket reads and writes.
     pub socket_timeout: Duration,
+
+    /// Initial delay for automatic reconnect attempts.
+    pub reconnect_initial_delay: Duration,
+
+    /// Maximum delay for automatic reconnect attempts.
+    pub reconnect_max_delay: Duration,
 }
 
 impl Default for SyncConfig {
@@ -48,6 +60,8 @@ impl Default for SyncConfig {
             queued_ops_limit: DEFAULT_QUEUED_OPS_LIMIT,
             max_message_size: DEFAULT_MAX_MESSAGE_SIZE,
             socket_timeout: DEFAULT_SOCKET_TIMEOUT,
+            reconnect_initial_delay: DEFAULT_RECONNECT_INITIAL_DELAY,
+            reconnect_max_delay: DEFAULT_RECONNECT_MAX_DELAY,
         }
     }
 }
@@ -92,6 +106,12 @@ impl SyncConfig {
         self
     }
 
+    pub fn with_reconnect_backoff(mut self, initial_delay: Duration, max_delay: Duration) -> Self {
+        self.reconnect_initial_delay = initial_delay;
+        self.reconnect_max_delay = max_delay;
+        self
+    }
+
     /// Sync is enabled iff we have a bound listen address.
     pub fn is_enabled(&self) -> bool {
         self.listen_addr.is_some()
@@ -110,6 +130,8 @@ mod tests {
         assert_eq!(cfg.queued_ops_limit, DEFAULT_QUEUED_OPS_LIMIT);
         assert_eq!(cfg.max_message_size, DEFAULT_MAX_MESSAGE_SIZE);
         assert_eq!(cfg.socket_timeout, DEFAULT_SOCKET_TIMEOUT);
+        assert_eq!(cfg.reconnect_initial_delay, DEFAULT_RECONNECT_INITIAL_DELAY);
+        assert_eq!(cfg.reconnect_max_delay, DEFAULT_RECONNECT_MAX_DELAY);
 
         let cfg = SyncConfig::new().with_listen_addr("0.0.0.0:9000");
         assert!(cfg.is_enabled());
@@ -134,11 +156,14 @@ mod tests {
             .with_max_peers(8)
             .with_queued_ops_limit(256)
             .with_max_message_size(1024)
-            .with_socket_timeout(Duration::from_secs(5));
+            .with_socket_timeout(Duration::from_secs(5))
+            .with_reconnect_backoff(Duration::from_millis(10), Duration::from_secs(2));
 
         assert_eq!(cfg.max_peers, 8);
         assert_eq!(cfg.queued_ops_limit, 256);
         assert_eq!(cfg.max_message_size, 1024);
         assert_eq!(cfg.socket_timeout, Duration::from_secs(5));
+        assert_eq!(cfg.reconnect_initial_delay, Duration::from_millis(10));
+        assert_eq!(cfg.reconnect_max_delay, Duration::from_secs(2));
     }
 }

--- a/crates/nx-core/src/sync_config.rs
+++ b/crates/nx-core/src/sync_config.rs
@@ -10,6 +10,9 @@ pub const DEFAULT_QUEUED_OPS_LIMIT: usize = 10_000;
 /// Default maximum number of in-memory ops retained for anti-entropy.
 pub const DEFAULT_OP_LOG_LIMIT: usize = 10_000;
 
+/// Default maximum number of seen OpIds retained for deduplication.
+pub const DEFAULT_SEEN_OPS_LIMIT: usize = 100_000;
+
 /// Default maximum accepted wire message size.
 pub const DEFAULT_MAX_MESSAGE_SIZE: usize = nx_net::DEFAULT_MAX_MESSAGE_SIZE;
 
@@ -49,6 +52,9 @@ pub struct SyncConfig {
     /// Maximum number of in-memory ops retained for anti-entropy.
     pub op_log_limit: usize,
 
+    /// Maximum number of seen OpIds retained for deduplication.
+    pub seen_ops_limit: usize,
+
     /// Maximum accepted wire message size.
     pub max_message_size: usize,
 
@@ -77,6 +83,7 @@ impl Default for SyncConfig {
             max_peers: DEFAULT_MAX_PEERS,
             queued_ops_limit: DEFAULT_QUEUED_OPS_LIMIT,
             op_log_limit: DEFAULT_OP_LOG_LIMIT,
+            seen_ops_limit: DEFAULT_SEEN_OPS_LIMIT,
             max_message_size: DEFAULT_MAX_MESSAGE_SIZE,
             socket_timeout: DEFAULT_SOCKET_TIMEOUT,
             reconnect_initial_delay: DEFAULT_RECONNECT_INITIAL_DELAY,
@@ -119,6 +126,11 @@ impl SyncConfig {
 
     pub fn with_op_log_limit(mut self, op_log_limit: usize) -> Self {
         self.op_log_limit = op_log_limit;
+        self
+    }
+
+    pub fn with_seen_ops_limit(mut self, seen_ops_limit: usize) -> Self {
+        self.seen_ops_limit = seen_ops_limit;
         self
     }
 
@@ -165,6 +177,7 @@ mod tests {
         assert_eq!(cfg.max_peers, DEFAULT_MAX_PEERS);
         assert_eq!(cfg.queued_ops_limit, DEFAULT_QUEUED_OPS_LIMIT);
         assert_eq!(cfg.op_log_limit, DEFAULT_OP_LOG_LIMIT);
+        assert_eq!(cfg.seen_ops_limit, DEFAULT_SEEN_OPS_LIMIT);
         assert_eq!(cfg.max_message_size, DEFAULT_MAX_MESSAGE_SIZE);
         assert_eq!(cfg.socket_timeout, DEFAULT_SOCKET_TIMEOUT);
         assert_eq!(cfg.reconnect_initial_delay, DEFAULT_RECONNECT_INITIAL_DELAY);
@@ -198,6 +211,7 @@ mod tests {
             .with_max_peers(8)
             .with_queued_ops_limit(256)
             .with_op_log_limit(512)
+            .with_seen_ops_limit(2048)
             .with_max_message_size(1024)
             .with_socket_timeout(Duration::from_secs(5))
             .with_reconnect_backoff(Duration::from_millis(10), Duration::from_secs(2))
@@ -207,6 +221,7 @@ mod tests {
         assert_eq!(cfg.max_peers, 8);
         assert_eq!(cfg.queued_ops_limit, 256);
         assert_eq!(cfg.op_log_limit, 512);
+        assert_eq!(cfg.seen_ops_limit, 2048);
         assert_eq!(cfg.max_message_size, 1024);
         assert_eq!(cfg.socket_timeout, Duration::from_secs(5));
         assert_eq!(cfg.reconnect_initial_delay, Duration::from_millis(10));

--- a/crates/nx-core/src/sync_config.rs
+++ b/crates/nx-core/src/sync_config.rs
@@ -19,6 +19,9 @@ pub const DEFAULT_RECONNECT_INITIAL_DELAY: Duration = Duration::from_millis(500)
 /// Default maximum delay between reconnect attempts for a configured peer.
 pub const DEFAULT_RECONNECT_MAX_DELAY: Duration = Duration::from_secs(30);
 
+/// Default number of consecutive failures after which a configured peer is considered dead.
+pub const DEFAULT_PEER_DEAD_AFTER_FAILURES: u32 = 3;
+
 /// Sync configuration for the runtime.
 #[derive(Debug, Clone)]
 pub struct SyncConfig {
@@ -48,6 +51,9 @@ pub struct SyncConfig {
 
     /// Maximum delay for automatic reconnect attempts.
     pub reconnect_max_delay: Duration,
+
+    /// Consecutive failures after which a configured peer is considered dead.
+    pub peer_dead_after_failures: u32,
 }
 
 impl Default for SyncConfig {
@@ -62,6 +68,7 @@ impl Default for SyncConfig {
             socket_timeout: DEFAULT_SOCKET_TIMEOUT,
             reconnect_initial_delay: DEFAULT_RECONNECT_INITIAL_DELAY,
             reconnect_max_delay: DEFAULT_RECONNECT_MAX_DELAY,
+            peer_dead_after_failures: DEFAULT_PEER_DEAD_AFTER_FAILURES,
         }
     }
 }
@@ -112,6 +119,11 @@ impl SyncConfig {
         self
     }
 
+    pub fn with_peer_dead_after_failures(mut self, failures: u32) -> Self {
+        self.peer_dead_after_failures = failures;
+        self
+    }
+
     /// Sync is enabled iff we have a bound listen address.
     pub fn is_enabled(&self) -> bool {
         self.listen_addr.is_some()
@@ -132,6 +144,10 @@ mod tests {
         assert_eq!(cfg.socket_timeout, DEFAULT_SOCKET_TIMEOUT);
         assert_eq!(cfg.reconnect_initial_delay, DEFAULT_RECONNECT_INITIAL_DELAY);
         assert_eq!(cfg.reconnect_max_delay, DEFAULT_RECONNECT_MAX_DELAY);
+        assert_eq!(
+            cfg.peer_dead_after_failures,
+            DEFAULT_PEER_DEAD_AFTER_FAILURES
+        );
 
         let cfg = SyncConfig::new().with_listen_addr("0.0.0.0:9000");
         assert!(cfg.is_enabled());
@@ -157,7 +173,8 @@ mod tests {
             .with_queued_ops_limit(256)
             .with_max_message_size(1024)
             .with_socket_timeout(Duration::from_secs(5))
-            .with_reconnect_backoff(Duration::from_millis(10), Duration::from_secs(2));
+            .with_reconnect_backoff(Duration::from_millis(10), Duration::from_secs(2))
+            .with_peer_dead_after_failures(5);
 
         assert_eq!(cfg.max_peers, 8);
         assert_eq!(cfg.queued_ops_limit, 256);
@@ -165,5 +182,6 @@ mod tests {
         assert_eq!(cfg.socket_timeout, Duration::from_secs(5));
         assert_eq!(cfg.reconnect_initial_delay, Duration::from_millis(10));
         assert_eq!(cfg.reconnect_max_delay, Duration::from_secs(2));
+        assert_eq!(cfg.peer_dead_after_failures, 5);
     }
 }

--- a/crates/nx-core/src/sync_config.rs
+++ b/crates/nx-core/src/sync_config.rs
@@ -7,6 +7,9 @@ pub const DEFAULT_MAX_PEERS: usize = nx_net::DEFAULT_MAX_PEERS;
 /// Default maximum number of locally-produced ops waiting for broadcast.
 pub const DEFAULT_QUEUED_OPS_LIMIT: usize = 10_000;
 
+/// Default maximum number of in-memory ops retained for anti-entropy.
+pub const DEFAULT_OP_LOG_LIMIT: usize = 10_000;
+
 /// Default maximum accepted wire message size.
 pub const DEFAULT_MAX_MESSAGE_SIZE: usize = nx_net::DEFAULT_MAX_MESSAGE_SIZE;
 
@@ -21,6 +24,9 @@ pub const DEFAULT_RECONNECT_MAX_DELAY: Duration = Duration::from_secs(30);
 
 /// Default number of consecutive failures after which a configured peer is considered dead.
 pub const DEFAULT_PEER_DEAD_AFTER_FAILURES: u32 = 3;
+
+/// Default interval between anti-entropy pull requests.
+pub const DEFAULT_ANTI_ENTROPY_INTERVAL: Duration = Duration::from_secs(30);
 
 /// Sync configuration for the runtime.
 #[derive(Debug, Clone)]
@@ -40,6 +46,9 @@ pub struct SyncConfig {
     /// Maximum number of locally-produced ops waiting for broadcast.
     pub queued_ops_limit: usize,
 
+    /// Maximum number of in-memory ops retained for anti-entropy.
+    pub op_log_limit: usize,
+
     /// Maximum accepted wire message size.
     pub max_message_size: usize,
 
@@ -54,6 +63,9 @@ pub struct SyncConfig {
 
     /// Consecutive failures after which a configured peer is considered dead.
     pub peer_dead_after_failures: u32,
+
+    /// Interval between periodic anti-entropy pull requests.
+    pub anti_entropy_interval: Duration,
 }
 
 impl Default for SyncConfig {
@@ -64,11 +76,13 @@ impl Default for SyncConfig {
             tls: None,
             max_peers: DEFAULT_MAX_PEERS,
             queued_ops_limit: DEFAULT_QUEUED_OPS_LIMIT,
+            op_log_limit: DEFAULT_OP_LOG_LIMIT,
             max_message_size: DEFAULT_MAX_MESSAGE_SIZE,
             socket_timeout: DEFAULT_SOCKET_TIMEOUT,
             reconnect_initial_delay: DEFAULT_RECONNECT_INITIAL_DELAY,
             reconnect_max_delay: DEFAULT_RECONNECT_MAX_DELAY,
             peer_dead_after_failures: DEFAULT_PEER_DEAD_AFTER_FAILURES,
+            anti_entropy_interval: DEFAULT_ANTI_ENTROPY_INTERVAL,
         }
     }
 }
@@ -103,6 +117,11 @@ impl SyncConfig {
         self
     }
 
+    pub fn with_op_log_limit(mut self, op_log_limit: usize) -> Self {
+        self.op_log_limit = op_log_limit;
+        self
+    }
+
     pub fn with_max_message_size(mut self, max_message_size: usize) -> Self {
         self.max_message_size = max_message_size;
         self
@@ -124,6 +143,11 @@ impl SyncConfig {
         self
     }
 
+    pub fn with_anti_entropy_interval(mut self, interval: Duration) -> Self {
+        self.anti_entropy_interval = interval;
+        self
+    }
+
     /// Sync is enabled iff we have a bound listen address.
     pub fn is_enabled(&self) -> bool {
         self.listen_addr.is_some()
@@ -140,6 +164,7 @@ mod tests {
         assert!(!cfg.is_enabled());
         assert_eq!(cfg.max_peers, DEFAULT_MAX_PEERS);
         assert_eq!(cfg.queued_ops_limit, DEFAULT_QUEUED_OPS_LIMIT);
+        assert_eq!(cfg.op_log_limit, DEFAULT_OP_LOG_LIMIT);
         assert_eq!(cfg.max_message_size, DEFAULT_MAX_MESSAGE_SIZE);
         assert_eq!(cfg.socket_timeout, DEFAULT_SOCKET_TIMEOUT);
         assert_eq!(cfg.reconnect_initial_delay, DEFAULT_RECONNECT_INITIAL_DELAY);
@@ -148,6 +173,7 @@ mod tests {
             cfg.peer_dead_after_failures,
             DEFAULT_PEER_DEAD_AFTER_FAILURES
         );
+        assert_eq!(cfg.anti_entropy_interval, DEFAULT_ANTI_ENTROPY_INTERVAL);
 
         let cfg = SyncConfig::new().with_listen_addr("0.0.0.0:9000");
         assert!(cfg.is_enabled());
@@ -171,17 +197,21 @@ mod tests {
         let cfg = SyncConfig::new()
             .with_max_peers(8)
             .with_queued_ops_limit(256)
+            .with_op_log_limit(512)
             .with_max_message_size(1024)
             .with_socket_timeout(Duration::from_secs(5))
             .with_reconnect_backoff(Duration::from_millis(10), Duration::from_secs(2))
-            .with_peer_dead_after_failures(5);
+            .with_peer_dead_after_failures(5)
+            .with_anti_entropy_interval(Duration::from_secs(3));
 
         assert_eq!(cfg.max_peers, 8);
         assert_eq!(cfg.queued_ops_limit, 256);
+        assert_eq!(cfg.op_log_limit, 512);
         assert_eq!(cfg.max_message_size, 1024);
         assert_eq!(cfg.socket_timeout, Duration::from_secs(5));
         assert_eq!(cfg.reconnect_initial_delay, Duration::from_millis(10));
         assert_eq!(cfg.reconnect_max_delay, Duration::from_secs(2));
         assert_eq!(cfg.peer_dead_after_failures, 5);
+        assert_eq!(cfg.anti_entropy_interval, Duration::from_secs(3));
     }
 }

--- a/crates/nx-core/src/sync_config.rs
+++ b/crates/nx-core/src/sync_config.rs
@@ -1,4 +1,4 @@
-use nx_net::TlsConfig;
+use nx_net::{SerializationFormat, TlsConfig};
 use std::time::Duration;
 
 /// Default maximum number of simultaneously connected peers.
@@ -72,6 +72,9 @@ pub struct SyncConfig {
 
     /// Interval between periodic anti-entropy pull requests.
     pub anti_entropy_interval: Duration,
+
+    /// Serialization format used for outgoing network messages.
+    pub serialization_format: SerializationFormat,
 }
 
 impl Default for SyncConfig {
@@ -90,6 +93,7 @@ impl Default for SyncConfig {
             reconnect_max_delay: DEFAULT_RECONNECT_MAX_DELAY,
             peer_dead_after_failures: DEFAULT_PEER_DEAD_AFTER_FAILURES,
             anti_entropy_interval: DEFAULT_ANTI_ENTROPY_INTERVAL,
+            serialization_format: SerializationFormat::Bincode,
         }
     }
 }
@@ -160,6 +164,11 @@ impl SyncConfig {
         self
     }
 
+    pub fn with_serialization_format(mut self, serialization_format: SerializationFormat) -> Self {
+        self.serialization_format = serialization_format;
+        self
+    }
+
     /// Sync is enabled iff we have a bound listen address.
     pub fn is_enabled(&self) -> bool {
         self.listen_addr.is_some()
@@ -187,6 +196,7 @@ mod tests {
             DEFAULT_PEER_DEAD_AFTER_FAILURES
         );
         assert_eq!(cfg.anti_entropy_interval, DEFAULT_ANTI_ENTROPY_INTERVAL);
+        assert_eq!(cfg.serialization_format, SerializationFormat::Bincode);
 
         let cfg = SyncConfig::new().with_listen_addr("0.0.0.0:9000");
         assert!(cfg.is_enabled());
@@ -216,7 +226,8 @@ mod tests {
             .with_socket_timeout(Duration::from_secs(5))
             .with_reconnect_backoff(Duration::from_millis(10), Duration::from_secs(2))
             .with_peer_dead_after_failures(5)
-            .with_anti_entropy_interval(Duration::from_secs(3));
+            .with_anti_entropy_interval(Duration::from_secs(3))
+            .with_serialization_format(SerializationFormat::Json);
 
         assert_eq!(cfg.max_peers, 8);
         assert_eq!(cfg.queued_ops_limit, 256);
@@ -228,5 +239,6 @@ mod tests {
         assert_eq!(cfg.reconnect_max_delay, Duration::from_secs(2));
         assert_eq!(cfg.peer_dead_after_failures, 5);
         assert_eq!(cfg.anti_entropy_interval, Duration::from_secs(3));
+        assert_eq!(cfg.serialization_format, SerializationFormat::Json);
     }
 }

--- a/crates/nx-core/src/sync_manager.rs
+++ b/crates/nx-core/src/sync_manager.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 
-use nx_net::{Node, NodeConfig, NodeEvent};
+use nx_net::{NetError, Node, NodeConfig, NodeEvent};
 use nx_store::Store as NxStore;
 use nx_sync::{GCounter, NodeId, Op, OpKind};
 use tokio::sync::{RwLock, mpsc, watch};
@@ -42,12 +42,18 @@ impl Default for PeerHealth {
 struct ReconnectLoopContext {
     node: Arc<Node>,
     peers: Vec<String>,
+    max_peers: usize,
     initial_delay: Duration,
     max_delay: Duration,
     peer_dead_after_failures: u32,
     shutdown_rx: watch::Receiver<bool>,
     metrics: Arc<RuntimeMetrics>,
     peer_health: Arc<RwLock<HashMap<String, PeerHealth>>>,
+}
+
+struct PeerReconnectState {
+    addr: String,
+    delay: Duration,
 }
 
 /// Clonable, cheap handle to the SyncManager exposed to host calls.
@@ -228,9 +234,26 @@ impl SyncManager {
         let peer_dead_after_failures =
             normalize_peer_dead_after_failures(self.config.peer_dead_after_failures);
         for peer_addr in &self.config.peers {
+            if node.connected_peer_count().await >= self.config.max_peers {
+                debug!(
+                    peer = %peer_addr,
+                    limit = self.config.max_peers,
+                    "skipping initial peer connect: peer slot limit reached"
+                );
+                break;
+            }
+
             match node.connect_to_peer(peer_addr).await {
                 Ok(()) => {
                     mark_peer_success(&self.peer_health, peer_addr).await;
+                }
+                Err(NetError::PeerLimitReached(limit)) => {
+                    debug!(
+                        peer = %peer_addr,
+                        limit,
+                        "skipping initial peer connect: peer slot limit reached"
+                    );
+                    break;
                 }
                 Err(e) => {
                     self.metrics.record_sync_error();
@@ -305,6 +328,7 @@ impl SyncManager {
         self.reconnect_task = spawn_reconnect_loop(ReconnectLoopContext {
             node: Arc::clone(&node),
             peers: self.config.peers.clone(),
+            max_peers: self.config.max_peers,
             initial_delay: self.config.reconnect_initial_delay,
             max_delay: self.config.reconnect_max_delay,
             peer_dead_after_failures: self.config.peer_dead_after_failures,
@@ -335,11 +359,27 @@ impl SyncManager {
                 mark_peer_success(&self.peer_health, peer_addr).await;
                 continue;
             }
+            if node.connected_peer_count().await >= self.config.max_peers {
+                debug!(
+                    peer = %peer_addr,
+                    limit = self.config.max_peers,
+                    "skipping configured peer reconnect: peer slot limit reached"
+                );
+                break;
+            }
             let peer_dead_after_failures =
                 normalize_peer_dead_after_failures(self.config.peer_dead_after_failures);
             match node.connect_to_peer(peer_addr).await {
                 Ok(()) => {
                     mark_peer_success(&self.peer_health, peer_addr).await;
+                }
+                Err(NetError::PeerLimitReached(limit)) => {
+                    debug!(
+                        peer = %peer_addr,
+                        limit,
+                        "skipping configured peer reconnect: peer slot limit reached"
+                    );
+                    break;
                 }
                 Err(e) => {
                     self.metrics.record_sync_error();
@@ -435,6 +475,7 @@ fn spawn_reconnect_loop(context: ReconnectLoopContext) -> Option<JoinHandle<()>>
     let ReconnectLoopContext {
         node,
         peers,
+        max_peers,
         initial_delay,
         max_delay,
         peer_dead_after_failures,
@@ -453,34 +494,56 @@ fn spawn_reconnect_loop(context: ReconnectLoopContext) -> Option<JoinHandle<()>>
         let peer_dead_after_failures = normalize_peer_dead_after_failures(peer_dead_after_failures);
         let mut state = peers
             .into_iter()
-            .map(|peer| (peer, initial_delay))
-            .collect::<HashMap<_, _>>();
+            .map(|addr| PeerReconnectState {
+                addr,
+                delay: initial_delay,
+            })
+            .collect::<Vec<_>>();
 
         loop {
             let mut sleep_for: Option<Duration> = None;
 
-            for (peer, delay) in state.iter_mut() {
-                if node.is_connected_addr(peer).await {
-                    mark_peer_success(&peer_health, peer).await;
-                    *delay = initial_delay;
+            for peer in state.iter_mut() {
+                let peer_addr = peer.addr.as_str();
+
+                if node.is_connected_addr(peer_addr).await {
+                    mark_peer_success(&peer_health, peer_addr).await;
+                    peer.delay = initial_delay;
                     continue;
                 }
 
-                let attempt_delay = *delay;
-                match node.connect_to_peer(peer).await {
+                if node.connected_peer_count().await >= max_peers {
+                    debug!(
+                        peer = %peer_addr,
+                        limit = max_peers,
+                        "skipping reconnect attempt: peer slot limit reached"
+                    );
+                    break;
+                }
+
+                let attempt_delay = peer.delay;
+                match node.connect_to_peer(peer_addr).await {
                     Ok(()) => {
-                        info!(peer = %peer, "reconnected configured peer");
-                        mark_peer_success(&peer_health, peer).await;
-                        *delay = initial_delay;
+                        info!(peer = %peer_addr, "reconnected configured peer");
+                        mark_peer_success(&peer_health, peer_addr).await;
+                        peer.delay = initial_delay;
+                    }
+                    Err(NetError::PeerLimitReached(limit)) => {
+                        debug!(
+                            peer = %peer_addr,
+                            limit,
+                            "skipping reconnect attempt: peer slot limit reached"
+                        );
+                        break;
                     }
                     Err(e) => {
                         metrics.record_sync_error();
-                        mark_peer_failure(&peer_health, peer, peer_dead_after_failures).await;
-                        debug!(peer = %peer, error = %e, delay = ?attempt_delay, "configured peer reconnect failed");
+                        mark_peer_failure(&peer_health, peer_addr, peer_dead_after_failures).await;
+                        debug!(peer = %peer_addr, error = %e, delay = ?attempt_delay, "configured peer reconnect failed");
                         sleep_for = Some(
                             sleep_for.map_or(attempt_delay, |current| current.min(attempt_delay)),
                         );
-                        *delay = next_reconnect_delay(attempt_delay, max_delay);
+                        peer.delay = next_reconnect_delay(attempt_delay, max_delay);
                     }
                 }
             }
@@ -1171,6 +1234,39 @@ mod tests {
 
         wait_for_connected_peer(&manager_a).await;
         wait_for_peer_health(&manager_a, &addr_b, PeerHealthState::Healthy).await;
+    }
+
+    #[tokio::test]
+    async fn peer_rotation_replaces_dead_peer_with_available_configured_peer() {
+        let addr_a = free_addr();
+        let addr_b = free_addr();
+        let addr_c = free_addr();
+
+        let (mut manager_b, _handle_b, _store_b) = started_manager(addr_b.clone()).await;
+        let (_manager_c, _handle_c, _store_c) = started_manager(addr_c.clone()).await;
+
+        let config_a = SyncConfig::new()
+            .with_listen_addr(addr_a)
+            .with_peer(addr_b.clone())
+            .with_peer(addr_c.clone())
+            .with_max_peers(1)
+            .with_reconnect_backoff(Duration::from_millis(10), Duration::from_millis(20))
+            .with_peer_dead_after_failures(1);
+        let (manager_a, _handle_a, _store_a) = started_manager_with_config(config_a).await;
+
+        wait_for_peer_health(&manager_a, &addr_b, PeerHealthState::Healthy).await;
+        sleep(Duration::from_millis(50)).await;
+        assert_eq!(
+            manager_a.peer_health_state(&addr_c).await,
+            Some(PeerHealthState::Suspect),
+            "peer C should not be marked failed while peer slots are full"
+        );
+
+        manager_b.shutdown().await.unwrap();
+
+        wait_for_peer_health(&manager_a, &addr_b, PeerHealthState::Dead).await;
+        wait_for_peer_health(&manager_a, &addr_c, PeerHealthState::Healthy).await;
+        assert_eq!(manager_a.connected_peer_count().await, 1);
     }
 
     #[tokio::test]

--- a/crates/nx-core/src/sync_manager.rs
+++ b/crates/nx-core/src/sync_manager.rs
@@ -16,6 +16,40 @@ use crate::sync_config::SyncConfig;
 const BROADCAST_BATCH_MAX: usize = 64;
 const GCOUNTER_STORE_PREFIX: &str = "__nx/crdt/gcounter/";
 
+/// Health state for a configured peer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PeerHealthState {
+    Healthy,
+    Suspect,
+    Dead,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct PeerHealth {
+    state: PeerHealthState,
+    consecutive_failures: u32,
+}
+
+impl Default for PeerHealth {
+    fn default() -> Self {
+        Self {
+            state: PeerHealthState::Suspect,
+            consecutive_failures: 0,
+        }
+    }
+}
+
+struct ReconnectLoopContext {
+    node: Arc<Node>,
+    peers: Vec<String>,
+    initial_delay: Duration,
+    max_delay: Duration,
+    peer_dead_after_failures: u32,
+    shutdown_rx: watch::Receiver<bool>,
+    metrics: Arc<RuntimeMetrics>,
+    peer_health: Arc<RwLock<HashMap<String, PeerHealth>>>,
+}
+
 /// Clonable, cheap handle to the SyncManager exposed to host calls.
 #[derive(Clone)]
 pub struct SyncHandle {
@@ -76,6 +110,9 @@ pub struct SyncManager {
     /// OpId
     seen_ops: Arc<RwLock<HashSet<String>>>,
 
+    /// Health state for configured peers, keyed by configured address.
+    peer_health: Arc<RwLock<HashMap<String, PeerHealth>>>,
+
     /// Channel to send Ops to broadcast.
     op_tx: mpsc::Sender<Op>,
 
@@ -106,6 +143,11 @@ impl SyncManager {
         let (op_tx, op_rx) = mpsc::channel(config.queued_ops_limit.max(1));
         let (shutdown_tx, _shutdown_rx) = watch::channel(false);
         let mut counters = HashMap::new();
+        let peer_health = config
+            .peers
+            .iter()
+            .map(|peer| (peer.clone(), PeerHealth::default()))
+            .collect::<HashMap<_, _>>();
 
         if let Err(e) = hydrate_gcounter_registry(&store, &node_id, &mut counters) {
             warn!(error = %e, "failed to hydrate GCounter registry");
@@ -120,6 +162,7 @@ impl SyncManager {
             store,
             metrics,
             seen_ops: Arc::new(RwLock::new(HashSet::new())),
+            peer_health: Arc::new(RwLock::new(peer_health)),
             op_tx,
             op_rx: Some(op_rx),
             shutdown_tx,
@@ -182,10 +225,18 @@ impl SyncManager {
         node.start_listener().await?;
 
         // Connect to initial peers.
+        let peer_dead_after_failures =
+            normalize_peer_dead_after_failures(self.config.peer_dead_after_failures);
         for peer_addr in &self.config.peers {
-            if let Err(e) = node.connect_to_peer(peer_addr).await {
-                self.metrics.record_sync_error();
-                warn!(peer = %peer_addr, error = %e, "failed to connect to peer");
+            match node.connect_to_peer(peer_addr).await {
+                Ok(()) => {
+                    mark_peer_success(&self.peer_health, peer_addr).await;
+                }
+                Err(e) => {
+                    self.metrics.record_sync_error();
+                    mark_peer_failure(&self.peer_health, peer_addr, peer_dead_after_failures).await;
+                    warn!(peer = %peer_addr, error = %e, "failed to connect to peer");
+                }
             }
         }
 
@@ -198,6 +249,9 @@ impl SyncManager {
         let seen_ops = Arc::clone(&self.seen_ops);
         let store = Arc::clone(&self.store);
         let metrics = Arc::clone(&self.metrics);
+        let peer_health = Arc::clone(&self.peer_health);
+        let peer_dead_after_failures =
+            normalize_peer_dead_after_failures(self.config.peer_dead_after_failures);
         let mut shutdown_rx = self.shutdown_tx.subscribe();
         self.event_task = Some(tokio::spawn(async move {
             loop {
@@ -205,7 +259,15 @@ impl SyncManager {
                     _ = shutdown_rx.changed() => {
                         if *shutdown_rx.borrow() {
                             debug!("event loop shutdown requested");
-                            drain_node_events(&mut event_rx, &counters, &seen_ops, &store, &metrics).await;
+                            drain_node_events(
+                                &mut event_rx,
+                                &counters,
+                                &seen_ops,
+                                &store,
+                                &metrics,
+                                &peer_health,
+                                peer_dead_after_failures,
+                            ).await;
                             break;
                         }
                     }
@@ -213,7 +275,15 @@ impl SyncManager {
                         let Some(event) = event else {
                             break;
                         };
-                        handle_node_event(event, &counters, &seen_ops, &store, &metrics).await;
+                        handle_node_event(
+                            event,
+                            &counters,
+                            &seen_ops,
+                            &store,
+                            &metrics,
+                            &peer_health,
+                            peer_dead_after_failures,
+                        ).await;
                     }
                 }
             }
@@ -232,14 +302,16 @@ impl SyncManager {
             Arc::clone(&self.metrics),
         ));
 
-        self.reconnect_task = spawn_reconnect_loop(
-            Arc::clone(&node),
-            self.config.peers.clone(),
-            self.config.reconnect_initial_delay,
-            self.config.reconnect_max_delay,
-            self.shutdown_tx.subscribe(),
-            Arc::clone(&self.metrics),
-        );
+        self.reconnect_task = spawn_reconnect_loop(ReconnectLoopContext {
+            node: Arc::clone(&node),
+            peers: self.config.peers.clone(),
+            initial_delay: self.config.reconnect_initial_delay,
+            max_delay: self.config.reconnect_max_delay,
+            peer_dead_after_failures: self.config.peer_dead_after_failures,
+            shutdown_rx: self.shutdown_tx.subscribe(),
+            metrics: Arc::clone(&self.metrics),
+            peer_health: Arc::clone(&self.peer_health),
+        });
 
         Ok(())
     }
@@ -260,13 +332,28 @@ impl SyncManager {
         };
         for peer_addr in &self.config.peers {
             if node.is_connected_addr(peer_addr).await {
+                mark_peer_success(&self.peer_health, peer_addr).await;
                 continue;
             }
-            if let Err(e) = node.connect_to_peer(peer_addr).await {
-                self.metrics.record_sync_error();
-                debug!(peer = %peer_addr, error = %e, "configured peer reconnect failed");
+            let peer_dead_after_failures =
+                normalize_peer_dead_after_failures(self.config.peer_dead_after_failures);
+            match node.connect_to_peer(peer_addr).await {
+                Ok(()) => {
+                    mark_peer_success(&self.peer_health, peer_addr).await;
+                }
+                Err(e) => {
+                    self.metrics.record_sync_error();
+                    mark_peer_failure(&self.peer_health, peer_addr, peer_dead_after_failures).await;
+                    debug!(peer = %peer_addr, error = %e, "configured peer reconnect failed");
+                }
             }
         }
+    }
+
+    /// Returns the current health state of a configured peer.
+    pub async fn peer_health_state(&self, addr: &str) -> Option<PeerHealthState> {
+        let peer_health = self.peer_health.read().await;
+        peer_health.get(addr).map(|health| health.state)
     }
 
     /// Returns the number of connected peers, or zero before networking starts.
@@ -344,14 +431,18 @@ fn spawn_broadcast_loop(
     })
 }
 
-fn spawn_reconnect_loop(
-    node: Arc<Node>,
-    peers: Vec<String>,
-    initial_delay: Duration,
-    max_delay: Duration,
-    mut shutdown_rx: watch::Receiver<bool>,
-    metrics: Arc<RuntimeMetrics>,
-) -> Option<JoinHandle<()>> {
+fn spawn_reconnect_loop(context: ReconnectLoopContext) -> Option<JoinHandle<()>> {
+    let ReconnectLoopContext {
+        node,
+        peers,
+        initial_delay,
+        max_delay,
+        peer_dead_after_failures,
+        mut shutdown_rx,
+        metrics,
+        peer_health,
+    } = context;
+
     if peers.is_empty() {
         return None;
     }
@@ -359,6 +450,7 @@ fn spawn_reconnect_loop(
     Some(tokio::spawn(async move {
         let initial_delay = normalize_reconnect_delay(initial_delay);
         let max_delay = max_delay.max(initial_delay);
+        let peer_dead_after_failures = normalize_peer_dead_after_failures(peer_dead_after_failures);
         let mut state = peers
             .into_iter()
             .map(|peer| (peer, initial_delay))
@@ -369,6 +461,7 @@ fn spawn_reconnect_loop(
 
             for (peer, delay) in state.iter_mut() {
                 if node.is_connected_addr(peer).await {
+                    mark_peer_success(&peer_health, peer).await;
                     *delay = initial_delay;
                     continue;
                 }
@@ -377,10 +470,12 @@ fn spawn_reconnect_loop(
                 match node.connect_to_peer(peer).await {
                     Ok(()) => {
                         info!(peer = %peer, "reconnected configured peer");
+                        mark_peer_success(&peer_health, peer).await;
                         *delay = initial_delay;
                     }
                     Err(e) => {
                         metrics.record_sync_error();
+                        mark_peer_failure(&peer_health, peer, peer_dead_after_failures).await;
                         debug!(peer = %peer, error = %e, delay = ?attempt_delay, "configured peer reconnect failed");
                         sleep_for = Some(
                             sleep_for.map_or(attempt_delay, |current| current.min(attempt_delay)),
@@ -411,6 +506,66 @@ fn normalize_reconnect_delay(delay: Duration) -> Duration {
 
 fn next_reconnect_delay(current: Duration, max_delay: Duration) -> Duration {
     current.saturating_mul(2).min(max_delay.max(current))
+}
+
+fn normalize_peer_dead_after_failures(failures: u32) -> u32 {
+    failures.max(1)
+}
+
+fn record_peer_success(peer_health: &mut HashMap<String, PeerHealth>, peer: &str) {
+    let health = peer_health.entry(peer.to_string()).or_default();
+    health.state = PeerHealthState::Healthy;
+    health.consecutive_failures = 0;
+}
+
+fn record_peer_failure(
+    peer_health: &mut HashMap<String, PeerHealth>,
+    peer: &str,
+    dead_after_failures: u32,
+) {
+    let dead_after_failures = normalize_peer_dead_after_failures(dead_after_failures);
+    let health = peer_health.entry(peer.to_string()).or_default();
+    health.consecutive_failures = health.consecutive_failures.saturating_add(1);
+    health.state = if health.consecutive_failures >= dead_after_failures {
+        PeerHealthState::Dead
+    } else {
+        PeerHealthState::Suspect
+    };
+}
+
+async fn mark_peer_success(peer_health: &Arc<RwLock<HashMap<String, PeerHealth>>>, peer: &str) {
+    let mut peer_health = peer_health.write().await;
+    record_peer_success(&mut peer_health, peer);
+}
+
+async fn mark_peer_failure(
+    peer_health: &Arc<RwLock<HashMap<String, PeerHealth>>>,
+    peer: &str,
+    dead_after_failures: u32,
+) {
+    let mut peer_health = peer_health.write().await;
+    record_peer_failure(&mut peer_health, peer, dead_after_failures);
+}
+
+async fn mark_known_peer_success(
+    peer_health: &Arc<RwLock<HashMap<String, PeerHealth>>>,
+    peer: &str,
+) {
+    let mut peer_health = peer_health.write().await;
+    if peer_health.contains_key(peer) {
+        record_peer_success(&mut peer_health, peer);
+    }
+}
+
+async fn mark_known_peer_failure(
+    peer_health: &Arc<RwLock<HashMap<String, PeerHealth>>>,
+    peer: &str,
+    dead_after_failures: u32,
+) {
+    let mut peer_health = peer_health.write().await;
+    if peer_health.contains_key(peer) {
+        record_peer_failure(&mut peer_health, peer, dead_after_failures);
+    }
 }
 
 async fn broadcast_batch(
@@ -458,9 +613,20 @@ async fn drain_node_events(
     seen_ops: &Arc<RwLock<HashSet<String>>>,
     store: &Arc<NxStore>,
     metrics: &Arc<RuntimeMetrics>,
+    peer_health: &Arc<RwLock<HashMap<String, PeerHealth>>>,
+    peer_dead_after_failures: u32,
 ) {
     while let Ok(event) = event_rx.try_recv() {
-        handle_node_event(event, counters, seen_ops, store, metrics).await;
+        handle_node_event(
+            event,
+            counters,
+            seen_ops,
+            store,
+            metrics,
+            peer_health,
+            peer_dead_after_failures,
+        )
+        .await;
     }
 }
 
@@ -470,6 +636,8 @@ async fn handle_node_event(
     seen_ops: &Arc<RwLock<HashSet<String>>>,
     store: &Arc<NxStore>,
     metrics: &Arc<RuntimeMetrics>,
+    peer_health: &Arc<RwLock<HashMap<String, PeerHealth>>>,
+    peer_dead_after_failures: u32,
 ) {
     match event {
         NodeEvent::OpsReceived { from, ops } => {
@@ -483,19 +651,23 @@ async fn handle_node_event(
         }
         NodeEvent::PeerConnected {
             node_id,
+            addr,
             peers_connected,
         } => {
+            mark_known_peer_success(peer_health, &addr).await;
             metrics.record_peer_connect();
             metrics.set_peers_connected(peers_connected);
-            info!(peer = %node_id, "peer connected");
+            info!(peer = %node_id, addr = %addr, "peer connected");
         }
         NodeEvent::PeerDisconnected {
             node_id,
+            addr,
             peers_connected,
         } => {
+            mark_known_peer_failure(peer_health, &addr, peer_dead_after_failures).await;
             metrics.record_peer_disconnect();
             metrics.set_peers_connected(peers_connected);
-            info!(peer = %node_id, "peer disconnected");
+            info!(peer = %node_id, addr = %addr, "peer disconnected");
         }
     }
 }
@@ -672,6 +844,20 @@ mod tests {
         }
     }
 
+    async fn wait_for_peer_health(manager: &SyncManager, peer: &str, expected: PeerHealthState) {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            if manager.peer_health_state(peer).await == Some(expected) {
+                return;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "peer {peer} did not reach health state {expected:?}"
+            );
+            sleep(Duration::from_millis(25)).await;
+        }
+    }
+
     async fn local_increment(handle: &SyncHandle, key: &str, delta: u64) {
         {
             let counters_arc = handle.counters();
@@ -733,6 +919,119 @@ mod tests {
             normalize_reconnect_delay(Duration::ZERO),
             Duration::from_millis(1)
         );
+    }
+
+    #[test]
+    fn peer_health_marks_suspect_then_dead_after_failures() {
+        let mut peer_health = HashMap::new();
+
+        record_peer_failure(&mut peer_health, "peer-a", 2);
+        let health = peer_health.get("peer-a").unwrap();
+        assert_eq!(health.state, PeerHealthState::Suspect);
+        assert_eq!(health.consecutive_failures, 1);
+
+        record_peer_failure(&mut peer_health, "peer-a", 2);
+        let health = peer_health.get("peer-a").unwrap();
+        assert_eq!(health.state, PeerHealthState::Dead);
+        assert_eq!(health.consecutive_failures, 2);
+    }
+
+    #[test]
+    fn peer_health_resets_after_success() {
+        let mut peer_health = HashMap::new();
+
+        record_peer_failure(&mut peer_health, "peer-a", 1);
+        assert_eq!(
+            peer_health.get("peer-a").unwrap().state,
+            PeerHealthState::Dead
+        );
+
+        record_peer_success(&mut peer_health, "peer-a");
+        let health = peer_health.get("peer-a").unwrap();
+        assert_eq!(health.state, PeerHealthState::Healthy);
+        assert_eq!(health.consecutive_failures, 0);
+    }
+
+    #[test]
+    fn peer_dead_after_failures_is_never_zero() {
+        assert_eq!(normalize_peer_dead_after_failures(0), 1);
+    }
+
+    #[tokio::test]
+    async fn peer_events_update_known_peer_health() {
+        let peer = "127.0.0.1:42000";
+        let peer_health = Arc::new(RwLock::new(HashMap::from([(
+            peer.to_string(),
+            PeerHealth::default(),
+        )])));
+        let counters = Arc::new(RwLock::new(HashMap::new()));
+        let seen_ops = Arc::new(RwLock::new(HashSet::new()));
+        let store = temp_store();
+        let metrics = metrics();
+        let node_id = NodeId::generate();
+
+        handle_node_event(
+            NodeEvent::PeerConnected {
+                node_id: node_id.clone(),
+                addr: peer.to_string(),
+                peers_connected: 1,
+            },
+            &counters,
+            &seen_ops,
+            &store,
+            &metrics,
+            &peer_health,
+            2,
+        )
+        .await;
+        assert_eq!(
+            peer_health.read().await.get(peer).unwrap().state,
+            PeerHealthState::Healthy
+        );
+
+        handle_node_event(
+            NodeEvent::PeerDisconnected {
+                node_id,
+                addr: peer.to_string(),
+                peers_connected: 0,
+            },
+            &counters,
+            &seen_ops,
+            &store,
+            &metrics,
+            &peer_health,
+            2,
+        )
+        .await;
+        let health = *peer_health.read().await.get(peer).unwrap();
+        assert_eq!(health.state, PeerHealthState::Suspect);
+        assert_eq!(health.consecutive_failures, 1);
+    }
+
+    #[tokio::test]
+    async fn peer_events_ignore_unknown_peer_health() {
+        let peer_health = Arc::new(RwLock::new(HashMap::new()));
+        let counters = Arc::new(RwLock::new(HashMap::new()));
+        let seen_ops = Arc::new(RwLock::new(HashSet::new()));
+        let store = temp_store();
+        let metrics = metrics();
+
+        handle_node_event(
+            NodeEvent::PeerConnected {
+                node_id: NodeId::generate(),
+                addr: "127.0.0.1:42001".to_string(),
+                peers_connected: 1,
+            },
+            &counters,
+            &seen_ops,
+            &store,
+            &metrics,
+            &peer_health,
+            1,
+        )
+        .await;
+
+        assert!(peer_health.read().await.is_empty());
     }
 
     #[tokio::test]
@@ -851,6 +1150,27 @@ mod tests {
 
         wait_for_counter(&manager_b, key, 1).await;
         assert_eq!(read_materialized(&store_b, key), 1);
+    }
+
+    #[tokio::test]
+    async fn peer_health_marks_dead_then_healthy_when_peer_recovers() {
+        let addr_a = free_addr();
+        let addr_b = free_addr();
+
+        let config_a = SyncConfig::new()
+            .with_listen_addr(addr_a)
+            .with_peer(addr_b.clone())
+            .with_reconnect_backoff(Duration::from_millis(10), Duration::from_millis(20))
+            .with_peer_dead_after_failures(2);
+        let (manager_a, _handle_a, _store_a) = started_manager_with_config(config_a).await;
+
+        wait_for_peer_health(&manager_a, &addr_b, PeerHealthState::Dead).await;
+
+        let config_b = SyncConfig::new().with_listen_addr(addr_b.clone());
+        let (_manager_b, _handle_b, _store_b) = started_manager_with_config(config_b).await;
+
+        wait_for_connected_peer(&manager_a).await;
+        wait_for_peer_health(&manager_a, &addr_b, PeerHealthState::Healthy).await;
     }
 
     #[tokio::test]

--- a/crates/nx-core/src/sync_manager.rs
+++ b/crates/nx-core/src/sync_manager.rs
@@ -15,6 +15,7 @@ use crate::sync_config::SyncConfig;
 /// Upper bound on how many ops we coalesce into a single PushOps message.
 const BROADCAST_BATCH_MAX: usize = 64;
 const GCOUNTER_STORE_PREFIX: &str = "__nx/crdt/gcounter/";
+const GCOUNTER_STATE_STORE_PREFIX: &str = "__nx/crdt/state/gcounter/";
 
 /// Health state for a configured peer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -983,19 +984,38 @@ async fn handle_node_event(event: NodeEvent, context: &NodeEventContext) {
 }
 
 pub(crate) fn materialized_gcounter_key(key: &str) -> Vec<u8> {
-    let mut out = Vec::with_capacity(GCOUNTER_STORE_PREFIX.len() + key.len());
-    out.extend_from_slice(GCOUNTER_STORE_PREFIX.as_bytes());
+    gcounter_store_key(GCOUNTER_STORE_PREFIX, key)
+}
+
+fn durable_gcounter_state_key(key: &str) -> Vec<u8> {
+    gcounter_store_key(GCOUNTER_STATE_STORE_PREFIX, key)
+}
+
+fn gcounter_store_key(prefix: &str, key: &str) -> Vec<u8> {
+    let mut out = Vec::with_capacity(prefix.len() + key.len());
+    out.extend_from_slice(prefix.as_bytes());
     out.extend_from_slice(key.as_bytes());
     out
 }
 
 fn logical_gcounter_key(store_key: &[u8]) -> anyhow::Result<String> {
-    let key = store_key
-        .strip_prefix(GCOUNTER_STORE_PREFIX.as_bytes())
-        .ok_or_else(|| anyhow::anyhow!("invalid GCounter materialized key"))?;
+    logical_key_for_prefix(store_key, GCOUNTER_STORE_PREFIX, "materialized GCounter")
+}
 
-    String::from_utf8(key.to_vec())
-        .map_err(|e| anyhow::anyhow!("invalid UTF-8 in GCounter materialized key: {e}"))
+fn logical_gcounter_state_key(store_key: &[u8]) -> anyhow::Result<String> {
+    logical_key_for_prefix(
+        store_key,
+        GCOUNTER_STATE_STORE_PREFIX,
+        "durable GCounter state",
+    )
+}
+
+fn logical_key_for_prefix(store_key: &[u8], prefix: &str, kind: &str) -> anyhow::Result<String> {
+    let key = store_key
+        .strip_prefix(prefix.as_bytes())
+        .ok_or_else(|| anyhow::anyhow!("invalid {kind} key"))?;
+
+    String::from_utf8(key.to_vec()).map_err(|e| anyhow::anyhow!("invalid UTF-8 in {kind} key: {e}"))
 }
 
 fn parse_materialized_gcounter_value(bytes: &[u8]) -> anyhow::Result<u64> {
@@ -1010,6 +1030,54 @@ fn parse_materialized_gcounter_value(bytes: &[u8]) -> anyhow::Result<u64> {
 }
 
 fn hydrate_gcounter_registry(
+    store: &NxStore,
+    node_id: &NodeId,
+    counters: &mut HashMap<String, GCounter>,
+) -> anyhow::Result<usize> {
+    let durable_count = hydrate_durable_gcounter_state(store, counters)?;
+    let materialized_count = hydrate_materialized_gcounter_values(store, node_id, counters)?;
+
+    debug!(
+        durable_count,
+        materialized_count,
+        total = counters.len(),
+        "hydrated GCounter registry from sled"
+    );
+    Ok(counters.len())
+}
+
+fn hydrate_durable_gcounter_state(
+    store: &NxStore,
+    counters: &mut HashMap<String, GCounter>,
+) -> anyhow::Result<usize> {
+    let entries = store.scan_prefix(GCOUNTER_STATE_STORE_PREFIX.as_bytes())?;
+    let mut hydrated = 0;
+
+    for (store_key, value_bytes) in entries {
+        let key = match logical_gcounter_state_key(&store_key) {
+            Ok(key) => key,
+            Err(e) => {
+                warn!(error = %e, "skipping invalid durable GCounter state key");
+                continue;
+            }
+        };
+        let counter = match parse_durable_gcounter_state(&value_bytes) {
+            Ok(counter) => counter,
+            Err(e) => {
+                warn!(key = %key, error = %e, "skipping invalid durable GCounter state");
+                continue;
+            }
+        };
+
+        materialize_gcounter_value(store, &key, counter.value())?;
+        counters.insert(key, counter);
+        hydrated += 1;
+    }
+
+    Ok(hydrated)
+}
+
+fn hydrate_materialized_gcounter_values(
     store: &NxStore,
     node_id: &NodeId,
     counters: &mut HashMap<String, GCounter>,
@@ -1032,6 +1100,9 @@ fn hydrate_gcounter_registry(
                 continue;
             }
         };
+        if counters.contains_key(&key) {
+            continue;
+        }
 
         let mut counter = GCounter::new();
         counter.increment(node_id, value);
@@ -1039,7 +1110,6 @@ fn hydrate_gcounter_registry(
         hydrated += 1;
     }
 
-    debug!(count = hydrated, "hydrated GCounter registry from sled");
     Ok(hydrated)
 }
 
@@ -1050,6 +1120,24 @@ pub(crate) fn materialize_gcounter_value(
 ) -> anyhow::Result<()> {
     let store_key = materialized_gcounter_key(key);
     store.set(&store_key, &value.to_le_bytes())?;
+    Ok(())
+}
+
+fn parse_durable_gcounter_state(bytes: &[u8]) -> anyhow::Result<GCounter> {
+    let json = std::str::from_utf8(bytes)
+        .map_err(|e| anyhow::anyhow!("invalid UTF-8 in durable GCounter state: {e}"))?;
+    GCounter::from_json(json).map_err(|e| anyhow::anyhow!("invalid durable GCounter JSON: {e}"))
+}
+
+pub(crate) fn persist_gcounter_state(
+    store: &NxStore,
+    key: &str,
+    counter: &GCounter,
+) -> anyhow::Result<()> {
+    let store_key = durable_gcounter_state_key(key);
+    let state_json = counter.to_json()?;
+    store.set(&store_key, state_json.as_bytes())?;
+    materialize_gcounter_value(store, key, counter.value())?;
     Ok(())
 }
 
@@ -1080,7 +1168,7 @@ async fn apply_remote_op(
             counter.increment(&op.origin, *increment);
             let total = counter.value();
 
-            materialize_gcounter_value(store, key, total)?;
+            persist_gcounter_state(store, key, &counter)?;
             counters.insert(key.clone(), counter);
 
             metrics.record_ops(1);
@@ -1133,6 +1221,12 @@ mod tests {
         let mut buf = [0u8; 8];
         buf.copy_from_slice(&bytes);
         u64::from_le_bytes(buf)
+    }
+
+    fn read_durable_gcounter_state(store: &NxStore, key: &str) -> GCounter {
+        let key = durable_gcounter_state_key(key);
+        let bytes = store.get(&key).unwrap().unwrap();
+        parse_durable_gcounter_state(&bytes).unwrap()
     }
 
     fn test_event_context(
@@ -1204,9 +1298,8 @@ mod tests {
             let mut counters = counters_arc.write().await;
             let mut counter = counters.get(key).cloned().unwrap_or_else(GCounter::new);
             counter.increment(handle.node_id(), delta);
-            let total = counter.value();
 
-            materialize_gcounter_value(&handle.store(), key, total).unwrap();
+            persist_gcounter_state(&handle.store(), key, &counter).unwrap();
             counters.insert(key.to_string(), counter);
         }
 
@@ -1502,6 +1595,8 @@ mod tests {
         buf.copy_from_slice(&bytes);
 
         assert_eq!(u64::from_le_bytes(buf), 3);
+        let state = read_durable_gcounter_state(&store, "counter:visits");
+        assert_eq!(state.value_for(&NodeId::new("remote-a")), 3);
     }
 
     #[tokio::test]
@@ -1542,6 +1637,55 @@ mod tests {
         let counters = manager.counters.read().await;
         let counter = counters.get("counter:visits").unwrap();
         assert_eq!(counter.value_for(&node_id), 42);
+    }
+
+    #[tokio::test]
+    async fn manager_hydrates_gcounter_registry_from_durable_state() {
+        let store = temp_store();
+        let node_a = NodeId::new("node-a");
+        let node_b = NodeId::new("node-b");
+        let mut counter = GCounter::new();
+        counter.increment(&node_a, 5);
+        counter.increment(&node_b, 7);
+
+        persist_gcounter_state(&store, "counter:visits", &counter).unwrap();
+
+        let manager = SyncManager::new(
+            NodeId::new("local-node"),
+            SyncConfig::new(),
+            Arc::clone(&store),
+            metrics(),
+        );
+
+        assert_eq!(manager.get_counter_value("counter:visits").await, 12);
+
+        let counters = manager.counters.read().await;
+        let hydrated = counters.get("counter:visits").unwrap();
+        assert_eq!(hydrated.value_for(&node_a), 5);
+        assert_eq!(hydrated.value_for(&node_b), 7);
+    }
+
+    #[tokio::test]
+    async fn durable_gcounter_state_takes_precedence_over_materialized_total() {
+        let store = temp_store();
+        let node_a = NodeId::new("node-a");
+        let node_b = NodeId::new("node-b");
+        let mut counter = GCounter::new();
+        counter.increment(&node_a, 2);
+        counter.increment(&node_b, 3);
+
+        persist_gcounter_state(&store, "counter:visits", &counter).unwrap();
+        materialize_gcounter_value(&store, "counter:visits", 99).unwrap();
+
+        let manager = SyncManager::new(
+            NodeId::new("local-node"),
+            SyncConfig::new(),
+            Arc::clone(&store),
+            metrics(),
+        );
+
+        assert_eq!(manager.get_counter_value("counter:visits").await, 5);
+        assert_eq!(read_materialized(&store, "counter:visits"), 5);
     }
 
     #[tokio::test]

--- a/crates/nx-core/src/sync_manager.rs
+++ b/crates/nx-core/src/sync_manager.rs
@@ -566,7 +566,7 @@ fn spawn_reconnect_loop(context: ReconnectLoopContext) -> Option<JoinHandle<()>>
 
                 if node.is_connected_addr(peer_addr).await {
                     mark_peer_success(&peer_health, peer_addr).await;
-                    peer.reset(initial_delay, now);
+                    peer.reset(initial_delay, StdInstant::now());
                     continue;
                 }
 
@@ -580,16 +580,16 @@ fn spawn_reconnect_loop(context: ReconnectLoopContext) -> Option<JoinHandle<()>>
                 match try_connect_configured_peer(&connect_context, peer_addr).await {
                     ConfiguredPeerConnectOutcome::Connected => {
                         info!(peer = %peer_addr, "reconnected configured peer");
-                        peer.reset(initial_delay, now);
+                        peer.reset(initial_delay, StdInstant::now());
                     }
                     ConfiguredPeerConnectOutcome::AlreadyConnected => {
-                        peer.reset(initial_delay, now);
+                        peer.reset(initial_delay, StdInstant::now());
                     }
                     ConfiguredPeerConnectOutcome::SlotLimitReached => {
                         break;
                     }
                     ConfiguredPeerConnectOutcome::Failed => {
-                        let attempt_delay = peer.record_failure(max_delay, now);
+                        let attempt_delay = peer.record_failure(max_delay, StdInstant::now());
                         sleep_for = Some(
                             sleep_for.map_or(attempt_delay, |current| current.min(attempt_delay)),
                         );
@@ -1047,6 +1047,21 @@ mod tests {
         state.reset(Duration::from_millis(500), now);
         assert_eq!(state.delay, Duration::from_millis(500));
         assert_eq!(state.next_attempt_at, now);
+    }
+
+    #[test]
+    fn peer_reconnect_state_schedules_backoff_from_failure_time() {
+        let started_at = StdInstant::now();
+        let failed_at = started_at + Duration::from_secs(3);
+        let mut state =
+            PeerReconnectState::new("peer-a".to_string(), Duration::from_millis(500), started_at);
+
+        state.record_failure(Duration::from_secs(5), failed_at);
+
+        assert_eq!(
+            state.next_attempt_at,
+            failed_at + Duration::from_millis(500)
+        );
     }
 
     #[test]

--- a/crates/nx-core/src/sync_manager.rs
+++ b/crates/nx-core/src/sync_manager.rs
@@ -1511,6 +1511,30 @@ mod tests {
     }
 
     async fn local_increment(handle: &SyncHandle, key: &str, delta: u64) {
+        let op = apply_local_increment(handle, key, delta).await;
+        handle.op_sender().send(op).await.unwrap();
+    }
+
+    async fn dropped_local_increment(
+        manager: &SyncManager,
+        handle: &SyncHandle,
+        key: &str,
+        delta: u64,
+    ) {
+        let op = apply_local_increment(handle, key, delta).await;
+        remember_ops(
+            &manager.seen_ops,
+            &manager.seen_ops_next_sequence,
+            &manager.op_log,
+            manager.config.op_log_limit,
+            &manager.store,
+            &[op],
+        )
+        .await
+        .unwrap();
+    }
+
+    async fn apply_local_increment(handle: &SyncHandle, key: &str, delta: u64) -> Op {
         {
             let counters_arc = handle.counters();
             let mut counters = counters_arc.write().await;
@@ -1521,8 +1545,7 @@ mod tests {
             counters.insert(key.to_string(), counter);
         }
 
-        let op = Op::gcounter_increment(handle.node_id().clone(), key, delta);
-        handle.op_sender().send(op).await.unwrap();
+        Op::gcounter_increment(handle.node_id().clone(), key, delta)
     }
 
     async fn started_manager(addr: String) -> (SyncManager, SyncHandle, Arc<NxStore>) {
@@ -1533,6 +1556,17 @@ mod tests {
         let handle = manager.handle();
         manager.start().await.unwrap();
         (manager, handle, store)
+    }
+
+    async fn started_manager_with_store(
+        node_id: NodeId,
+        config: SyncConfig,
+        store: Arc<NxStore>,
+    ) -> (SyncManager, SyncHandle) {
+        let mut manager = SyncManager::new(node_id, config, store, metrics());
+        let handle = manager.handle();
+        manager.start().await.unwrap();
+        (manager, handle)
     }
 
     async fn started_manager_with_config(
@@ -2112,6 +2146,86 @@ mod tests {
         wait_for_counter(&manager_b, key, 1).await;
         assert_eq!(read_materialized(&store_b, key), 1);
         assert_eq!(manager_a.get_counter_value(key).await, 1);
+    }
+
+    #[tokio::test]
+    async fn intermittent_network_with_ten_percent_lost_pushes_converges() {
+        let key = "visits";
+        let addr_a = free_addr();
+        let addr_b = free_addr();
+
+        let config_a = SyncConfig::new()
+            .with_listen_addr(addr_a.clone())
+            .with_peer(addr_b.clone())
+            .with_anti_entropy_interval(Duration::from_millis(10));
+        let (manager_a, handle_a, store_a) = started_manager_with_config(config_a).await;
+
+        let config_b = SyncConfig::new()
+            .with_listen_addr(addr_b)
+            .with_peer(addr_a)
+            .with_anti_entropy_interval(Duration::from_millis(10));
+        let (manager_b, _handle_b, store_b) = started_manager_with_config(config_b).await;
+
+        wait_for_connected_peer(&manager_a).await;
+        wait_for_connected_peer(&manager_b).await;
+
+        for i in 0..100 {
+            if i % 10 == 0 {
+                dropped_local_increment(&manager_a, &handle_a, key, 1).await;
+            } else {
+                local_increment(&handle_a, key, 1).await;
+            }
+        }
+
+        wait_for_counter(&manager_b, key, 100).await;
+        assert_eq!(manager_a.get_counter_value(key).await, 100);
+        assert_eq!(read_materialized(&store_a, key), 100);
+        assert_eq!(read_materialized(&store_b, key), 100);
+    }
+
+    #[tokio::test]
+    async fn node_restart_reconnects_and_converges_from_durable_state() {
+        let key = "visits";
+        let addr_a = free_addr();
+        let addr_b = free_addr();
+        let store_b = temp_store();
+        let node_b_id = NodeId::new("node-b");
+
+        let config_a = SyncConfig::new()
+            .with_listen_addr(addr_a.clone())
+            .with_peer(addr_b.clone())
+            .with_reconnect_backoff(Duration::from_millis(10), Duration::from_millis(50))
+            .with_anti_entropy_interval(Duration::from_millis(10));
+        let (manager_a, handle_a, store_a) = started_manager_with_config(config_a).await;
+
+        let config_b = SyncConfig::new()
+            .with_listen_addr(addr_b.clone())
+            .with_peer(addr_a.clone())
+            .with_anti_entropy_interval(Duration::from_millis(10));
+        let (mut manager_b, _handle_b) =
+            started_manager_with_store(node_b_id.clone(), config_b, Arc::clone(&store_b)).await;
+
+        wait_for_connected_peer(&manager_a).await;
+        local_increment(&handle_a, key, 1).await;
+        wait_for_counter(&manager_b, key, 1).await;
+
+        manager_b.shutdown().await.unwrap();
+        local_increment(&handle_a, key, 1).await;
+
+        let config_b_restart = SyncConfig::new()
+            .with_listen_addr(addr_b)
+            .with_peer(addr_a)
+            .with_anti_entropy_interval(Duration::from_millis(10));
+        let (manager_b_restarted, _handle_b_restarted) =
+            started_manager_with_store(node_b_id, config_b_restart, Arc::clone(&store_b)).await;
+
+        wait_for_connected_peer(&manager_a).await;
+        wait_for_connected_peer(&manager_b_restarted).await;
+        wait_for_counter(&manager_b_restarted, key, 2).await;
+
+        assert_eq!(manager_a.get_counter_value(key).await, 2);
+        assert_eq!(read_materialized(&store_a, key), 2);
+        assert_eq!(read_materialized(&store_b, key), 2);
     }
 
     #[tokio::test]

--- a/crates/nx-core/src/sync_manager.rs
+++ b/crates/nx-core/src/sync_manager.rs
@@ -20,6 +20,7 @@ const BROADCAST_BATCH_MAX: usize = 64;
 const GCOUNTER_STORE_PREFIX: &str = "__nx/crdt/gcounter/";
 const GCOUNTER_STATE_STORE_PREFIX: &str = "__nx/crdt/state/gcounter/";
 const SEEN_OP_STORE_PREFIX: &str = "__nx/crdt/seen-op/";
+const OP_LOG_STORE_PREFIX: &str = "__nx/crdt/op-log/";
 
 #[derive(Debug, PartialEq, Eq)]
 enum SeenOpsInsert {
@@ -50,7 +51,7 @@ impl Default for PeerHealth {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct SeenOps {
     ids: HashSet<String>,
     order: VecDeque<String>,
@@ -113,6 +114,8 @@ struct AntiEntropyLoopContext {
     interval: Duration,
     shutdown_rx: watch::Receiver<bool>,
     metrics: Arc<RuntimeMetrics>,
+    peer_node_ids: Arc<RwLock<HashMap<String, NodeId>>>,
+    anti_entropy_watermarks: Arc<RwLock<HashMap<NodeId, String>>>,
 }
 
 struct BroadcastLoopContext {
@@ -120,6 +123,7 @@ struct BroadcastLoopContext {
     seen_ops: Arc<RwLock<SeenOps>>,
     seen_ops_next_sequence: Arc<AtomicU64>,
     op_log: Arc<RwLock<Vec<Op>>>,
+    op_log_next_sequence: Arc<AtomicU64>,
     op_log_limit: usize,
     store: Arc<NxStore>,
     metrics: Arc<RuntimeMetrics>,
@@ -130,9 +134,28 @@ struct RemoteOpApplyContext<'a> {
     seen_ops: &'a Arc<RwLock<SeenOps>>,
     seen_ops_next_sequence: &'a Arc<AtomicU64>,
     op_log: &'a Arc<RwLock<Vec<Op>>>,
+    op_log_next_sequence: &'a Arc<AtomicU64>,
     op_log_limit: usize,
     store: &'a Arc<NxStore>,
     metrics: &'a Arc<RuntimeMetrics>,
+}
+
+struct OpPersistencePlan {
+    op: Op,
+    seen_sequence: u64,
+    op_log_sequence: u64,
+    seen_evicted: Vec<String>,
+    op_log_evicted: Vec<Op>,
+}
+
+struct RemoteGCounterPersistence<'a> {
+    key: &'a str,
+    counter: &'a GCounter,
+    op: &'a Op,
+    seen_sequence: u64,
+    op_log_sequence: u64,
+    seen_evicted: &'a [String],
+    op_log_evicted: &'a [Op],
 }
 
 #[derive(Clone)]
@@ -141,11 +164,14 @@ struct NodeEventContext {
     seen_ops: Arc<RwLock<SeenOps>>,
     seen_ops_next_sequence: Arc<AtomicU64>,
     op_log: Arc<RwLock<Vec<Op>>>,
+    op_log_next_sequence: Arc<AtomicU64>,
     op_log_limit: usize,
     store: Arc<NxStore>,
     metrics: Arc<RuntimeMetrics>,
     node: Arc<Node>,
     peer_health: Arc<RwLock<HashMap<String, PeerHealth>>>,
+    peer_node_ids: Arc<RwLock<HashMap<String, NodeId>>>,
+    anti_entropy_watermarks: Arc<RwLock<HashMap<NodeId, String>>>,
     peer_dead_after_failures: u32,
 }
 
@@ -258,8 +284,17 @@ pub struct SyncManager {
     /// In-memory operation log used to answer anti-entropy pull requests.
     op_log: Arc<RwLock<Vec<Op>>>,
 
+    /// Monotonic sequence used to retain recent durable operation-log entries.
+    op_log_next_sequence: Arc<AtomicU64>,
+
     /// Health state for configured peers, keyed by configured address.
     peer_health: Arc<RwLock<HashMap<String, PeerHealth>>>,
+
+    /// Connected configured peer NodeIds, keyed by configured address.
+    peer_node_ids: Arc<RwLock<HashMap<String, NodeId>>>,
+
+    /// Last received OpId per peer NodeId, used for incremental anti-entropy pulls.
+    anti_entropy_watermarks: Arc<RwLock<HashMap<NodeId, String>>>,
 
     /// Channel to send Ops to broadcast.
     op_tx: mpsc::Sender<Op>,
@@ -296,6 +331,13 @@ impl SyncManager {
         let seen_ops_limit = normalize_seen_ops_limit(config.seen_ops_limit);
         let (shutdown_tx, _shutdown_rx) = watch::channel(false);
         let mut counters = HashMap::new();
+        let (op_log, op_log_next_sequence) = match hydrate_op_log(&store, op_log_limit) {
+            Ok(hydrated) => hydrated,
+            Err(e) => {
+                warn!(error = %e, "failed to hydrate operation log");
+                (Vec::with_capacity(op_log_limit.min(1024)), 0)
+            }
+        };
         let peer_health = config
             .peers
             .iter()
@@ -324,8 +366,11 @@ impl SyncManager {
             metrics,
             seen_ops: Arc::new(RwLock::new(seen_ops)),
             seen_ops_next_sequence: Arc::new(AtomicU64::new(seen_ops_next_sequence)),
-            op_log: Arc::new(RwLock::new(Vec::with_capacity(op_log_limit.min(1024)))),
+            op_log: Arc::new(RwLock::new(op_log)),
+            op_log_next_sequence: Arc::new(AtomicU64::new(op_log_next_sequence)),
             peer_health: Arc::new(RwLock::new(peer_health)),
+            peer_node_ids: Arc::new(RwLock::new(HashMap::new())),
+            anti_entropy_watermarks: Arc::new(RwLock::new(HashMap::new())),
             op_tx,
             op_rx: Some(op_rx),
             shutdown_tx,
@@ -417,11 +462,14 @@ impl SyncManager {
             seen_ops: Arc::clone(&self.seen_ops),
             seen_ops_next_sequence: Arc::clone(&self.seen_ops_next_sequence),
             op_log: Arc::clone(&self.op_log),
+            op_log_next_sequence: Arc::clone(&self.op_log_next_sequence),
             op_log_limit: normalize_op_log_limit(self.config.op_log_limit),
             store: Arc::clone(&self.store),
             metrics: Arc::clone(&self.metrics),
             node: Arc::clone(&node),
             peer_health: Arc::clone(&self.peer_health),
+            peer_node_ids: Arc::clone(&self.peer_node_ids),
+            anti_entropy_watermarks: Arc::clone(&self.anti_entropy_watermarks),
             peer_dead_after_failures: normalize_peer_dead_after_failures(
                 self.config.peer_dead_after_failures,
             ),
@@ -459,6 +507,7 @@ impl SyncManager {
                 seen_ops: Arc::clone(&self.seen_ops),
                 seen_ops_next_sequence: Arc::clone(&self.seen_ops_next_sequence),
                 op_log: Arc::clone(&self.op_log),
+                op_log_next_sequence: Arc::clone(&self.op_log_next_sequence),
                 op_log_limit: normalize_op_log_limit(self.config.op_log_limit),
                 store: Arc::clone(&self.store),
                 metrics: Arc::clone(&self.metrics),
@@ -485,6 +534,8 @@ impl SyncManager {
             interval: self.config.anti_entropy_interval,
             shutdown_rx: self.shutdown_tx.subscribe(),
             metrics: Arc::clone(&self.metrics),
+            peer_node_ids: Arc::clone(&self.peer_node_ids),
+            anti_entropy_watermarks: Arc::clone(&self.anti_entropy_watermarks),
         });
 
         Ok(())
@@ -757,6 +808,8 @@ fn spawn_anti_entropy_loop(context: AntiEntropyLoopContext) -> Option<JoinHandle
         interval,
         mut shutdown_rx,
         metrics,
+        peer_node_ids,
+        anti_entropy_watermarks,
     } = context;
 
     if peers.is_empty() {
@@ -779,7 +832,15 @@ fn spawn_anti_entropy_loop(context: AntiEntropyLoopContext) -> Option<JoinHandle
                             continue;
                         }
 
-                        if let Err(e) = node.send_pull_since_to_addr(peer, None).await {
+                        let since_op_id = {
+                            let peer_node_ids = peer_node_ids.read().await;
+                            let Some(node_id) = peer_node_ids.get(peer) else {
+                                continue;
+                            };
+                            anti_entropy_watermarks.read().await.get(node_id).cloned()
+                        };
+
+                        if let Err(e) = node.send_pull_since_to_addr(peer, since_op_id).await {
                             metrics.record_sync_error();
                             debug!(peer = %peer, error = %e, "anti-entropy pull failed");
                         } else {
@@ -894,6 +955,7 @@ async fn broadcast_batch(
         &context.seen_ops,
         &context.seen_ops_next_sequence,
         &context.op_log,
+        &context.op_log_next_sequence,
         context.op_log_limit,
         &context.store,
         &batch,
@@ -902,6 +964,7 @@ async fn broadcast_batch(
     {
         context.metrics.record_sync_error();
         warn!(error = %e, "failed to persist local op dedup metadata");
+        return;
     }
     let started = std::time::Instant::now();
     if let Err(e) = context.node.broadcast_ops(batch).await {
@@ -924,27 +987,49 @@ async fn remember_ops(
     seen_ops: &Arc<RwLock<SeenOps>>,
     seen_ops_next_sequence: &Arc<AtomicU64>,
     op_log: &Arc<RwLock<Vec<Op>>>,
+    op_log_next_sequence: &Arc<AtomicU64>,
     op_log_limit: usize,
     store: &Arc<NxStore>,
     ops: &[Op],
 ) -> anyhow::Result<()> {
     let mut seen = seen_ops.write().await;
     let mut log = op_log.write().await;
+    let mut next_seen_sequence = seen_ops_next_sequence.load(Ordering::Relaxed);
+    let mut next_op_log_sequence = op_log_next_sequence.load(Ordering::Relaxed);
+    let mut planned_seen = seen.clone();
+    let mut planned_log = log.clone();
+    let mut inserts = Vec::new();
     for op in ops {
-        if let SeenOpsInsert::Inserted { evicted } = seen.insert(op.id.as_str().to_string()) {
-            persist_seen_op_insert(store, seen_ops_next_sequence, op.id.as_str(), &evicted)?;
-            log.push(op.clone());
+        if let SeenOpsInsert::Inserted { evicted } = planned_seen.insert(op.id.as_str().to_string())
+        {
+            planned_log.push(op.clone());
+            let op_log_evicted = prune_op_log_and_return_evicted(&mut planned_log, op_log_limit);
+            inserts.push(OpPersistencePlan {
+                op: op.clone(),
+                seen_sequence: next_seen_sequence,
+                op_log_sequence: next_op_log_sequence,
+                seen_evicted: evicted,
+                op_log_evicted,
+            });
+            next_seen_sequence = next_seen_sequence.saturating_add(1);
+            next_op_log_sequence = next_op_log_sequence.saturating_add(1);
         }
     }
-    prune_op_log(&mut log, op_log_limit);
+    persist_local_ops_batch(store, &inserts)?;
+    *seen = planned_seen;
+    *log = planned_log;
+    seen_ops_next_sequence.store(next_seen_sequence, Ordering::Relaxed);
+    op_log_next_sequence.store(next_op_log_sequence, Ordering::Relaxed);
     Ok(())
 }
 
-fn prune_op_log(log: &mut Vec<Op>, limit: usize) {
+fn prune_op_log_and_return_evicted(log: &mut Vec<Op>, limit: usize) -> Vec<Op> {
     let limit = normalize_op_log_limit(limit);
     if log.len() > limit {
         let remove_count = log.len() - limit;
-        log.drain(..remove_count);
+        log.drain(..remove_count).collect()
+    } else {
+        Vec::new()
     }
 }
 
@@ -969,20 +1054,28 @@ async fn handle_node_event(event: NodeEvent, context: &NodeEventContext) {
     match event {
         NodeEvent::OpsReceived { from, ops } => {
             debug!(from = %from, count = ops.len(), "received ops from peer");
-            for op in ops {
+            for op in &ops {
                 let apply_context = RemoteOpApplyContext {
                     counters: &context.counters,
                     seen_ops: &context.seen_ops,
                     seen_ops_next_sequence: &context.seen_ops_next_sequence,
                     op_log: &context.op_log,
+                    op_log_next_sequence: &context.op_log_next_sequence,
                     op_log_limit: context.op_log_limit,
                     store: &context.store,
                     metrics: &context.metrics,
                 };
-                if let Err(e) = apply_remote_op(&op, &apply_context).await {
+                if let Err(e) = apply_remote_op(op, &apply_context).await {
                     context.metrics.record_sync_error();
                     error!(error = %e, "failed to apply remote op");
                 }
+            }
+            if let Some(last_op) = ops.last() {
+                context
+                    .anti_entropy_watermarks
+                    .write()
+                    .await
+                    .insert(from, last_op.id.as_str().to_string());
             }
         }
         NodeEvent::PullRequested {
@@ -1005,6 +1098,11 @@ async fn handle_node_event(event: NodeEvent, context: &NodeEventContext) {
             peers_connected,
         } => {
             mark_known_peer_success(&context.peer_health, &addr).await;
+            context
+                .peer_node_ids
+                .write()
+                .await
+                .insert(addr.clone(), node_id.clone());
             context.metrics.record_peer_connect();
             context.metrics.set_peers_connected(peers_connected);
             info!(peer = %node_id, addr = %addr, "peer connected");
@@ -1020,6 +1118,7 @@ async fn handle_node_event(event: NodeEvent, context: &NodeEventContext) {
                 context.peer_dead_after_failures,
             )
             .await;
+            context.peer_node_ids.write().await.remove(&addr);
             context.metrics.record_peer_disconnect();
             context.metrics.set_peers_connected(peers_connected);
             info!(peer = %node_id, addr = %addr, "peer disconnected");
@@ -1037,6 +1136,10 @@ fn durable_gcounter_state_key(key: &str) -> Vec<u8> {
 
 fn seen_op_store_key(op_id: &str) -> Vec<u8> {
     gcounter_store_key(SEEN_OP_STORE_PREFIX, op_id)
+}
+
+fn op_log_store_key(op_id: &str) -> Vec<u8> {
+    gcounter_store_key(OP_LOG_STORE_PREFIX, op_id)
 }
 
 fn gcounter_store_key(prefix: &str, key: &str) -> Vec<u8> {
@@ -1060,6 +1163,10 @@ fn logical_gcounter_state_key(store_key: &[u8]) -> anyhow::Result<String> {
 
 fn logical_seen_op_id(store_key: &[u8]) -> anyhow::Result<String> {
     logical_key_for_prefix(store_key, SEEN_OP_STORE_PREFIX, "seen OpId")
+}
+
+fn logical_op_log_id(store_key: &[u8]) -> anyhow::Result<String> {
+    logical_key_for_prefix(store_key, OP_LOG_STORE_PREFIX, "op log OpId")
 }
 
 fn logical_key_for_prefix(store_key: &[u8], prefix: &str, kind: &str) -> anyhow::Result<String> {
@@ -1090,6 +1197,28 @@ fn parse_materialized_gcounter_value(bytes: &[u8]) -> anyhow::Result<u64> {
     })?;
 
     Ok(u64::from_le_bytes(buf))
+}
+
+fn encode_durable_op_log_value(sequence: u64, op: &Op) -> anyhow::Result<Vec<u8>> {
+    let op_bytes = op.to_bytes()?;
+    let mut out = Vec::with_capacity(8 + op_bytes.len());
+    out.extend_from_slice(&sequence.to_be_bytes());
+    out.extend_from_slice(&op_bytes);
+    Ok(out)
+}
+
+fn parse_durable_op_log_value(bytes: &[u8]) -> anyhow::Result<(u64, Op)> {
+    if bytes.len() < 8 {
+        anyhow::bail!(
+            "invalid op log value length: expected at least 8, got {}",
+            bytes.len()
+        );
+    }
+    let mut seq = [0u8; 8];
+    seq.copy_from_slice(&bytes[..8]);
+    let op = Op::from_bytes(&bytes[8..])
+        .map_err(|e| anyhow::anyhow!("invalid durable op log JSON: {e}"))?;
+    Ok((u64::from_be_bytes(seq), op))
 }
 
 fn hydrate_gcounter_registry(
@@ -1153,6 +1282,44 @@ fn hydrate_seen_ops(store: &NxStore, limit: usize) -> anyhow::Result<(SeenOps, u
         next_sequence, "hydrated seen OpId metadata from sled"
     );
     Ok((seen, next_sequence))
+}
+
+fn hydrate_op_log(store: &NxStore, limit: usize) -> anyhow::Result<(Vec<Op>, u64)> {
+    let limit = normalize_op_log_limit(limit);
+    let entries = store.scan_prefix(OP_LOG_STORE_PREFIX.as_bytes())?;
+    let mut ordered = Vec::with_capacity(entries.len());
+    let mut next_sequence = 0;
+
+    for (store_key, value_bytes) in entries {
+        let op_id = match logical_op_log_id(&store_key) {
+            Ok(op_id) => op_id,
+            Err(e) => {
+                warn!(error = %e, "skipping invalid durable op log key");
+                continue;
+            }
+        };
+        let (sequence, op) = match parse_durable_op_log_value(&value_bytes) {
+            Ok(value) => value,
+            Err(e) => {
+                warn!(op_id = %op_id, error = %e, "skipping invalid durable op log entry");
+                continue;
+            }
+        };
+
+        next_sequence = next_sequence.max(sequence.saturating_add(1));
+        ordered.push((sequence, op));
+    }
+
+    ordered.sort_by_key(|(sequence, _)| *sequence);
+    let mut op_log = ordered.into_iter().map(|(_, op)| op).collect::<Vec<_>>();
+    let evicted = prune_op_log_and_return_evicted(&mut op_log, limit);
+    persist_op_log_evictions(store, &evicted)?;
+
+    debug!(
+        count = op_log.len(),
+        next_sequence, "hydrated durable op log from sled"
+    );
+    Ok((op_log, next_sequence))
 }
 
 fn hydrate_durable_gcounter_state(
@@ -1250,16 +1417,7 @@ pub(crate) fn persist_gcounter_state(
     Ok(())
 }
 
-fn persist_seen_op_insert(
-    store: &NxStore,
-    next_sequence: &AtomicU64,
-    op_id: &str,
-    evicted: &[String],
-) -> anyhow::Result<()> {
-    let sequence = next_sequence.fetch_add(1, Ordering::Relaxed);
-    persist_seen_op_batch(store, op_id, sequence, evicted)
-}
-
+#[cfg(test)]
 fn persist_seen_op_batch(
     store: &NxStore,
     op_id: &str,
@@ -1284,6 +1442,20 @@ fn persist_seen_op_batch(
     Ok(())
 }
 
+fn collect_seen_delete_keys(evicted: &[String]) -> Vec<Vec<u8>> {
+    evicted
+        .iter()
+        .map(|op_id| seen_op_store_key(op_id))
+        .collect()
+}
+
+fn collect_op_log_delete_keys(evicted: &[Op]) -> Vec<Vec<u8>> {
+    evicted
+        .iter()
+        .map(|op| op_log_store_key(op.id.as_str()))
+        .collect()
+}
+
 fn persist_seen_op_evictions(store: &NxStore, evicted: &[String]) -> anyhow::Result<()> {
     if evicted.is_empty() {
         return Ok(());
@@ -1301,25 +1473,66 @@ fn persist_seen_op_evictions(store: &NxStore, evicted: &[String]) -> anyhow::Res
     Ok(())
 }
 
+fn persist_op_log_evictions(store: &NxStore, evicted: &[Op]) -> anyhow::Result<()> {
+    if evicted.is_empty() {
+        return Ok(());
+    }
+
+    let delete_keys = collect_op_log_delete_keys(evicted);
+    let delete_refs = delete_keys
+        .iter()
+        .map(|key| key.as_slice())
+        .collect::<Vec<_>>();
+    store.apply_batch(&[], &delete_refs)?;
+    Ok(())
+}
+
+fn persist_local_ops_batch(store: &NxStore, plans: &[OpPersistencePlan]) -> anyhow::Result<()> {
+    if plans.is_empty() {
+        return Ok(());
+    }
+
+    let mut set_keys = Vec::new();
+    let mut set_values = Vec::new();
+    let mut delete_keys = Vec::new();
+
+    for plan in plans {
+        set_keys.push(seen_op_store_key(plan.op.id.as_str()));
+        set_values.push(plan.seen_sequence.to_be_bytes().to_vec());
+        set_keys.push(op_log_store_key(plan.op.id.as_str()));
+        set_values.push(encode_durable_op_log_value(plan.op_log_sequence, &plan.op)?);
+        delete_keys.extend(collect_seen_delete_keys(&plan.seen_evicted));
+        delete_keys.extend(collect_op_log_delete_keys(&plan.op_log_evicted));
+    }
+
+    let sets = set_keys
+        .iter()
+        .zip(set_values.iter())
+        .map(|(key, value)| (key.as_slice(), value.as_slice()))
+        .collect::<Vec<_>>();
+    let deletes = delete_keys
+        .iter()
+        .map(|key| key.as_slice())
+        .collect::<Vec<_>>();
+
+    store.apply_batch(&sets, &deletes)?;
+    Ok(())
+}
+
 fn persist_remote_gcounter_op(
     store: &NxStore,
-    next_sequence: &AtomicU64,
-    key: &str,
-    counter: &GCounter,
-    op_id: &str,
-    evicted: &[String],
+    change: RemoteGCounterPersistence<'_>,
 ) -> anyhow::Result<()> {
-    let sequence = next_sequence.fetch_add(1, Ordering::Relaxed);
-    let state_key = durable_gcounter_state_key(key);
-    let state_json = counter.to_json()?;
-    let materialized_key = materialized_gcounter_key(key);
-    let materialized_value = counter.value().to_le_bytes();
-    let seen_key = seen_op_store_key(op_id);
-    let seen_value = sequence.to_be_bytes();
-    let delete_keys = evicted
-        .iter()
-        .map(|op_id| seen_op_store_key(op_id))
-        .collect::<Vec<_>>();
+    let state_key = durable_gcounter_state_key(change.key);
+    let state_json = change.counter.to_json()?;
+    let materialized_key = materialized_gcounter_key(change.key);
+    let materialized_value = change.counter.value().to_le_bytes();
+    let seen_key = seen_op_store_key(change.op.id.as_str());
+    let seen_value = change.seen_sequence.to_be_bytes();
+    let op_log_key = op_log_store_key(change.op.id.as_str());
+    let op_log_value = encode_durable_op_log_value(change.op_log_sequence, change.op)?;
+    let mut delete_keys = collect_seen_delete_keys(change.seen_evicted);
+    delete_keys.extend(collect_op_log_delete_keys(change.op_log_evicted));
     let delete_refs = delete_keys
         .iter()
         .map(|key| key.as_slice())
@@ -1330,6 +1543,7 @@ fn persist_remote_gcounter_op(
             (state_key.as_slice(), state_json.as_bytes()),
             (materialized_key.as_slice(), materialized_value.as_slice()),
             (seen_key.as_slice(), seen_value.as_slice()),
+            (op_log_key.as_slice(), op_log_value.as_slice()),
         ],
         &delete_refs,
     )?;
@@ -1338,11 +1552,9 @@ fn persist_remote_gcounter_op(
 
 /// Apply an operation received from a remote peer.
 async fn apply_remote_op(op: &Op, context: &RemoteOpApplyContext<'_>) -> anyhow::Result<()> {
-    let seen_insert = {
-        let mut seen = context.seen_ops.write().await;
-        seen.insert(op.id.as_str().to_string())
-    };
-    let evicted = match seen_insert {
+    let mut seen = context.seen_ops.write().await;
+    let mut planned_seen = seen.clone();
+    let seen_evicted = match planned_seen.insert(op.id.as_str().to_string()) {
         SeenOpsInsert::AlreadySeen => {
             debug!(op_id = %op.id, "skipping duplicate op");
             return Ok(());
@@ -1350,7 +1562,13 @@ async fn apply_remote_op(op: &Op, context: &RemoteOpApplyContext<'_>) -> anyhow:
         SeenOpsInsert::Inserted { evicted } => evicted,
     };
 
-    // Apply according to type
+    let mut log = context.op_log.write().await;
+    let mut planned_log = log.clone();
+    planned_log.push(op.clone());
+    let op_log_evicted = prune_op_log_and_return_evicted(&mut planned_log, context.op_log_limit);
+    let seen_sequence = context.seen_ops_next_sequence.load(Ordering::Relaxed);
+    let op_log_sequence = context.op_log_next_sequence.load(Ordering::Relaxed);
+
     match &op.kind {
         OpKind::GCounterIncrement { key, increment } => {
             let mut counters = context.counters.write().await;
@@ -1360,22 +1578,30 @@ async fn apply_remote_op(op: &Op, context: &RemoteOpApplyContext<'_>) -> anyhow:
 
             persist_remote_gcounter_op(
                 context.store,
-                context.seen_ops_next_sequence,
-                key,
-                &counter,
-                op.id.as_str(),
-                &evicted,
+                RemoteGCounterPersistence {
+                    key,
+                    counter: &counter,
+                    op,
+                    seen_sequence,
+                    op_log_sequence,
+                    seen_evicted: &seen_evicted,
+                    op_log_evicted: &op_log_evicted,
+                },
             )?;
             counters.insert(key.clone(), counter);
+            *seen = planned_seen;
+            *log = planned_log;
+            context
+                .seen_ops_next_sequence
+                .store(seen_sequence.saturating_add(1), Ordering::Relaxed);
+            context
+                .op_log_next_sequence
+                .store(op_log_sequence.saturating_add(1), Ordering::Relaxed);
 
             context.metrics.record_ops(1);
             debug!(op_id = %op.id, key = %key, from = %op.origin, increment = %increment, total, "applied remote increment");
         }
     }
-
-    let mut log = context.op_log.write().await;
-    log.push(op.clone());
-    prune_op_log(&mut log, context.op_log_limit);
 
     Ok(())
 }
@@ -1438,6 +1664,7 @@ mod tests {
             seen_ops,
             seen_ops_next_sequence: Arc::new(AtomicU64::new(0)),
             op_log,
+            op_log_next_sequence: Arc::new(AtomicU64::new(0)),
             op_log_limit: 1024,
             store,
             metrics,
@@ -1446,6 +1673,8 @@ mod tests {
                 "127.0.0.1:0",
             ))),
             peer_health,
+            peer_node_ids: Arc::new(RwLock::new(HashMap::new())),
+            anti_entropy_watermarks: Arc::new(RwLock::new(HashMap::new())),
             peer_dead_after_failures: 2,
         }
     }
@@ -1456,6 +1685,7 @@ mod tests {
         seen_ops: &Arc<RwLock<SeenOps>>,
         seen_ops_next_sequence: &Arc<AtomicU64>,
         op_log: &Arc<RwLock<Vec<Op>>>,
+        op_log_next_sequence: &Arc<AtomicU64>,
         store: &Arc<NxStore>,
     ) {
         let metrics = metrics();
@@ -1464,6 +1694,7 @@ mod tests {
             seen_ops,
             seen_ops_next_sequence,
             op_log,
+            op_log_next_sequence,
             op_log_limit: 1024,
             store,
             metrics: &metrics,
@@ -1526,6 +1757,7 @@ mod tests {
             &manager.seen_ops,
             &manager.seen_ops_next_sequence,
             &manager.op_log,
+            &manager.op_log_next_sequence,
             manager.config.op_log_limit,
             &manager.store,
             &[op],
@@ -1659,6 +1891,7 @@ mod tests {
         let store = temp_store();
         let seen_ops = Arc::new(RwLock::new(SeenOps::new(10)));
         let seen_ops_next_sequence = Arc::new(AtomicU64::new(0));
+        let op_log_next_sequence = Arc::new(AtomicU64::new(0));
         let op_log = Arc::new(RwLock::new(Vec::new()));
         let op_a = Op::gcounter_increment(NodeId::new("node-a"), "counter:visits", 1);
         let op_b = Op::gcounter_increment(NodeId::new("node-b"), "counter:visits", 2);
@@ -1668,6 +1901,7 @@ mod tests {
             &seen_ops,
             &seen_ops_next_sequence,
             &op_log,
+            &op_log_next_sequence,
             2,
             &store,
             &[op_a.clone(), op_b.clone(), op_c.clone()],
@@ -1890,12 +2124,54 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn ops_received_updates_anti_entropy_watermark() {
+        let peer = NodeId::new("peer-a");
+        let peer_health = Arc::new(RwLock::new(HashMap::new()));
+        let counters = Arc::new(RwLock::new(HashMap::new()));
+        let seen_ops = Arc::new(RwLock::new(SeenOps::new(1024)));
+        let op_log = Arc::new(RwLock::new(Vec::new()));
+        let store = temp_store();
+        let metrics = metrics();
+        let context = test_event_context(
+            Arc::clone(&counters),
+            Arc::clone(&seen_ops),
+            Arc::clone(&op_log),
+            Arc::clone(&store),
+            Arc::clone(&metrics),
+            Arc::clone(&peer_health),
+        );
+        let op_a = Op::gcounter_increment(peer.clone(), "counter:visits", 1);
+        let op_b = Op::gcounter_increment(peer.clone(), "counter:visits", 1);
+        let expected = op_b.id.as_str().to_string();
+
+        handle_node_event(
+            NodeEvent::OpsReceived {
+                from: peer.clone(),
+                ops: vec![op_a, op_b],
+            },
+            &context,
+        )
+        .await;
+
+        assert_eq!(
+            context
+                .anti_entropy_watermarks
+                .read()
+                .await
+                .get(&peer)
+                .cloned(),
+            Some(expected)
+        );
+    }
+
+    #[tokio::test]
     async fn apply_remote_op_materializes_counter_value() {
         let store = temp_store();
         let counters = Arc::new(RwLock::new(HashMap::new()));
         let seen_ops = Arc::new(RwLock::new(SeenOps::new(1024)));
         let seen_ops_next_sequence = Arc::new(AtomicU64::new(0));
         let op_log = Arc::new(RwLock::new(Vec::new()));
+        let op_log_next_sequence = Arc::new(AtomicU64::new(0));
         let origin = NodeId::new("remote-a");
         let op = Op::gcounter_increment(origin, "counter:visits", 3);
 
@@ -1905,6 +2181,7 @@ mod tests {
             &seen_ops,
             &seen_ops_next_sequence,
             &op_log,
+            &op_log_next_sequence,
             &store,
         )
         .await;
@@ -1926,6 +2203,7 @@ mod tests {
         let seen_ops = Arc::new(RwLock::new(SeenOps::new(1024)));
         let seen_ops_next_sequence = Arc::new(AtomicU64::new(0));
         let op_log = Arc::new(RwLock::new(Vec::new()));
+        let op_log_next_sequence = Arc::new(AtomicU64::new(0));
         let origin = NodeId::new("remote-a");
         let op = Op::gcounter_increment(origin, "counter:visits", 3);
 
@@ -1935,6 +2213,7 @@ mod tests {
             &seen_ops,
             &seen_ops_next_sequence,
             &op_log,
+            &op_log_next_sequence,
             &store,
         )
         .await;
@@ -1944,6 +2223,7 @@ mod tests {
             &seen_ops,
             &seen_ops_next_sequence,
             &op_log,
+            &op_log_next_sequence,
             &store,
         )
         .await;
@@ -1974,6 +2254,7 @@ mod tests {
             &first_manager.seen_ops,
             &first_manager.seen_ops_next_sequence,
             &first_manager.op_log,
+            &first_manager.op_log_next_sequence,
             &store,
         )
         .await;
@@ -1990,6 +2271,7 @@ mod tests {
             &restarted_manager.seen_ops,
             &restarted_manager.seen_ops_next_sequence,
             &restarted_manager.op_log,
+            &restarted_manager.op_log_next_sequence,
             &store,
         )
         .await;
@@ -2226,6 +2508,51 @@ mod tests {
         assert_eq!(manager_a.get_counter_value(key).await, 2);
         assert_eq!(read_materialized(&store_a, key), 2);
         assert_eq!(read_materialized(&store_b, key), 2);
+    }
+
+    #[tokio::test]
+    async fn source_restart_before_anti_entropy_still_serves_missed_ops() {
+        let key = "visits";
+        let addr_a = free_addr();
+        let addr_b = free_addr();
+        let store_a = temp_store();
+        let node_a_id = NodeId::new("node-a");
+
+        let config_a = SyncConfig::new()
+            .with_listen_addr(addr_a.clone())
+            .with_peer(addr_b.clone())
+            .with_reconnect_backoff(Duration::from_millis(10), Duration::from_millis(50))
+            .with_anti_entropy_interval(Duration::from_millis(10));
+        let (mut manager_a, handle_a) =
+            started_manager_with_store(node_a_id.clone(), config_a, Arc::clone(&store_a)).await;
+
+        let config_b = SyncConfig::new()
+            .with_listen_addr(addr_b)
+            .with_peer(addr_a.clone())
+            .with_reconnect_backoff(Duration::from_millis(10), Duration::from_millis(50))
+            .with_anti_entropy_interval(Duration::from_millis(10));
+        let (manager_b, _handle_b, store_b) = started_manager_with_config(config_b).await;
+
+        wait_for_connected_peer(&manager_a).await;
+        wait_for_connected_peer(&manager_b).await;
+
+        dropped_local_increment(&manager_a, &handle_a, key, 1).await;
+        manager_a.shutdown().await.unwrap();
+
+        let config_a_restart = SyncConfig::new()
+            .with_listen_addr(addr_a)
+            .with_peer(manager_b.config.listen_addr.clone().unwrap())
+            .with_reconnect_backoff(Duration::from_millis(10), Duration::from_millis(50))
+            .with_anti_entropy_interval(Duration::from_millis(10));
+        let (manager_a_restarted, _handle_a_restarted) =
+            started_manager_with_store(node_a_id, config_a_restart, Arc::clone(&store_a)).await;
+
+        wait_for_connected_peer(&manager_a_restarted).await;
+        wait_for_connected_peer(&manager_b).await;
+        wait_for_counter(&manager_b, key, 1).await;
+
+        assert_eq!(read_materialized(&store_a, key), 1);
+        assert_eq!(read_materialized(&store_b, key), 1);
     }
 
     #[tokio::test]

--- a/crates/nx-core/src/sync_manager.rs
+++ b/crates/nx-core/src/sync_manager.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
+use std::time::Duration;
 
 use nx_net::{Node, NodeConfig, NodeEvent};
 use nx_store::Store as NxStore;
@@ -89,6 +90,9 @@ pub struct SyncManager {
 
     /// Outbound broadcast drain task.
     broadcast_task: Option<JoinHandle<()>>,
+
+    /// Configured peer reconnect task.
+    reconnect_task: Option<JoinHandle<()>>,
 }
 
 impl SyncManager {
@@ -121,6 +125,7 @@ impl SyncManager {
             shutdown_tx,
             event_task: None,
             broadcast_task: None,
+            reconnect_task: None,
         }
     }
 
@@ -227,6 +232,15 @@ impl SyncManager {
             Arc::clone(&self.metrics),
         ));
 
+        self.reconnect_task = spawn_reconnect_loop(
+            Arc::clone(&node),
+            self.config.peers.clone(),
+            self.config.reconnect_initial_delay,
+            self.config.reconnect_max_delay,
+            self.shutdown_tx.subscribe(),
+            Arc::clone(&self.metrics),
+        );
+
         Ok(())
     }
 
@@ -241,12 +255,26 @@ impl SyncManager {
 
     /// Retry connecting to the peers configured at startup.
     pub async fn reconnect_configured_peers(&self) {
+        let Some(node) = self.node.as_ref() else {
+            return;
+        };
         for peer_addr in &self.config.peers {
-            if let Err(e) = self.connect_to_peer(peer_addr).await {
+            if node.is_connected_addr(peer_addr).await {
+                continue;
+            }
+            if let Err(e) = node.connect_to_peer(peer_addr).await {
                 self.metrics.record_sync_error();
                 debug!(peer = %peer_addr, error = %e, "configured peer reconnect failed");
             }
         }
+    }
+
+    /// Returns the number of connected peers, or zero before networking starts.
+    pub async fn connected_peer_count(&self) -> usize {
+        let Some(node) = self.node.as_ref() else {
+            return 0;
+        };
+        node.connected_peer_count().await
     }
 
     /// Returns the current value of a GCounter.
@@ -263,6 +291,12 @@ impl SyncManager {
             && let Err(e) = task.await
         {
             warn!(error = %e, "broadcast task failed during shutdown");
+        }
+
+        if let Some(task) = self.reconnect_task.take()
+            && let Err(e) = task.await
+        {
+            warn!(error = %e, "reconnect task failed during shutdown");
         }
 
         if let Some(node) = self.node.as_ref() {
@@ -308,6 +342,75 @@ fn spawn_broadcast_loop(
         }
         debug!("broadcast loop terminated");
     })
+}
+
+fn spawn_reconnect_loop(
+    node: Arc<Node>,
+    peers: Vec<String>,
+    initial_delay: Duration,
+    max_delay: Duration,
+    mut shutdown_rx: watch::Receiver<bool>,
+    metrics: Arc<RuntimeMetrics>,
+) -> Option<JoinHandle<()>> {
+    if peers.is_empty() {
+        return None;
+    }
+
+    Some(tokio::spawn(async move {
+        let initial_delay = normalize_reconnect_delay(initial_delay);
+        let max_delay = max_delay.max(initial_delay);
+        let mut state = peers
+            .into_iter()
+            .map(|peer| (peer, initial_delay))
+            .collect::<HashMap<_, _>>();
+
+        loop {
+            let mut sleep_for: Option<Duration> = None;
+
+            for (peer, delay) in state.iter_mut() {
+                if node.is_connected_addr(peer).await {
+                    *delay = initial_delay;
+                    continue;
+                }
+
+                let attempt_delay = *delay;
+                match node.connect_to_peer(peer).await {
+                    Ok(()) => {
+                        info!(peer = %peer, "reconnected configured peer");
+                        *delay = initial_delay;
+                    }
+                    Err(e) => {
+                        metrics.record_sync_error();
+                        debug!(peer = %peer, error = %e, delay = ?attempt_delay, "configured peer reconnect failed");
+                        sleep_for = Some(
+                            sleep_for.map_or(attempt_delay, |current| current.min(attempt_delay)),
+                        );
+                        *delay = next_reconnect_delay(attempt_delay, max_delay);
+                    }
+                }
+            }
+            let sleep_for = sleep_for.unwrap_or(initial_delay);
+
+            tokio::select! {
+                _ = shutdown_rx.changed() => {
+                    if *shutdown_rx.borrow() {
+                        debug!("reconnect loop shutdown requested");
+                        break;
+                    }
+                }
+                _ = tokio::time::sleep(sleep_for) => {}
+            }
+        }
+        debug!("reconnect loop terminated");
+    }))
+}
+
+fn normalize_reconnect_delay(delay: Duration) -> Duration {
+    delay.max(Duration::from_millis(1))
+}
+
+fn next_reconnect_delay(current: Duration, max_delay: Duration) -> Duration {
+    current.saturating_mul(2).min(max_delay.max(current))
 }
 
 async fn broadcast_batch(
@@ -558,6 +661,17 @@ mod tests {
         }
     }
 
+    async fn wait_for_connected_peer(manager: &SyncManager) {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            if manager.connected_peer_count().await > 0 {
+                return;
+            }
+            assert!(Instant::now() < deadline, "manager did not connect to peer");
+            sleep(Duration::from_millis(25)).await;
+        }
+    }
+
     async fn local_increment(handle: &SyncHandle, key: &str, delta: u64) {
         {
             let counters_arc = handle.counters();
@@ -582,6 +696,43 @@ mod tests {
         let handle = manager.handle();
         manager.start().await.unwrap();
         (manager, handle, store)
+    }
+
+    async fn started_manager_with_config(
+        config: SyncConfig,
+    ) -> (SyncManager, SyncHandle, Arc<NxStore>) {
+        let store = temp_store();
+        let mut manager =
+            SyncManager::new(NodeId::generate(), config, Arc::clone(&store), metrics());
+        let handle = manager.handle();
+        manager.start().await.unwrap();
+        (manager, handle, store)
+    }
+
+    #[test]
+    fn reconnect_backoff_doubles_until_max() {
+        let max = Duration::from_secs(5);
+
+        assert_eq!(
+            next_reconnect_delay(Duration::from_millis(500), max),
+            Duration::from_secs(1)
+        );
+        assert_eq!(
+            next_reconnect_delay(Duration::from_secs(4), max),
+            Duration::from_secs(5)
+        );
+        assert_eq!(
+            next_reconnect_delay(Duration::from_secs(5), max),
+            Duration::from_secs(5)
+        );
+    }
+
+    #[test]
+    fn reconnect_delay_is_never_zero() {
+        assert_eq!(
+            normalize_reconnect_delay(Duration::ZERO),
+            Duration::from_millis(1)
+        );
     }
 
     #[tokio::test]
@@ -678,6 +829,28 @@ mod tests {
         wait_for_counter(&manager_b, key, 2).await;
         assert_eq!(read_materialized(&store_a, key), 2);
         assert_eq!(read_materialized(&store_b, key), 2);
+    }
+
+    #[tokio::test]
+    async fn reconnect_loop_connects_configured_peer_that_starts_later() {
+        let key = "visits";
+        let addr_a = free_addr();
+        let addr_b = free_addr();
+
+        let config_a = SyncConfig::new()
+            .with_listen_addr(addr_a)
+            .with_peer(addr_b.clone())
+            .with_reconnect_backoff(Duration::from_millis(10), Duration::from_millis(50));
+        let (manager_a, handle_a, _store_a) = started_manager_with_config(config_a).await;
+
+        let config_b = SyncConfig::new().with_listen_addr(addr_b);
+        let (manager_b, _handle_b, store_b) = started_manager_with_config(config_b).await;
+
+        wait_for_connected_peer(&manager_a).await;
+        local_increment(&handle_a, key, 1).await;
+
+        wait_for_counter(&manager_b, key, 1).await;
+        assert_eq!(read_materialized(&store_b, key), 1);
     }
 
     #[tokio::test]

--- a/crates/nx-core/src/sync_manager.rs
+++ b/crates/nx-core/src/sync_manager.rs
@@ -1054,6 +1054,7 @@ async fn handle_node_event(event: NodeEvent, context: &NodeEventContext) {
     match event {
         NodeEvent::OpsReceived { from, ops } => {
             debug!(from = %from, count = ops.len(), "received ops from peer");
+            let mut last_applied_op_id = None;
             for op in &ops {
                 let apply_context = RemoteOpApplyContext {
                     counters: &context.counters,
@@ -1068,14 +1069,16 @@ async fn handle_node_event(event: NodeEvent, context: &NodeEventContext) {
                 if let Err(e) = apply_remote_op(op, &apply_context).await {
                     context.metrics.record_sync_error();
                     error!(error = %e, "failed to apply remote op");
+                    break;
                 }
+                last_applied_op_id = Some(op.id.as_str().to_string());
             }
-            if let Some(last_op) = ops.last() {
+            if let Some(op_id) = last_applied_op_id {
                 context
                     .anti_entropy_watermarks
                     .write()
                     .await
-                    .insert(from, last_op.id.as_str().to_string());
+                    .insert(from, op_id);
             }
         }
         NodeEvent::PullRequested {
@@ -1305,6 +1308,14 @@ fn hydrate_op_log(store: &NxStore, limit: usize) -> anyhow::Result<(Vec<Op>, u64
                 continue;
             }
         };
+        if op.id.as_str() != op_id {
+            warn!(
+                key_op_id = %op_id,
+                value_op_id = %op.id,
+                "skipping durable op log entry with mismatched OpId"
+            );
+            continue;
+        }
 
         next_sequence = next_sequence.max(sequence.saturating_add(1));
         ordered.push((sequence, op));
@@ -1649,6 +1660,12 @@ mod tests {
 
     fn seen_op_exists(store: &NxStore, op_id: &str) -> bool {
         store.get(&seen_op_store_key(op_id)).unwrap().is_some()
+    }
+
+    fn write_durable_op_log_entry(store: &NxStore, key_op_id: &str, sequence: u64, op: &Op) {
+        let key = op_log_store_key(key_op_id);
+        let value = encode_durable_op_log_value(sequence, op).unwrap();
+        store.set(&key, &value).unwrap();
     }
 
     fn test_event_context(
@@ -2005,6 +2022,21 @@ mod tests {
         assert!(!seen_op_exists(&store, "op-a"));
         assert!(seen_op_exists(&store, "op-b"));
         assert!(seen_op_exists(&store, "op-c"));
+    }
+
+    #[test]
+    fn hydrate_op_log_skips_key_value_op_id_mismatch() {
+        let store = temp_store();
+        let op_a = Op::gcounter_increment(NodeId::new("node-a"), "counter:visits", 1);
+        let op_b = Op::gcounter_increment(NodeId::new("node-b"), "counter:visits", 1);
+
+        write_durable_op_log_entry(&store, op_a.id.as_str(), 1, &op_a);
+        write_durable_op_log_entry(&store, "different-op-id", 2, &op_b);
+
+        let (op_log, next_sequence) = hydrate_op_log(&store, 10).unwrap();
+
+        assert_eq!(op_log, vec![op_a]);
+        assert_eq!(next_sequence, 2);
     }
 
     #[test]

--- a/crates/nx-core/src/sync_manager.rs
+++ b/crates/nx-core/src/sync_manager.rs
@@ -51,6 +51,27 @@ struct ReconnectLoopContext {
     peer_health: Arc<RwLock<HashMap<String, PeerHealth>>>,
 }
 
+struct AntiEntropyLoopContext {
+    node: Arc<Node>,
+    peers: Vec<String>,
+    interval: Duration,
+    shutdown_rx: watch::Receiver<bool>,
+    metrics: Arc<RuntimeMetrics>,
+}
+
+#[derive(Clone)]
+struct NodeEventContext {
+    counters: Arc<RwLock<HashMap<String, GCounter>>>,
+    seen_ops: Arc<RwLock<HashSet<String>>>,
+    op_log: Arc<RwLock<Vec<Op>>>,
+    op_log_limit: usize,
+    store: Arc<NxStore>,
+    metrics: Arc<RuntimeMetrics>,
+    node: Arc<Node>,
+    peer_health: Arc<RwLock<HashMap<String, PeerHealth>>>,
+    peer_dead_after_failures: u32,
+}
+
 struct PeerReconnectState {
     addr: String,
     delay: Duration,
@@ -154,6 +175,9 @@ pub struct SyncManager {
     /// OpId
     seen_ops: Arc<RwLock<HashSet<String>>>,
 
+    /// In-memory operation log used to answer anti-entropy pull requests.
+    op_log: Arc<RwLock<Vec<Op>>>,
+
     /// Health state for configured peers, keyed by configured address.
     peer_health: Arc<RwLock<HashMap<String, PeerHealth>>>,
 
@@ -174,6 +198,9 @@ pub struct SyncManager {
 
     /// Configured peer reconnect task.
     reconnect_task: Option<JoinHandle<()>>,
+
+    /// Periodic anti-entropy pull task.
+    anti_entropy_task: Option<JoinHandle<()>>,
 }
 
 impl SyncManager {
@@ -185,6 +212,7 @@ impl SyncManager {
         metrics: Arc<RuntimeMetrics>,
     ) -> Self {
         let (op_tx, op_rx) = mpsc::channel(config.queued_ops_limit.max(1));
+        let op_log_limit = normalize_op_log_limit(config.op_log_limit);
         let (shutdown_tx, _shutdown_rx) = watch::channel(false);
         let mut counters = HashMap::new();
         let peer_health = config
@@ -206,6 +234,7 @@ impl SyncManager {
             store,
             metrics,
             seen_ops: Arc::new(RwLock::new(HashSet::new())),
+            op_log: Arc::new(RwLock::new(Vec::with_capacity(op_log_limit.min(1024)))),
             peer_health: Arc::new(RwLock::new(peer_health)),
             op_tx,
             op_rx: Some(op_rx),
@@ -213,6 +242,7 @@ impl SyncManager {
             event_task: None,
             broadcast_task: None,
             reconnect_task: None,
+            anti_entropy_task: None,
         }
     }
 
@@ -292,13 +322,19 @@ impl SyncManager {
         self.node = Some(Arc::clone(&node));
 
         // Inbound loop: apply remote ops into the counter registry.
-        let counters = Arc::clone(&self.counters);
-        let seen_ops = Arc::clone(&self.seen_ops);
-        let store = Arc::clone(&self.store);
-        let metrics = Arc::clone(&self.metrics);
-        let peer_health = Arc::clone(&self.peer_health);
-        let peer_dead_after_failures =
-            normalize_peer_dead_after_failures(self.config.peer_dead_after_failures);
+        let event_context = NodeEventContext {
+            counters: Arc::clone(&self.counters),
+            seen_ops: Arc::clone(&self.seen_ops),
+            op_log: Arc::clone(&self.op_log),
+            op_log_limit: normalize_op_log_limit(self.config.op_log_limit),
+            store: Arc::clone(&self.store),
+            metrics: Arc::clone(&self.metrics),
+            node: Arc::clone(&node),
+            peer_health: Arc::clone(&self.peer_health),
+            peer_dead_after_failures: normalize_peer_dead_after_failures(
+                self.config.peer_dead_after_failures,
+            ),
+        };
         let mut shutdown_rx = self.shutdown_tx.subscribe();
         self.event_task = Some(tokio::spawn(async move {
             loop {
@@ -306,15 +342,7 @@ impl SyncManager {
                     _ = shutdown_rx.changed() => {
                         if *shutdown_rx.borrow() {
                             debug!("event loop shutdown requested");
-                            drain_node_events(
-                                &mut event_rx,
-                                &counters,
-                                &seen_ops,
-                                &store,
-                                &metrics,
-                                &peer_health,
-                                peer_dead_after_failures,
-                            ).await;
+                            drain_node_events(&mut event_rx, &event_context).await;
                             break;
                         }
                     }
@@ -322,15 +350,7 @@ impl SyncManager {
                         let Some(event) = event else {
                             break;
                         };
-                        handle_node_event(
-                            event,
-                            &counters,
-                            &seen_ops,
-                            &store,
-                            &metrics,
-                            &peer_health,
-                            peer_dead_after_failures,
-                        ).await;
+                        handle_node_event(event, &event_context).await;
                     }
                 }
             }
@@ -345,6 +365,9 @@ impl SyncManager {
         self.broadcast_task = Some(spawn_broadcast_loop(
             Arc::clone(&node),
             op_rx,
+            Arc::clone(&self.seen_ops),
+            Arc::clone(&self.op_log),
+            normalize_op_log_limit(self.config.op_log_limit),
             self.shutdown_tx.subscribe(),
             Arc::clone(&self.metrics),
         ));
@@ -359,6 +382,14 @@ impl SyncManager {
             shutdown_rx: self.shutdown_tx.subscribe(),
             metrics: Arc::clone(&self.metrics),
             peer_health: Arc::clone(&self.peer_health),
+        });
+
+        self.anti_entropy_task = spawn_anti_entropy_loop(AntiEntropyLoopContext {
+            node: Arc::clone(&node),
+            peers: self.config.peers.clone(),
+            interval: self.config.anti_entropy_interval,
+            shutdown_rx: self.shutdown_tx.subscribe(),
+            metrics: Arc::clone(&self.metrics),
         });
 
         Ok(())
@@ -433,6 +464,12 @@ impl SyncManager {
             warn!(error = %e, "reconnect task failed during shutdown");
         }
 
+        if let Some(task) = self.anti_entropy_task.take()
+            && let Err(e) = task.await
+        {
+            warn!(error = %e, "anti-entropy task failed during shutdown");
+        }
+
         if let Some(node) = self.node.as_ref() {
             node.shutdown().await;
         }
@@ -453,6 +490,9 @@ impl SyncManager {
 fn spawn_broadcast_loop(
     node: Arc<Node>,
     mut op_rx: mpsc::Receiver<Op>,
+    seen_ops: Arc<RwLock<HashSet<String>>>,
+    op_log: Arc<RwLock<Vec<Op>>>,
+    op_log_limit: usize,
     mut shutdown_rx: watch::Receiver<bool>,
     metrics: Arc<RuntimeMetrics>,
 ) -> JoinHandle<()> {
@@ -462,7 +502,14 @@ fn spawn_broadcast_loop(
                 _ = shutdown_rx.changed() => {
                     if *shutdown_rx.borrow() {
                         debug!("broadcast loop shutdown requested");
-                        drain_broadcast_queue(&node, &mut op_rx, &metrics).await;
+                        drain_broadcast_queue(
+                            &node,
+                            &mut op_rx,
+                            &seen_ops,
+                            &op_log,
+                            op_log_limit,
+                            &metrics,
+                        ).await;
                         break;
                     }
                 }
@@ -470,7 +517,15 @@ fn spawn_broadcast_loop(
                     let Some(first) = op else {
                         break;
                     };
-                    broadcast_batch(&node, &mut op_rx, first, &metrics).await;
+                    broadcast_batch(
+                        &node,
+                        &mut op_rx,
+                        first,
+                        &seen_ops,
+                        &op_log,
+                        op_log_limit,
+                        &metrics,
+                    ).await;
                 }
             }
         }
@@ -612,8 +667,59 @@ fn spawn_reconnect_loop(context: ReconnectLoopContext) -> Option<JoinHandle<()>>
     }))
 }
 
+fn spawn_anti_entropy_loop(context: AntiEntropyLoopContext) -> Option<JoinHandle<()>> {
+    let AntiEntropyLoopContext {
+        node,
+        peers,
+        interval,
+        mut shutdown_rx,
+        metrics,
+    } = context;
+
+    if peers.is_empty() {
+        return None;
+    }
+
+    Some(tokio::spawn(async move {
+        let interval = normalize_anti_entropy_interval(interval);
+        loop {
+            tokio::select! {
+                _ = shutdown_rx.changed() => {
+                    if *shutdown_rx.borrow() {
+                        debug!("anti-entropy loop shutdown requested");
+                        break;
+                    }
+                }
+                _ = tokio::time::sleep(interval) => {
+                    for peer in &peers {
+                        if !node.is_connected_addr(peer).await {
+                            continue;
+                        }
+
+                        if let Err(e) = node.send_pull_since_to_addr(peer, None).await {
+                            metrics.record_sync_error();
+                            debug!(peer = %peer, error = %e, "anti-entropy pull failed");
+                        } else {
+                            debug!(peer = %peer, "anti-entropy pull requested");
+                        }
+                    }
+                }
+            }
+        }
+        debug!("anti-entropy loop terminated");
+    }))
+}
+
 fn normalize_reconnect_delay(delay: Duration) -> Duration {
     delay.max(Duration::from_millis(1))
+}
+
+fn normalize_anti_entropy_interval(interval: Duration) -> Duration {
+    interval.max(Duration::from_millis(1))
+}
+
+fn normalize_op_log_limit(limit: usize) -> usize {
+    limit.max(1)
 }
 
 fn next_reconnect_delay(current: Duration, max_delay: Duration) -> Duration {
@@ -684,6 +790,9 @@ async fn broadcast_batch(
     node: &Arc<Node>,
     op_rx: &mut mpsc::Receiver<Op>,
     first: Op,
+    seen_ops: &Arc<RwLock<HashSet<String>>>,
+    op_log: &Arc<RwLock<Vec<Op>>>,
+    op_log_limit: usize,
     metrics: &Arc<RuntimeMetrics>,
 ) {
     let mut batch = Vec::with_capacity(BROADCAST_BATCH_MAX);
@@ -698,6 +807,7 @@ async fn broadcast_batch(
     }
 
     let count = batch.len();
+    remember_ops(seen_ops, op_log, op_log_limit, &batch).await;
     let started = std::time::Instant::now();
     if let Err(e) = node.broadcast_ops(batch).await {
         metrics.record_sync_error();
@@ -712,53 +822,90 @@ async fn broadcast_batch(
 async fn drain_broadcast_queue(
     node: &Arc<Node>,
     op_rx: &mut mpsc::Receiver<Op>,
+    seen_ops: &Arc<RwLock<HashSet<String>>>,
+    op_log: &Arc<RwLock<Vec<Op>>>,
+    op_log_limit: usize,
     metrics: &Arc<RuntimeMetrics>,
 ) {
     while let Ok(first) = op_rx.try_recv() {
-        broadcast_batch(node, op_rx, first, metrics).await;
+        broadcast_batch(node, op_rx, first, seen_ops, op_log, op_log_limit, metrics).await;
     }
 }
 
-async fn drain_node_events(
-    event_rx: &mut mpsc::Receiver<NodeEvent>,
-    counters: &Arc<RwLock<HashMap<String, GCounter>>>,
+async fn remember_ops(
     seen_ops: &Arc<RwLock<HashSet<String>>>,
-    store: &Arc<NxStore>,
-    metrics: &Arc<RuntimeMetrics>,
-    peer_health: &Arc<RwLock<HashMap<String, PeerHealth>>>,
-    peer_dead_after_failures: u32,
+    op_log: &Arc<RwLock<Vec<Op>>>,
+    op_log_limit: usize,
+    ops: &[Op],
 ) {
+    let mut seen = seen_ops.write().await;
+    let mut log = op_log.write().await;
+    for op in ops {
+        if seen.insert(op.id.as_str().to_string()) {
+            log.push(op.clone());
+        }
+    }
+    prune_op_log(&mut log, op_log_limit);
+}
+
+fn prune_op_log(log: &mut Vec<Op>, limit: usize) {
+    let limit = normalize_op_log_limit(limit);
+    if log.len() > limit {
+        let remove_count = log.len() - limit;
+        log.drain(..remove_count);
+    }
+}
+
+async fn op_log_since(op_log: &Arc<RwLock<Vec<Op>>>, since_op_id: Option<&str>) -> Vec<Op> {
+    let log = op_log.read().await;
+    match since_op_id {
+        Some(op_id) => log
+            .iter()
+            .position(|op| op.id.as_str() == op_id)
+            .map_or_else(|| log.clone(), |index| log[index + 1..].to_vec()),
+        None => log.clone(),
+    }
+}
+
+async fn drain_node_events(event_rx: &mut mpsc::Receiver<NodeEvent>, context: &NodeEventContext) {
     while let Ok(event) = event_rx.try_recv() {
-        handle_node_event(
-            event,
-            counters,
-            seen_ops,
-            store,
-            metrics,
-            peer_health,
-            peer_dead_after_failures,
-        )
-        .await;
+        handle_node_event(event, context).await;
     }
 }
 
-async fn handle_node_event(
-    event: NodeEvent,
-    counters: &Arc<RwLock<HashMap<String, GCounter>>>,
-    seen_ops: &Arc<RwLock<HashSet<String>>>,
-    store: &Arc<NxStore>,
-    metrics: &Arc<RuntimeMetrics>,
-    peer_health: &Arc<RwLock<HashMap<String, PeerHealth>>>,
-    peer_dead_after_failures: u32,
-) {
+async fn handle_node_event(event: NodeEvent, context: &NodeEventContext) {
     match event {
         NodeEvent::OpsReceived { from, ops } => {
             debug!(from = %from, count = ops.len(), "received ops from peer");
             for op in ops {
-                if let Err(e) = apply_remote_op(&op, counters, seen_ops, store, metrics).await {
-                    metrics.record_sync_error();
+                if let Err(e) = apply_remote_op(
+                    &op,
+                    &context.counters,
+                    &context.seen_ops,
+                    &context.op_log,
+                    context.op_log_limit,
+                    &context.store,
+                    &context.metrics,
+                )
+                .await
+                {
+                    context.metrics.record_sync_error();
                     error!(error = %e, "failed to apply remote op");
                 }
+            }
+        }
+        NodeEvent::PullRequested {
+            from,
+            addr,
+            since_op_id,
+        } => {
+            let ops = op_log_since(&context.op_log, since_op_id.as_deref()).await;
+            let count = ops.len();
+            if let Err(e) = context.node.send_ops_to_addr(&addr, ops).await {
+                context.metrics.record_sync_error();
+                warn!(peer = %from, addr = %addr, error = %e, "failed to answer pull request");
+            } else {
+                debug!(peer = %from, addr = %addr, count, "answered pull request");
             }
         }
         NodeEvent::PeerConnected {
@@ -766,9 +913,9 @@ async fn handle_node_event(
             addr,
             peers_connected,
         } => {
-            mark_known_peer_success(peer_health, &addr).await;
-            metrics.record_peer_connect();
-            metrics.set_peers_connected(peers_connected);
+            mark_known_peer_success(&context.peer_health, &addr).await;
+            context.metrics.record_peer_connect();
+            context.metrics.set_peers_connected(peers_connected);
             info!(peer = %node_id, addr = %addr, "peer connected");
         }
         NodeEvent::PeerDisconnected {
@@ -776,9 +923,14 @@ async fn handle_node_event(
             addr,
             peers_connected,
         } => {
-            mark_known_peer_failure(peer_health, &addr, peer_dead_after_failures).await;
-            metrics.record_peer_disconnect();
-            metrics.set_peers_connected(peers_connected);
+            mark_known_peer_failure(
+                &context.peer_health,
+                &addr,
+                context.peer_dead_after_failures,
+            )
+            .await;
+            context.metrics.record_peer_disconnect();
+            context.metrics.set_peers_connected(peers_connected);
             info!(peer = %node_id, addr = %addr, "peer disconnected");
         }
     }
@@ -860,6 +1012,8 @@ async fn apply_remote_op(
     op: &Op,
     counters: &Arc<RwLock<HashMap<String, GCounter>>>,
     seen_ops: &Arc<RwLock<HashSet<String>>>,
+    op_log: &Arc<RwLock<Vec<Op>>>,
+    op_log_limit: usize,
     store: &Arc<NxStore>,
     metrics: &Arc<RuntimeMetrics>,
 ) -> anyhow::Result<()> {
@@ -890,7 +1044,11 @@ async fn apply_remote_op(
 
     {
         let mut seen = seen_ops.write().await;
-        seen.insert(op.id.as_str().to_string());
+        if seen.insert(op.id.as_str().to_string()) {
+            let mut log = op_log.write().await;
+            log.push(op.clone());
+            prune_op_log(&mut log, op_log_limit);
+        }
     }
 
     Ok(())
@@ -929,6 +1087,30 @@ mod tests {
         let mut buf = [0u8; 8];
         buf.copy_from_slice(&bytes);
         u64::from_le_bytes(buf)
+    }
+
+    fn test_event_context(
+        counters: Arc<RwLock<HashMap<String, GCounter>>>,
+        seen_ops: Arc<RwLock<HashSet<String>>>,
+        op_log: Arc<RwLock<Vec<Op>>>,
+        store: Arc<NxStore>,
+        metrics: Arc<RuntimeMetrics>,
+        peer_health: Arc<RwLock<HashMap<String, PeerHealth>>>,
+    ) -> NodeEventContext {
+        NodeEventContext {
+            counters,
+            seen_ops,
+            op_log,
+            op_log_limit: 1024,
+            store,
+            metrics,
+            node: Arc::new(Node::new(NodeConfig::new(
+                NodeId::generate(),
+                "127.0.0.1:0",
+            ))),
+            peer_health,
+            peer_dead_after_failures: 2,
+        }
     }
 
     async fn wait_for_counter(manager: &SyncManager, key: &str, expected: u64) {
@@ -1064,6 +1246,48 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn op_log_since_returns_ops_after_known_id() {
+        let op_a = Op::gcounter_increment(NodeId::new("node-a"), "counter:visits", 1);
+        let op_b = Op::gcounter_increment(NodeId::new("node-b"), "counter:visits", 2);
+        let op_c = Op::gcounter_increment(NodeId::new("node-c"), "counter:visits", 3);
+        let op_log = Arc::new(RwLock::new(vec![op_a.clone(), op_b.clone(), op_c.clone()]));
+
+        assert_eq!(
+            op_log_since(&op_log, None).await,
+            vec![op_a, op_b.clone(), op_c.clone()]
+        );
+        assert_eq!(
+            op_log_since(&op_log, Some(op_b.id.as_str())).await,
+            vec![op_c]
+        );
+    }
+
+    #[tokio::test]
+    async fn remember_ops_prunes_op_log_to_configured_limit() {
+        let seen_ops = Arc::new(RwLock::new(HashSet::new()));
+        let op_log = Arc::new(RwLock::new(Vec::new()));
+        let op_a = Op::gcounter_increment(NodeId::new("node-a"), "counter:visits", 1);
+        let op_b = Op::gcounter_increment(NodeId::new("node-b"), "counter:visits", 2);
+        let op_c = Op::gcounter_increment(NodeId::new("node-c"), "counter:visits", 3);
+
+        remember_ops(
+            &seen_ops,
+            &op_log,
+            2,
+            &[op_a.clone(), op_b.clone(), op_c.clone()],
+        )
+        .await;
+
+        assert_eq!(op_log.read().await.as_slice(), &[op_b, op_c]);
+        assert!(seen_ops.read().await.contains(op_a.id.as_str()));
+    }
+
+    #[test]
+    fn op_log_limit_is_never_zero() {
+        assert_eq!(normalize_op_log_limit(0), 1);
+    }
+
     #[test]
     fn peer_health_marks_suspect_then_dead_after_failures() {
         let mut peer_health = HashMap::new();
@@ -1109,8 +1333,17 @@ mod tests {
         )])));
         let counters = Arc::new(RwLock::new(HashMap::new()));
         let seen_ops = Arc::new(RwLock::new(HashSet::new()));
+        let op_log = Arc::new(RwLock::new(Vec::new()));
         let store = temp_store();
         let metrics = metrics();
+        let context = test_event_context(
+            Arc::clone(&counters),
+            Arc::clone(&seen_ops),
+            Arc::clone(&op_log),
+            Arc::clone(&store),
+            Arc::clone(&metrics),
+            Arc::clone(&peer_health),
+        );
         let node_id = NodeId::generate();
 
         handle_node_event(
@@ -1119,12 +1352,7 @@ mod tests {
                 addr: peer.to_string(),
                 peers_connected: 1,
             },
-            &counters,
-            &seen_ops,
-            &store,
-            &metrics,
-            &peer_health,
-            2,
+            &context,
         )
         .await;
         assert_eq!(
@@ -1138,12 +1366,7 @@ mod tests {
                 addr: peer.to_string(),
                 peers_connected: 0,
             },
-            &counters,
-            &seen_ops,
-            &store,
-            &metrics,
-            &peer_health,
-            2,
+            &context,
         )
         .await;
         let health = *peer_health.read().await.get(peer).unwrap();
@@ -1156,8 +1379,17 @@ mod tests {
         let peer_health = Arc::new(RwLock::new(HashMap::new()));
         let counters = Arc::new(RwLock::new(HashMap::new()));
         let seen_ops = Arc::new(RwLock::new(HashSet::new()));
+        let op_log = Arc::new(RwLock::new(Vec::new()));
         let store = temp_store();
         let metrics = metrics();
+        let context = test_event_context(
+            Arc::clone(&counters),
+            Arc::clone(&seen_ops),
+            Arc::clone(&op_log),
+            Arc::clone(&store),
+            Arc::clone(&metrics),
+            Arc::clone(&peer_health),
+        );
 
         handle_node_event(
             NodeEvent::PeerConnected {
@@ -1165,12 +1397,7 @@ mod tests {
                 addr: "127.0.0.1:42001".to_string(),
                 peers_connected: 1,
             },
-            &counters,
-            &seen_ops,
-            &store,
-            &metrics,
-            &peer_health,
-            1,
+            &context,
         )
         .await;
 
@@ -1182,10 +1409,11 @@ mod tests {
         let store = temp_store();
         let counters = Arc::new(RwLock::new(HashMap::new()));
         let seen_ops = Arc::new(RwLock::new(HashSet::new()));
+        let op_log = Arc::new(RwLock::new(Vec::new()));
         let origin = NodeId::new("remote-a");
         let op = Op::gcounter_increment(origin, "counter:visits", 3);
 
-        apply_remote_op(&op, &counters, &seen_ops, &store, &metrics())
+        apply_remote_op(&op, &counters, &seen_ops, &op_log, 1024, &store, &metrics())
             .await
             .unwrap();
 
@@ -1202,13 +1430,14 @@ mod tests {
         let store = temp_store();
         let counters = Arc::new(RwLock::new(HashMap::new()));
         let seen_ops = Arc::new(RwLock::new(HashSet::new()));
+        let op_log = Arc::new(RwLock::new(Vec::new()));
         let origin = NodeId::new("remote-a");
         let op = Op::gcounter_increment(origin, "counter:visits", 3);
 
-        apply_remote_op(&op, &counters, &seen_ops, &store, &metrics())
+        apply_remote_op(&op, &counters, &seen_ops, &op_log, 1024, &store, &metrics())
             .await
             .unwrap();
-        apply_remote_op(&op, &counters, &seen_ops, &store, &metrics())
+        apply_remote_op(&op, &counters, &seen_ops, &op_log, 1024, &store, &metrics())
             .await
             .unwrap();
 
@@ -1293,6 +1522,29 @@ mod tests {
 
         wait_for_counter(&manager_b, key, 1).await;
         assert_eq!(read_materialized(&store_b, key), 1);
+    }
+
+    #[tokio::test]
+    async fn anti_entropy_pull_converges_peer_that_missed_broadcast() {
+        let key = "visits";
+        let addr_a = free_addr();
+        let addr_b = free_addr();
+
+        let config_a = SyncConfig::new().with_listen_addr(addr_a.clone());
+        let (manager_a, handle_a, _store_a) = started_manager_with_config(config_a).await;
+
+        local_increment(&handle_a, key, 1).await;
+
+        let config_b = SyncConfig::new()
+            .with_listen_addr(addr_b)
+            .with_peer(addr_a)
+            .with_anti_entropy_interval(Duration::from_millis(10));
+        let (manager_b, _handle_b, store_b) = started_manager_with_config(config_b).await;
+
+        wait_for_connected_peer(&manager_b).await;
+        wait_for_counter(&manager_b, key, 1).await;
+        assert_eq!(read_materialized(&store_b, key), 1);
+        assert_eq!(manager_a.get_counter_value(key).await, 1);
     }
 
     #[tokio::test]

--- a/crates/nx-core/src/sync_manager.rs
+++ b/crates/nx-core/src/sync_manager.rs
@@ -422,7 +422,8 @@ impl SyncManager {
             .with_peers(self.config.peers.clone())
             .with_max_peers(self.config.max_peers)
             .with_max_message_size(self.config.max_message_size)
-            .with_socket_timeout(self.config.socket_timeout);
+            .with_socket_timeout(self.config.socket_timeout)
+            .with_serialization_format(self.config.serialization_format);
 
         if let Some(tls) = self.config.tls.clone() {
             node_config = node_config.with_tls(tls);

--- a/crates/nx-core/src/sync_manager.rs
+++ b/crates/nx-core/src/sync_manager.rs
@@ -1,5 +1,8 @@
 use std::collections::{HashMap, HashSet, VecDeque};
-use std::sync::Arc;
+use std::sync::{
+    Arc,
+    atomic::{AtomicU64, Ordering},
+};
 use std::time::{Duration, Instant as StdInstant};
 
 use nx_net::{NetError, Node, NodeConfig, NodeEvent};
@@ -16,6 +19,13 @@ use crate::sync_config::SyncConfig;
 const BROADCAST_BATCH_MAX: usize = 64;
 const GCOUNTER_STORE_PREFIX: &str = "__nx/crdt/gcounter/";
 const GCOUNTER_STATE_STORE_PREFIX: &str = "__nx/crdt/state/gcounter/";
+const SEEN_OP_STORE_PREFIX: &str = "__nx/crdt/seen-op/";
+
+#[derive(Debug, PartialEq, Eq)]
+enum SeenOpsInsert {
+    AlreadySeen,
+    Inserted { evicted: Vec<String> },
+}
 
 /// Health state for a configured peer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -56,26 +66,30 @@ impl SeenOps {
         }
     }
 
+    #[cfg(test)]
     fn contains(&self, op_id: &str) -> bool {
         self.ids.contains(op_id)
     }
 
-    fn insert(&mut self, op_id: impl Into<String>) -> bool {
+    fn insert(&mut self, op_id: impl Into<String>) -> SeenOpsInsert {
         let op_id = op_id.into();
         if !self.ids.insert(op_id.clone()) {
-            return false;
+            return SeenOpsInsert::AlreadySeen;
         }
 
         self.order.push_back(op_id);
+        let mut evicted_ids = Vec::new();
         while self.order.len() > self.limit {
             if let Some(evicted) = self.order.pop_front() {
                 self.ids.remove(&evicted);
+                evicted_ids.push(evicted);
             }
         }
-        true
+        SeenOpsInsert::Inserted {
+            evicted: evicted_ids,
+        }
     }
 
-    #[cfg(test)]
     fn len(&self) -> usize {
         self.ids.len()
     }
@@ -101,10 +115,31 @@ struct AntiEntropyLoopContext {
     metrics: Arc<RuntimeMetrics>,
 }
 
+struct BroadcastLoopContext {
+    node: Arc<Node>,
+    seen_ops: Arc<RwLock<SeenOps>>,
+    seen_ops_next_sequence: Arc<AtomicU64>,
+    op_log: Arc<RwLock<Vec<Op>>>,
+    op_log_limit: usize,
+    store: Arc<NxStore>,
+    metrics: Arc<RuntimeMetrics>,
+}
+
+struct RemoteOpApplyContext<'a> {
+    counters: &'a Arc<RwLock<HashMap<String, GCounter>>>,
+    seen_ops: &'a Arc<RwLock<SeenOps>>,
+    seen_ops_next_sequence: &'a Arc<AtomicU64>,
+    op_log: &'a Arc<RwLock<Vec<Op>>>,
+    op_log_limit: usize,
+    store: &'a Arc<NxStore>,
+    metrics: &'a Arc<RuntimeMetrics>,
+}
+
 #[derive(Clone)]
 struct NodeEventContext {
     counters: Arc<RwLock<HashMap<String, GCounter>>>,
     seen_ops: Arc<RwLock<SeenOps>>,
+    seen_ops_next_sequence: Arc<AtomicU64>,
     op_log: Arc<RwLock<Vec<Op>>>,
     op_log_limit: usize,
     store: Arc<NxStore>,
@@ -217,6 +252,9 @@ pub struct SyncManager {
     /// OpId
     seen_ops: Arc<RwLock<SeenOps>>,
 
+    /// Monotonic sequence used to retain recent durable dedup metadata.
+    seen_ops_next_sequence: Arc<AtomicU64>,
+
     /// In-memory operation log used to answer anti-entropy pull requests.
     op_log: Arc<RwLock<Vec<Op>>>,
 
@@ -264,6 +302,14 @@ impl SyncManager {
             .map(|peer| (peer.clone(), PeerHealth::default()))
             .collect::<HashMap<_, _>>();
 
+        let (seen_ops, seen_ops_next_sequence) = match hydrate_seen_ops(&store, seen_ops_limit) {
+            Ok(hydrated) => hydrated,
+            Err(e) => {
+                warn!(error = %e, "failed to hydrate seen OpIds");
+                (SeenOps::new(seen_ops_limit), 0)
+            }
+        };
+
         if let Err(e) = hydrate_gcounter_registry(&store, &node_id, &mut counters) {
             warn!(error = %e, "failed to hydrate GCounter registry");
         }
@@ -276,7 +322,8 @@ impl SyncManager {
             counters,
             store,
             metrics,
-            seen_ops: Arc::new(RwLock::new(SeenOps::new(seen_ops_limit))),
+            seen_ops: Arc::new(RwLock::new(seen_ops)),
+            seen_ops_next_sequence: Arc::new(AtomicU64::new(seen_ops_next_sequence)),
             op_log: Arc::new(RwLock::new(Vec::with_capacity(op_log_limit.min(1024)))),
             peer_health: Arc::new(RwLock::new(peer_health)),
             op_tx,
@@ -368,6 +415,7 @@ impl SyncManager {
         let event_context = NodeEventContext {
             counters: Arc::clone(&self.counters),
             seen_ops: Arc::clone(&self.seen_ops),
+            seen_ops_next_sequence: Arc::clone(&self.seen_ops_next_sequence),
             op_log: Arc::clone(&self.op_log),
             op_log_limit: normalize_op_log_limit(self.config.op_log_limit),
             store: Arc::clone(&self.store),
@@ -406,13 +454,17 @@ impl SyncManager {
             .take()
             .expect("op_rx already taken: SyncManager::start called twice?");
         self.broadcast_task = Some(spawn_broadcast_loop(
-            Arc::clone(&node),
+            BroadcastLoopContext {
+                node: Arc::clone(&node),
+                seen_ops: Arc::clone(&self.seen_ops),
+                seen_ops_next_sequence: Arc::clone(&self.seen_ops_next_sequence),
+                op_log: Arc::clone(&self.op_log),
+                op_log_limit: normalize_op_log_limit(self.config.op_log_limit),
+                store: Arc::clone(&self.store),
+                metrics: Arc::clone(&self.metrics),
+            },
             op_rx,
-            Arc::clone(&self.seen_ops),
-            Arc::clone(&self.op_log),
-            normalize_op_log_limit(self.config.op_log_limit),
             self.shutdown_tx.subscribe(),
-            Arc::clone(&self.metrics),
         ));
 
         self.reconnect_task = spawn_reconnect_loop(ReconnectLoopContext {
@@ -531,13 +583,9 @@ impl SyncManager {
 
 /// Spawn the outbound broadcast drain loop.
 fn spawn_broadcast_loop(
-    node: Arc<Node>,
+    context: BroadcastLoopContext,
     mut op_rx: mpsc::Receiver<Op>,
-    seen_ops: Arc<RwLock<SeenOps>>,
-    op_log: Arc<RwLock<Vec<Op>>>,
-    op_log_limit: usize,
     mut shutdown_rx: watch::Receiver<bool>,
-    metrics: Arc<RuntimeMetrics>,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
         loop {
@@ -546,12 +594,8 @@ fn spawn_broadcast_loop(
                     if *shutdown_rx.borrow() {
                         debug!("broadcast loop shutdown requested");
                         drain_broadcast_queue(
-                            &node,
+                            &context,
                             &mut op_rx,
-                            &seen_ops,
-                            &op_log,
-                            op_log_limit,
-                            &metrics,
                         ).await;
                         break;
                     }
@@ -561,13 +605,9 @@ fn spawn_broadcast_loop(
                         break;
                     };
                     broadcast_batch(
-                        &node,
+                        &context,
                         &mut op_rx,
                         first,
-                        &seen_ops,
-                        &op_log,
-                        op_log_limit,
-                        &metrics,
                     ).await;
                 }
             }
@@ -834,13 +874,9 @@ async fn mark_known_peer_failure(
 }
 
 async fn broadcast_batch(
-    node: &Arc<Node>,
+    context: &BroadcastLoopContext,
     op_rx: &mut mpsc::Receiver<Op>,
     first: Op,
-    seen_ops: &Arc<RwLock<SeenOps>>,
-    op_log: &Arc<RwLock<Vec<Op>>>,
-    op_log_limit: usize,
-    metrics: &Arc<RuntimeMetrics>,
 ) {
     let mut batch = Vec::with_capacity(BROADCAST_BATCH_MAX);
     batch.push(first);
@@ -854,45 +890,54 @@ async fn broadcast_batch(
     }
 
     let count = batch.len();
-    remember_ops(seen_ops, op_log, op_log_limit, &batch).await;
+    if let Err(e) = remember_ops(
+        &context.seen_ops,
+        &context.seen_ops_next_sequence,
+        &context.op_log,
+        context.op_log_limit,
+        &context.store,
+        &batch,
+    )
+    .await
+    {
+        context.metrics.record_sync_error();
+        warn!(error = %e, "failed to persist local op dedup metadata");
+    }
     let started = std::time::Instant::now();
-    if let Err(e) = node.broadcast_ops(batch).await {
-        metrics.record_sync_error();
+    if let Err(e) = context.node.broadcast_ops(batch).await {
+        context.metrics.record_sync_error();
         warn!(error = %e, count, "broadcast partially failed; ops dropped for failed peers");
     } else {
-        metrics.record_broadcast_batch(count);
-        metrics.record_sync_latency(started.elapsed());
+        context.metrics.record_broadcast_batch(count);
+        context.metrics.record_sync_latency(started.elapsed());
         debug!(count, "broadcast batch sent");
     }
 }
 
-async fn drain_broadcast_queue(
-    node: &Arc<Node>,
-    op_rx: &mut mpsc::Receiver<Op>,
-    seen_ops: &Arc<RwLock<SeenOps>>,
-    op_log: &Arc<RwLock<Vec<Op>>>,
-    op_log_limit: usize,
-    metrics: &Arc<RuntimeMetrics>,
-) {
+async fn drain_broadcast_queue(context: &BroadcastLoopContext, op_rx: &mut mpsc::Receiver<Op>) {
     while let Ok(first) = op_rx.try_recv() {
-        broadcast_batch(node, op_rx, first, seen_ops, op_log, op_log_limit, metrics).await;
+        broadcast_batch(context, op_rx, first).await;
     }
 }
 
 async fn remember_ops(
     seen_ops: &Arc<RwLock<SeenOps>>,
+    seen_ops_next_sequence: &Arc<AtomicU64>,
     op_log: &Arc<RwLock<Vec<Op>>>,
     op_log_limit: usize,
+    store: &Arc<NxStore>,
     ops: &[Op],
-) {
+) -> anyhow::Result<()> {
     let mut seen = seen_ops.write().await;
     let mut log = op_log.write().await;
     for op in ops {
-        if seen.insert(op.id.as_str().to_string()) {
+        if let SeenOpsInsert::Inserted { evicted } = seen.insert(op.id.as_str().to_string()) {
+            persist_seen_op_insert(store, seen_ops_next_sequence, op.id.as_str(), &evicted)?;
             log.push(op.clone());
         }
     }
     prune_op_log(&mut log, op_log_limit);
+    Ok(())
 }
 
 fn prune_op_log(log: &mut Vec<Op>, limit: usize) {
@@ -925,17 +970,16 @@ async fn handle_node_event(event: NodeEvent, context: &NodeEventContext) {
         NodeEvent::OpsReceived { from, ops } => {
             debug!(from = %from, count = ops.len(), "received ops from peer");
             for op in ops {
-                if let Err(e) = apply_remote_op(
-                    &op,
-                    &context.counters,
-                    &context.seen_ops,
-                    &context.op_log,
-                    context.op_log_limit,
-                    &context.store,
-                    &context.metrics,
-                )
-                .await
-                {
+                let apply_context = RemoteOpApplyContext {
+                    counters: &context.counters,
+                    seen_ops: &context.seen_ops,
+                    seen_ops_next_sequence: &context.seen_ops_next_sequence,
+                    op_log: &context.op_log,
+                    op_log_limit: context.op_log_limit,
+                    store: &context.store,
+                    metrics: &context.metrics,
+                };
+                if let Err(e) = apply_remote_op(&op, &apply_context).await {
                     context.metrics.record_sync_error();
                     error!(error = %e, "failed to apply remote op");
                 }
@@ -991,6 +1035,10 @@ fn durable_gcounter_state_key(key: &str) -> Vec<u8> {
     gcounter_store_key(GCOUNTER_STATE_STORE_PREFIX, key)
 }
 
+fn seen_op_store_key(op_id: &str) -> Vec<u8> {
+    gcounter_store_key(SEEN_OP_STORE_PREFIX, op_id)
+}
+
 fn gcounter_store_key(prefix: &str, key: &str) -> Vec<u8> {
     let mut out = Vec::with_capacity(prefix.len() + key.len());
     out.extend_from_slice(prefix.as_bytes());
@@ -1010,12 +1058,27 @@ fn logical_gcounter_state_key(store_key: &[u8]) -> anyhow::Result<String> {
     )
 }
 
+fn logical_seen_op_id(store_key: &[u8]) -> anyhow::Result<String> {
+    logical_key_for_prefix(store_key, SEEN_OP_STORE_PREFIX, "seen OpId")
+}
+
 fn logical_key_for_prefix(store_key: &[u8], prefix: &str, kind: &str) -> anyhow::Result<String> {
     let key = store_key
         .strip_prefix(prefix.as_bytes())
         .ok_or_else(|| anyhow::anyhow!("invalid {kind} key"))?;
 
     String::from_utf8(key.to_vec()).map_err(|e| anyhow::anyhow!("invalid UTF-8 in {kind} key: {e}"))
+}
+
+fn parse_seen_op_sequence(bytes: &[u8]) -> anyhow::Result<u64> {
+    let buf: [u8; 8] = bytes.try_into().map_err(|_| {
+        anyhow::anyhow!(
+            "invalid seen OpId sequence length: expected 8, got {}",
+            bytes.len()
+        )
+    })?;
+
+    Ok(u64::from_be_bytes(buf))
 }
 
 fn parse_materialized_gcounter_value(bytes: &[u8]) -> anyhow::Result<u64> {
@@ -1044,6 +1107,52 @@ fn hydrate_gcounter_registry(
         "hydrated GCounter registry from sled"
     );
     Ok(counters.len())
+}
+
+fn hydrate_seen_ops(store: &NxStore, limit: usize) -> anyhow::Result<(SeenOps, u64)> {
+    let limit = normalize_seen_ops_limit(limit);
+    let entries = store.scan_prefix(SEEN_OP_STORE_PREFIX.as_bytes())?;
+    let mut ordered = Vec::with_capacity(entries.len());
+    let mut next_sequence = 0;
+
+    for (store_key, value_bytes) in entries {
+        let op_id = match logical_seen_op_id(&store_key) {
+            Ok(op_id) => op_id,
+            Err(e) => {
+                warn!(error = %e, "skipping invalid seen OpId key");
+                continue;
+            }
+        };
+        let sequence = match parse_seen_op_sequence(&value_bytes) {
+            Ok(sequence) => sequence,
+            Err(e) => {
+                warn!(op_id = %op_id, error = %e, "skipping invalid seen OpId metadata");
+                continue;
+            }
+        };
+
+        next_sequence = next_sequence.max(sequence.saturating_add(1));
+        ordered.push((sequence, op_id));
+    }
+
+    ordered.sort_by_key(|(sequence, _)| *sequence);
+    let mut seen = SeenOps::new(limit);
+    let mut evicted = Vec::new();
+    for (_, op_id) in ordered {
+        if let SeenOpsInsert::Inserted {
+            evicted: evicted_ids,
+        } = seen.insert(op_id)
+        {
+            evicted.extend(evicted_ids);
+        }
+    }
+    persist_seen_op_evictions(store, &evicted)?;
+
+    debug!(
+        count = seen.len(),
+        next_sequence, "hydrated seen OpId metadata from sled"
+    );
+    Ok((seen, next_sequence))
 }
 
 fn hydrate_durable_gcounter_state(
@@ -1141,49 +1250,132 @@ pub(crate) fn persist_gcounter_state(
     Ok(())
 }
 
-/// Apply an operation received from a remote peer.
-async fn apply_remote_op(
-    op: &Op,
-    counters: &Arc<RwLock<HashMap<String, GCounter>>>,
-    seen_ops: &Arc<RwLock<SeenOps>>,
-    op_log: &Arc<RwLock<Vec<Op>>>,
-    op_log_limit: usize,
-    store: &Arc<NxStore>,
-    metrics: &Arc<RuntimeMetrics>,
+fn persist_seen_op_insert(
+    store: &NxStore,
+    next_sequence: &AtomicU64,
+    op_id: &str,
+    evicted: &[String],
 ) -> anyhow::Result<()> {
-    // Deduplication
-    {
-        let seen = seen_ops.read().await;
-        if seen.contains(op.id.as_str()) {
+    let sequence = next_sequence.fetch_add(1, Ordering::Relaxed);
+    persist_seen_op_batch(store, op_id, sequence, evicted)
+}
+
+fn persist_seen_op_batch(
+    store: &NxStore,
+    op_id: &str,
+    sequence: u64,
+    evicted: &[String],
+) -> anyhow::Result<()> {
+    let seen_key = seen_op_store_key(op_id);
+    let seen_value = sequence.to_be_bytes();
+    let delete_keys = evicted
+        .iter()
+        .map(|op_id| seen_op_store_key(op_id))
+        .collect::<Vec<_>>();
+    let delete_refs = delete_keys
+        .iter()
+        .map(|key| key.as_slice())
+        .collect::<Vec<_>>();
+
+    store.apply_batch(
+        &[(seen_key.as_slice(), seen_value.as_slice())],
+        &delete_refs,
+    )?;
+    Ok(())
+}
+
+fn persist_seen_op_evictions(store: &NxStore, evicted: &[String]) -> anyhow::Result<()> {
+    if evicted.is_empty() {
+        return Ok(());
+    }
+
+    let delete_keys = evicted
+        .iter()
+        .map(|op_id| seen_op_store_key(op_id))
+        .collect::<Vec<_>>();
+    let delete_refs = delete_keys
+        .iter()
+        .map(|key| key.as_slice())
+        .collect::<Vec<_>>();
+    store.apply_batch(&[], &delete_refs)?;
+    Ok(())
+}
+
+fn persist_remote_gcounter_op(
+    store: &NxStore,
+    next_sequence: &AtomicU64,
+    key: &str,
+    counter: &GCounter,
+    op_id: &str,
+    evicted: &[String],
+) -> anyhow::Result<()> {
+    let sequence = next_sequence.fetch_add(1, Ordering::Relaxed);
+    let state_key = durable_gcounter_state_key(key);
+    let state_json = counter.to_json()?;
+    let materialized_key = materialized_gcounter_key(key);
+    let materialized_value = counter.value().to_le_bytes();
+    let seen_key = seen_op_store_key(op_id);
+    let seen_value = sequence.to_be_bytes();
+    let delete_keys = evicted
+        .iter()
+        .map(|op_id| seen_op_store_key(op_id))
+        .collect::<Vec<_>>();
+    let delete_refs = delete_keys
+        .iter()
+        .map(|key| key.as_slice())
+        .collect::<Vec<_>>();
+
+    store.apply_batch(
+        &[
+            (state_key.as_slice(), state_json.as_bytes()),
+            (materialized_key.as_slice(), materialized_value.as_slice()),
+            (seen_key.as_slice(), seen_value.as_slice()),
+        ],
+        &delete_refs,
+    )?;
+    Ok(())
+}
+
+/// Apply an operation received from a remote peer.
+async fn apply_remote_op(op: &Op, context: &RemoteOpApplyContext<'_>) -> anyhow::Result<()> {
+    let seen_insert = {
+        let mut seen = context.seen_ops.write().await;
+        seen.insert(op.id.as_str().to_string())
+    };
+    let evicted = match seen_insert {
+        SeenOpsInsert::AlreadySeen => {
             debug!(op_id = %op.id, "skipping duplicate op");
             return Ok(());
         }
-    }
+        SeenOpsInsert::Inserted { evicted } => evicted,
+    };
 
     // Apply according to type
     match &op.kind {
         OpKind::GCounterIncrement { key, increment } => {
-            let mut counters = counters.write().await;
+            let mut counters = context.counters.write().await;
             let mut counter = counters.get(key).cloned().unwrap_or_else(GCounter::new);
             counter.increment(&op.origin, *increment);
             let total = counter.value();
 
-            persist_gcounter_state(store, key, &counter)?;
+            persist_remote_gcounter_op(
+                context.store,
+                context.seen_ops_next_sequence,
+                key,
+                &counter,
+                op.id.as_str(),
+                &evicted,
+            )?;
             counters.insert(key.clone(), counter);
 
-            metrics.record_ops(1);
+            context.metrics.record_ops(1);
             debug!(op_id = %op.id, key = %key, from = %op.origin, increment = %increment, total, "applied remote increment");
         }
     }
 
-    {
-        let mut seen = seen_ops.write().await;
-        if seen.insert(op.id.as_str().to_string()) {
-            let mut log = op_log.write().await;
-            log.push(op.clone());
-            prune_op_log(&mut log, op_log_limit);
-        }
-    }
+    let mut log = context.op_log.write().await;
+    log.push(op.clone());
+    prune_op_log(&mut log, context.op_log_limit);
 
     Ok(())
 }
@@ -1229,6 +1421,10 @@ mod tests {
         parse_durable_gcounter_state(&bytes).unwrap()
     }
 
+    fn seen_op_exists(store: &NxStore, op_id: &str) -> bool {
+        store.get(&seen_op_store_key(op_id)).unwrap().is_some()
+    }
+
     fn test_event_context(
         counters: Arc<RwLock<HashMap<String, GCounter>>>,
         seen_ops: Arc<RwLock<SeenOps>>,
@@ -1240,6 +1436,7 @@ mod tests {
         NodeEventContext {
             counters,
             seen_ops,
+            seen_ops_next_sequence: Arc::new(AtomicU64::new(0)),
             op_log,
             op_log_limit: 1024,
             store,
@@ -1251,6 +1448,27 @@ mod tests {
             peer_health,
             peer_dead_after_failures: 2,
         }
+    }
+
+    async fn apply_remote_op_for_test(
+        op: &Op,
+        counters: &Arc<RwLock<HashMap<String, GCounter>>>,
+        seen_ops: &Arc<RwLock<SeenOps>>,
+        seen_ops_next_sequence: &Arc<AtomicU64>,
+        op_log: &Arc<RwLock<Vec<Op>>>,
+        store: &Arc<NxStore>,
+    ) {
+        let metrics = metrics();
+        let context = RemoteOpApplyContext {
+            counters,
+            seen_ops,
+            seen_ops_next_sequence,
+            op_log,
+            op_log_limit: 1024,
+            store,
+            metrics: &metrics,
+        };
+        apply_remote_op(op, &context).await.unwrap();
     }
 
     async fn wait_for_counter(manager: &SyncManager, key: &str, expected: u64) {
@@ -1404,7 +1622,9 @@ mod tests {
 
     #[tokio::test]
     async fn remember_ops_prunes_op_log_to_configured_limit() {
+        let store = temp_store();
         let seen_ops = Arc::new(RwLock::new(SeenOps::new(10)));
+        let seen_ops_next_sequence = Arc::new(AtomicU64::new(0));
         let op_log = Arc::new(RwLock::new(Vec::new()));
         let op_a = Op::gcounter_increment(NodeId::new("node-a"), "counter:visits", 1);
         let op_b = Op::gcounter_increment(NodeId::new("node-b"), "counter:visits", 2);
@@ -1412,11 +1632,14 @@ mod tests {
 
         remember_ops(
             &seen_ops,
+            &seen_ops_next_sequence,
             &op_log,
             2,
+            &store,
             &[op_a.clone(), op_b.clone(), op_c.clone()],
         )
-        .await;
+        .await
+        .unwrap();
 
         assert_eq!(op_log.read().await.as_slice(), &[op_b, op_c]);
         assert!(seen_ops.read().await.contains(op_a.id.as_str()));
@@ -1436,9 +1659,20 @@ mod tests {
     fn seen_ops_eviction_keeps_recent_ids() {
         let mut seen = SeenOps::new(2);
 
-        assert!(seen.insert("op-a"));
-        assert!(seen.insert("op-b"));
-        assert!(seen.insert("op-c"));
+        assert!(matches!(
+            seen.insert("op-a"),
+            SeenOpsInsert::Inserted { .. }
+        ));
+        assert!(matches!(
+            seen.insert("op-b"),
+            SeenOpsInsert::Inserted { .. }
+        ));
+        assert_eq!(
+            seen.insert("op-c"),
+            SeenOpsInsert::Inserted {
+                evicted: vec!["op-a".to_string()]
+            }
+        );
 
         assert!(!seen.contains("op-a"));
         assert!(seen.contains("op-b"));
@@ -1450,14 +1684,59 @@ mod tests {
     fn seen_ops_duplicate_does_not_refresh_position() {
         let mut seen = SeenOps::new(2);
 
-        assert!(seen.insert("op-a"));
-        assert!(seen.insert("op-b"));
-        assert!(!seen.insert("op-a"));
-        assert!(seen.insert("op-c"));
+        assert!(matches!(
+            seen.insert("op-a"),
+            SeenOpsInsert::Inserted { .. }
+        ));
+        assert!(matches!(
+            seen.insert("op-b"),
+            SeenOpsInsert::Inserted { .. }
+        ));
+        assert_eq!(seen.insert("op-a"), SeenOpsInsert::AlreadySeen);
+        assert_eq!(
+            seen.insert("op-c"),
+            SeenOpsInsert::Inserted {
+                evicted: vec!["op-a".to_string()]
+            }
+        );
 
         assert!(!seen.contains("op-a"));
         assert!(seen.contains("op-b"));
         assert!(seen.contains("op-c"));
+    }
+
+    #[test]
+    fn hydrate_seen_ops_restores_recent_ids_and_next_sequence() {
+        let store = temp_store();
+
+        persist_seen_op_batch(&store, "op-a", 7, &[]).unwrap();
+        persist_seen_op_batch(&store, "op-b", 8, &[]).unwrap();
+
+        let (seen, next_sequence) = hydrate_seen_ops(&store, 10).unwrap();
+
+        assert!(seen.contains("op-a"));
+        assert!(seen.contains("op-b"));
+        assert_eq!(seen.len(), 2);
+        assert_eq!(next_sequence, 9);
+    }
+
+    #[test]
+    fn hydrate_seen_ops_prunes_old_metadata_to_limit() {
+        let store = temp_store();
+
+        persist_seen_op_batch(&store, "op-a", 1, &[]).unwrap();
+        persist_seen_op_batch(&store, "op-b", 2, &[]).unwrap();
+        persist_seen_op_batch(&store, "op-c", 3, &[]).unwrap();
+
+        let (seen, next_sequence) = hydrate_seen_ops(&store, 2).unwrap();
+
+        assert!(!seen.contains("op-a"));
+        assert!(seen.contains("op-b"));
+        assert!(seen.contains("op-c"));
+        assert_eq!(next_sequence, 4);
+        assert!(!seen_op_exists(&store, "op-a"));
+        assert!(seen_op_exists(&store, "op-b"));
+        assert!(seen_op_exists(&store, "op-c"));
     }
 
     #[test]
@@ -1581,13 +1860,20 @@ mod tests {
         let store = temp_store();
         let counters = Arc::new(RwLock::new(HashMap::new()));
         let seen_ops = Arc::new(RwLock::new(SeenOps::new(1024)));
+        let seen_ops_next_sequence = Arc::new(AtomicU64::new(0));
         let op_log = Arc::new(RwLock::new(Vec::new()));
         let origin = NodeId::new("remote-a");
         let op = Op::gcounter_increment(origin, "counter:visits", 3);
 
-        apply_remote_op(&op, &counters, &seen_ops, &op_log, 1024, &store, &metrics())
-            .await
-            .unwrap();
+        apply_remote_op_for_test(
+            &op,
+            &counters,
+            &seen_ops,
+            &seen_ops_next_sequence,
+            &op_log,
+            &store,
+        )
+        .await;
 
         let key = materialized_gcounter_key("counter:visits");
         let bytes = store.get(&key).unwrap().unwrap();
@@ -1604,16 +1890,29 @@ mod tests {
         let store = temp_store();
         let counters = Arc::new(RwLock::new(HashMap::new()));
         let seen_ops = Arc::new(RwLock::new(SeenOps::new(1024)));
+        let seen_ops_next_sequence = Arc::new(AtomicU64::new(0));
         let op_log = Arc::new(RwLock::new(Vec::new()));
         let origin = NodeId::new("remote-a");
         let op = Op::gcounter_increment(origin, "counter:visits", 3);
 
-        apply_remote_op(&op, &counters, &seen_ops, &op_log, 1024, &store, &metrics())
-            .await
-            .unwrap();
-        apply_remote_op(&op, &counters, &seen_ops, &op_log, 1024, &store, &metrics())
-            .await
-            .unwrap();
+        apply_remote_op_for_test(
+            &op,
+            &counters,
+            &seen_ops,
+            &seen_ops_next_sequence,
+            &op_log,
+            &store,
+        )
+        .await;
+        apply_remote_op_for_test(
+            &op,
+            &counters,
+            &seen_ops,
+            &seen_ops_next_sequence,
+            &op_log,
+            &store,
+        )
+        .await;
 
         let key = materialized_gcounter_key("counter:visits");
         let bytes = store.get(&key).unwrap().unwrap();
@@ -1621,6 +1920,51 @@ mod tests {
         buf.copy_from_slice(&bytes);
 
         assert_eq!(u64::from_le_bytes(buf), 3);
+    }
+
+    #[tokio::test]
+    async fn duplicate_remote_op_after_restart_does_not_double_count() {
+        let store = temp_store();
+        let origin = NodeId::new("remote-a");
+        let op = Op::gcounter_increment(origin, "counter:visits", 3);
+
+        let first_manager = SyncManager::new(
+            NodeId::new("local-node"),
+            SyncConfig::new(),
+            Arc::clone(&store),
+            metrics(),
+        );
+        apply_remote_op_for_test(
+            &op,
+            &first_manager.counters,
+            &first_manager.seen_ops,
+            &first_manager.seen_ops_next_sequence,
+            &first_manager.op_log,
+            &store,
+        )
+        .await;
+
+        let restarted_manager = SyncManager::new(
+            NodeId::new("local-node"),
+            SyncConfig::new(),
+            Arc::clone(&store),
+            metrics(),
+        );
+        apply_remote_op_for_test(
+            &op,
+            &restarted_manager.counters,
+            &restarted_manager.seen_ops,
+            &restarted_manager.seen_ops_next_sequence,
+            &restarted_manager.op_log,
+            &store,
+        )
+        .await;
+
+        assert_eq!(
+            restarted_manager.get_counter_value("counter:visits").await,
+            3
+        );
+        assert_eq!(read_materialized(&store, "counter:visits"), 3);
     }
 
     #[tokio::test]

--- a/crates/nx-core/src/sync_manager.rs
+++ b/crates/nx-core/src/sync_manager.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
 use std::time::{Duration, Instant as StdInstant};
 
@@ -39,6 +39,47 @@ impl Default for PeerHealth {
     }
 }
 
+#[derive(Debug)]
+struct SeenOps {
+    ids: HashSet<String>,
+    order: VecDeque<String>,
+    limit: usize,
+}
+
+impl SeenOps {
+    fn new(limit: usize) -> Self {
+        Self {
+            ids: HashSet::new(),
+            order: VecDeque::new(),
+            limit: normalize_seen_ops_limit(limit),
+        }
+    }
+
+    fn contains(&self, op_id: &str) -> bool {
+        self.ids.contains(op_id)
+    }
+
+    fn insert(&mut self, op_id: impl Into<String>) -> bool {
+        let op_id = op_id.into();
+        if !self.ids.insert(op_id.clone()) {
+            return false;
+        }
+
+        self.order.push_back(op_id);
+        while self.order.len() > self.limit {
+            if let Some(evicted) = self.order.pop_front() {
+                self.ids.remove(&evicted);
+            }
+        }
+        true
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.ids.len()
+    }
+}
+
 struct ReconnectLoopContext {
     node: Arc<Node>,
     peers: Vec<String>,
@@ -62,7 +103,7 @@ struct AntiEntropyLoopContext {
 #[derive(Clone)]
 struct NodeEventContext {
     counters: Arc<RwLock<HashMap<String, GCounter>>>,
-    seen_ops: Arc<RwLock<HashSet<String>>>,
+    seen_ops: Arc<RwLock<SeenOps>>,
     op_log: Arc<RwLock<Vec<Op>>>,
     op_log_limit: usize,
     store: Arc<NxStore>,
@@ -173,7 +214,7 @@ pub struct SyncManager {
     metrics: Arc<RuntimeMetrics>,
 
     /// OpId
-    seen_ops: Arc<RwLock<HashSet<String>>>,
+    seen_ops: Arc<RwLock<SeenOps>>,
 
     /// In-memory operation log used to answer anti-entropy pull requests.
     op_log: Arc<RwLock<Vec<Op>>>,
@@ -213,6 +254,7 @@ impl SyncManager {
     ) -> Self {
         let (op_tx, op_rx) = mpsc::channel(config.queued_ops_limit.max(1));
         let op_log_limit = normalize_op_log_limit(config.op_log_limit);
+        let seen_ops_limit = normalize_seen_ops_limit(config.seen_ops_limit);
         let (shutdown_tx, _shutdown_rx) = watch::channel(false);
         let mut counters = HashMap::new();
         let peer_health = config
@@ -233,7 +275,7 @@ impl SyncManager {
             counters,
             store,
             metrics,
-            seen_ops: Arc::new(RwLock::new(HashSet::new())),
+            seen_ops: Arc::new(RwLock::new(SeenOps::new(seen_ops_limit))),
             op_log: Arc::new(RwLock::new(Vec::with_capacity(op_log_limit.min(1024)))),
             peer_health: Arc::new(RwLock::new(peer_health)),
             op_tx,
@@ -490,7 +532,7 @@ impl SyncManager {
 fn spawn_broadcast_loop(
     node: Arc<Node>,
     mut op_rx: mpsc::Receiver<Op>,
-    seen_ops: Arc<RwLock<HashSet<String>>>,
+    seen_ops: Arc<RwLock<SeenOps>>,
     op_log: Arc<RwLock<Vec<Op>>>,
     op_log_limit: usize,
     mut shutdown_rx: watch::Receiver<bool>,
@@ -722,6 +764,10 @@ fn normalize_op_log_limit(limit: usize) -> usize {
     limit.max(1)
 }
 
+fn normalize_seen_ops_limit(limit: usize) -> usize {
+    limit.max(1)
+}
+
 fn next_reconnect_delay(current: Duration, max_delay: Duration) -> Duration {
     current.saturating_mul(2).min(max_delay.max(current))
 }
@@ -790,7 +836,7 @@ async fn broadcast_batch(
     node: &Arc<Node>,
     op_rx: &mut mpsc::Receiver<Op>,
     first: Op,
-    seen_ops: &Arc<RwLock<HashSet<String>>>,
+    seen_ops: &Arc<RwLock<SeenOps>>,
     op_log: &Arc<RwLock<Vec<Op>>>,
     op_log_limit: usize,
     metrics: &Arc<RuntimeMetrics>,
@@ -822,7 +868,7 @@ async fn broadcast_batch(
 async fn drain_broadcast_queue(
     node: &Arc<Node>,
     op_rx: &mut mpsc::Receiver<Op>,
-    seen_ops: &Arc<RwLock<HashSet<String>>>,
+    seen_ops: &Arc<RwLock<SeenOps>>,
     op_log: &Arc<RwLock<Vec<Op>>>,
     op_log_limit: usize,
     metrics: &Arc<RuntimeMetrics>,
@@ -833,7 +879,7 @@ async fn drain_broadcast_queue(
 }
 
 async fn remember_ops(
-    seen_ops: &Arc<RwLock<HashSet<String>>>,
+    seen_ops: &Arc<RwLock<SeenOps>>,
     op_log: &Arc<RwLock<Vec<Op>>>,
     op_log_limit: usize,
     ops: &[Op],
@@ -1011,7 +1057,7 @@ pub(crate) fn materialize_gcounter_value(
 async fn apply_remote_op(
     op: &Op,
     counters: &Arc<RwLock<HashMap<String, GCounter>>>,
-    seen_ops: &Arc<RwLock<HashSet<String>>>,
+    seen_ops: &Arc<RwLock<SeenOps>>,
     op_log: &Arc<RwLock<Vec<Op>>>,
     op_log_limit: usize,
     store: &Arc<NxStore>,
@@ -1091,7 +1137,7 @@ mod tests {
 
     fn test_event_context(
         counters: Arc<RwLock<HashMap<String, GCounter>>>,
-        seen_ops: Arc<RwLock<HashSet<String>>>,
+        seen_ops: Arc<RwLock<SeenOps>>,
         op_log: Arc<RwLock<Vec<Op>>>,
         store: Arc<NxStore>,
         metrics: Arc<RuntimeMetrics>,
@@ -1265,7 +1311,7 @@ mod tests {
 
     #[tokio::test]
     async fn remember_ops_prunes_op_log_to_configured_limit() {
-        let seen_ops = Arc::new(RwLock::new(HashSet::new()));
+        let seen_ops = Arc::new(RwLock::new(SeenOps::new(10)));
         let op_log = Arc::new(RwLock::new(Vec::new()));
         let op_a = Op::gcounter_increment(NodeId::new("node-a"), "counter:visits", 1);
         let op_b = Op::gcounter_increment(NodeId::new("node-b"), "counter:visits", 2);
@@ -1286,6 +1332,39 @@ mod tests {
     #[test]
     fn op_log_limit_is_never_zero() {
         assert_eq!(normalize_op_log_limit(0), 1);
+    }
+
+    #[test]
+    fn seen_ops_limit_is_never_zero() {
+        assert_eq!(normalize_seen_ops_limit(0), 1);
+    }
+
+    #[test]
+    fn seen_ops_eviction_keeps_recent_ids() {
+        let mut seen = SeenOps::new(2);
+
+        assert!(seen.insert("op-a"));
+        assert!(seen.insert("op-b"));
+        assert!(seen.insert("op-c"));
+
+        assert!(!seen.contains("op-a"));
+        assert!(seen.contains("op-b"));
+        assert!(seen.contains("op-c"));
+        assert_eq!(seen.len(), 2);
+    }
+
+    #[test]
+    fn seen_ops_duplicate_does_not_refresh_position() {
+        let mut seen = SeenOps::new(2);
+
+        assert!(seen.insert("op-a"));
+        assert!(seen.insert("op-b"));
+        assert!(!seen.insert("op-a"));
+        assert!(seen.insert("op-c"));
+
+        assert!(!seen.contains("op-a"));
+        assert!(seen.contains("op-b"));
+        assert!(seen.contains("op-c"));
     }
 
     #[test]
@@ -1332,7 +1411,7 @@ mod tests {
             PeerHealth::default(),
         )])));
         let counters = Arc::new(RwLock::new(HashMap::new()));
-        let seen_ops = Arc::new(RwLock::new(HashSet::new()));
+        let seen_ops = Arc::new(RwLock::new(SeenOps::new(1024)));
         let op_log = Arc::new(RwLock::new(Vec::new()));
         let store = temp_store();
         let metrics = metrics();
@@ -1378,7 +1457,7 @@ mod tests {
     async fn peer_events_ignore_unknown_peer_health() {
         let peer_health = Arc::new(RwLock::new(HashMap::new()));
         let counters = Arc::new(RwLock::new(HashMap::new()));
-        let seen_ops = Arc::new(RwLock::new(HashSet::new()));
+        let seen_ops = Arc::new(RwLock::new(SeenOps::new(1024)));
         let op_log = Arc::new(RwLock::new(Vec::new()));
         let store = temp_store();
         let metrics = metrics();
@@ -1408,7 +1487,7 @@ mod tests {
     async fn apply_remote_op_materializes_counter_value() {
         let store = temp_store();
         let counters = Arc::new(RwLock::new(HashMap::new()));
-        let seen_ops = Arc::new(RwLock::new(HashSet::new()));
+        let seen_ops = Arc::new(RwLock::new(SeenOps::new(1024)));
         let op_log = Arc::new(RwLock::new(Vec::new()));
         let origin = NodeId::new("remote-a");
         let op = Op::gcounter_increment(origin, "counter:visits", 3);
@@ -1429,7 +1508,7 @@ mod tests {
     async fn apply_remote_op_duplicate_does_not_double_materialize() {
         let store = temp_store();
         let counters = Arc::new(RwLock::new(HashMap::new()));
-        let seen_ops = Arc::new(RwLock::new(HashSet::new()));
+        let seen_ops = Arc::new(RwLock::new(SeenOps::new(1024)));
         let op_log = Arc::new(RwLock::new(Vec::new()));
         let origin = NodeId::new("remote-a");
         let op = Op::gcounter_increment(origin, "counter:visits", 3);

--- a/crates/nx-core/src/sync_manager.rs
+++ b/crates/nx-core/src/sync_manager.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant as StdInstant};
 
 use nx_net::{NetError, Node, NodeConfig, NodeEvent};
 use nx_store::Store as NxStore;
@@ -54,6 +54,44 @@ struct ReconnectLoopContext {
 struct PeerReconnectState {
     addr: String,
     delay: Duration,
+    next_attempt_at: StdInstant,
+}
+
+impl PeerReconnectState {
+    fn new(addr: String, initial_delay: Duration, now: StdInstant) -> Self {
+        Self {
+            addr,
+            delay: initial_delay,
+            next_attempt_at: now,
+        }
+    }
+
+    fn reset(&mut self, initial_delay: Duration, now: StdInstant) {
+        self.delay = initial_delay;
+        self.next_attempt_at = now;
+    }
+
+    fn record_failure(&mut self, max_delay: Duration, now: StdInstant) -> Duration {
+        let attempt_delay = self.delay;
+        self.next_attempt_at = now + attempt_delay;
+        self.delay = next_reconnect_delay(attempt_delay, max_delay);
+        attempt_delay
+    }
+}
+
+struct ConfiguredPeerConnectContext<'a> {
+    node: &'a Node,
+    max_peers: usize,
+    peer_dead_after_failures: u32,
+    metrics: &'a Arc<RuntimeMetrics>,
+    peer_health: &'a Arc<RwLock<HashMap<String, PeerHealth>>>,
+}
+
+enum ConfiguredPeerConnectOutcome {
+    Connected,
+    AlreadyConnected,
+    SlotLimitReached,
+    Failed,
 }
 
 /// Clonable, cheap handle to the SyncManager exposed to host calls.
@@ -233,33 +271,19 @@ impl SyncManager {
         // Connect to initial peers.
         let peer_dead_after_failures =
             normalize_peer_dead_after_failures(self.config.peer_dead_after_failures);
+        let connect_context = ConfiguredPeerConnectContext {
+            node: &node,
+            max_peers: self.config.max_peers,
+            peer_dead_after_failures,
+            metrics: &self.metrics,
+            peer_health: &self.peer_health,
+        };
         for peer_addr in &self.config.peers {
-            if node.connected_peer_count().await >= self.config.max_peers {
-                debug!(
-                    peer = %peer_addr,
-                    limit = self.config.max_peers,
-                    "skipping initial peer connect: peer slot limit reached"
-                );
+            if matches!(
+                try_connect_configured_peer(&connect_context, peer_addr).await,
+                ConfiguredPeerConnectOutcome::SlotLimitReached
+            ) {
                 break;
-            }
-
-            match node.connect_to_peer(peer_addr).await {
-                Ok(()) => {
-                    mark_peer_success(&self.peer_health, peer_addr).await;
-                }
-                Err(NetError::PeerLimitReached(limit)) => {
-                    debug!(
-                        peer = %peer_addr,
-                        limit,
-                        "skipping initial peer connect: peer slot limit reached"
-                    );
-                    break;
-                }
-                Err(e) => {
-                    self.metrics.record_sync_error();
-                    mark_peer_failure(&self.peer_health, peer_addr, peer_dead_after_failures).await;
-                    warn!(peer = %peer_addr, error = %e, "failed to connect to peer");
-                }
             }
         }
 
@@ -354,38 +378,21 @@ impl SyncManager {
         let Some(node) = self.node.as_ref() else {
             return;
         };
+        let peer_dead_after_failures =
+            normalize_peer_dead_after_failures(self.config.peer_dead_after_failures);
+        let connect_context = ConfiguredPeerConnectContext {
+            node,
+            max_peers: self.config.max_peers,
+            peer_dead_after_failures,
+            metrics: &self.metrics,
+            peer_health: &self.peer_health,
+        };
         for peer_addr in &self.config.peers {
-            if node.is_connected_addr(peer_addr).await {
-                mark_peer_success(&self.peer_health, peer_addr).await;
-                continue;
-            }
-            if node.connected_peer_count().await >= self.config.max_peers {
-                debug!(
-                    peer = %peer_addr,
-                    limit = self.config.max_peers,
-                    "skipping configured peer reconnect: peer slot limit reached"
-                );
+            if matches!(
+                try_connect_configured_peer(&connect_context, peer_addr).await,
+                ConfiguredPeerConnectOutcome::SlotLimitReached
+            ) {
                 break;
-            }
-            let peer_dead_after_failures =
-                normalize_peer_dead_after_failures(self.config.peer_dead_after_failures);
-            match node.connect_to_peer(peer_addr).await {
-                Ok(()) => {
-                    mark_peer_success(&self.peer_health, peer_addr).await;
-                }
-                Err(NetError::PeerLimitReached(limit)) => {
-                    debug!(
-                        peer = %peer_addr,
-                        limit,
-                        "skipping configured peer reconnect: peer slot limit reached"
-                    );
-                    break;
-                }
-                Err(e) => {
-                    self.metrics.record_sync_error();
-                    mark_peer_failure(&self.peer_health, peer_addr, peer_dead_after_failures).await;
-                    debug!(peer = %peer_addr, error = %e, "configured peer reconnect failed");
-                }
             }
         }
     }
@@ -471,6 +478,51 @@ fn spawn_broadcast_loop(
     })
 }
 
+async fn try_connect_configured_peer(
+    context: &ConfiguredPeerConnectContext<'_>,
+    peer_addr: &str,
+) -> ConfiguredPeerConnectOutcome {
+    if context.node.is_connected_addr(peer_addr).await {
+        mark_peer_success(context.peer_health, peer_addr).await;
+        return ConfiguredPeerConnectOutcome::AlreadyConnected;
+    }
+
+    if context.node.connected_peer_count().await >= context.max_peers {
+        debug!(
+            peer = %peer_addr,
+            limit = context.max_peers,
+            "skipping configured peer connect: peer slot limit reached"
+        );
+        return ConfiguredPeerConnectOutcome::SlotLimitReached;
+    }
+
+    match context.node.connect_to_peer(peer_addr).await {
+        Ok(()) => {
+            mark_peer_success(context.peer_health, peer_addr).await;
+            ConfiguredPeerConnectOutcome::Connected
+        }
+        Err(NetError::PeerLimitReached(limit)) => {
+            debug!(
+                peer = %peer_addr,
+                limit,
+                "skipping configured peer connect: peer slot limit reached"
+            );
+            ConfiguredPeerConnectOutcome::SlotLimitReached
+        }
+        Err(e) => {
+            context.metrics.record_sync_error();
+            mark_peer_failure(
+                context.peer_health,
+                peer_addr,
+                context.peer_dead_after_failures,
+            )
+            .await;
+            debug!(peer = %peer_addr, error = %e, "configured peer connect failed");
+            ConfiguredPeerConnectOutcome::Failed
+        }
+    }
+}
+
 fn spawn_reconnect_loop(context: ReconnectLoopContext) -> Option<JoinHandle<()>> {
     let ReconnectLoopContext {
         node,
@@ -492,58 +544,55 @@ fn spawn_reconnect_loop(context: ReconnectLoopContext) -> Option<JoinHandle<()>>
         let initial_delay = normalize_reconnect_delay(initial_delay);
         let max_delay = max_delay.max(initial_delay);
         let peer_dead_after_failures = normalize_peer_dead_after_failures(peer_dead_after_failures);
+        let now = StdInstant::now();
         let mut state = peers
             .into_iter()
-            .map(|addr| PeerReconnectState {
-                addr,
-                delay: initial_delay,
-            })
+            .map(|addr| PeerReconnectState::new(addr, initial_delay, now))
             .collect::<Vec<_>>();
 
         loop {
             let mut sleep_for: Option<Duration> = None;
+            let now = StdInstant::now();
+            let connect_context = ConfiguredPeerConnectContext {
+                node: node.as_ref(),
+                max_peers,
+                peer_dead_after_failures,
+                metrics: &metrics,
+                peer_health: &peer_health,
+            };
 
             for peer in state.iter_mut() {
                 let peer_addr = peer.addr.as_str();
 
                 if node.is_connected_addr(peer_addr).await {
                     mark_peer_success(&peer_health, peer_addr).await;
-                    peer.delay = initial_delay;
+                    peer.reset(initial_delay, now);
                     continue;
                 }
 
-                if node.connected_peer_count().await >= max_peers {
-                    debug!(
-                        peer = %peer_addr,
-                        limit = max_peers,
-                        "skipping reconnect attempt: peer slot limit reached"
-                    );
-                    break;
+                if let Some(wait) = peer.next_attempt_at.checked_duration_since(now)
+                    && !wait.is_zero()
+                {
+                    sleep_for = Some(sleep_for.map_or(wait, |current| current.min(wait)));
+                    continue;
                 }
 
-                let attempt_delay = peer.delay;
-                match node.connect_to_peer(peer_addr).await {
-                    Ok(()) => {
+                match try_connect_configured_peer(&connect_context, peer_addr).await {
+                    ConfiguredPeerConnectOutcome::Connected => {
                         info!(peer = %peer_addr, "reconnected configured peer");
-                        mark_peer_success(&peer_health, peer_addr).await;
-                        peer.delay = initial_delay;
+                        peer.reset(initial_delay, now);
                     }
-                    Err(NetError::PeerLimitReached(limit)) => {
-                        debug!(
-                            peer = %peer_addr,
-                            limit,
-                            "skipping reconnect attempt: peer slot limit reached"
-                        );
+                    ConfiguredPeerConnectOutcome::AlreadyConnected => {
+                        peer.reset(initial_delay, now);
+                    }
+                    ConfiguredPeerConnectOutcome::SlotLimitReached => {
                         break;
                     }
-                    Err(e) => {
-                        metrics.record_sync_error();
-                        mark_peer_failure(&peer_health, peer_addr, peer_dead_after_failures).await;
-                        debug!(peer = %peer_addr, error = %e, delay = ?attempt_delay, "configured peer reconnect failed");
+                    ConfiguredPeerConnectOutcome::Failed => {
+                        let attempt_delay = peer.record_failure(max_delay, now);
                         sleep_for = Some(
                             sleep_for.map_or(attempt_delay, |current| current.min(attempt_delay)),
                         );
-                        peer.delay = next_reconnect_delay(attempt_delay, max_delay);
                     }
                 }
             }
@@ -982,6 +1031,22 @@ mod tests {
             normalize_reconnect_delay(Duration::ZERO),
             Duration::from_millis(1)
         );
+    }
+
+    #[test]
+    fn peer_reconnect_state_tracks_next_attempt_per_peer() {
+        let now = StdInstant::now();
+        let mut state =
+            PeerReconnectState::new("peer-a".to_string(), Duration::from_millis(500), now);
+
+        let first_delay = state.record_failure(Duration::from_secs(5), now);
+        assert_eq!(first_delay, Duration::from_millis(500));
+        assert_eq!(state.delay, Duration::from_secs(1));
+        assert_eq!(state.next_attempt_at, now + Duration::from_millis(500));
+
+        state.reset(Duration::from_millis(500), now);
+        assert_eq!(state.delay, Duration::from_millis(500));
+        assert_eq!(state.next_attempt_at, now);
     }
 
     #[test]

--- a/crates/nx-net/Cargo.toml
+++ b/crates/nx-net/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 nx-sync = { path = "../nx-sync" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+bincode = "1"
 thiserror = "2"
 tokio = { version = "1", features = ["net", "io-util", "sync", "rt-multi-thread", "macros", "time"] }
 tokio-rustls = "0.26"
@@ -22,3 +23,7 @@ x509-parser = "0.18.1"
 [dev-dependencies]
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "time", "io-util"] }
 tokio-test = "0.4"
+
+[[bench]]
+name = "serialization"
+harness = false

--- a/crates/nx-net/benches/serialization.rs
+++ b/crates/nx-net/benches/serialization.rs
@@ -1,0 +1,62 @@
+use std::hint::black_box;
+use std::time::{Duration, Instant};
+
+use nx_net::{Message, SerializationFormat};
+use nx_sync::{NodeId, Op};
+
+const OPS: usize = 1_000;
+const ITERS: usize = 1_000;
+
+fn main() {
+    let msg = Message::push_ops(sample_ops());
+
+    let json_bytes = msg.to_bytes_with_format(SerializationFormat::Json).unwrap();
+    let bincode_bytes = msg
+        .to_bytes_with_format(SerializationFormat::Bincode)
+        .unwrap();
+
+    let json_roundtrip = measure_roundtrip(&msg, SerializationFormat::Json, ITERS);
+    let bincode_roundtrip = measure_roundtrip(&msg, SerializationFormat::Bincode, ITERS);
+
+    println!("serialization benchmark");
+    println!("ops_per_message: {OPS}");
+    println!("iterations: {ITERS}");
+    println!(
+        "json_size_bytes: {} ({:.2}x bincode)",
+        json_bytes.len(),
+        json_bytes.len() as f64 / bincode_bytes.len() as f64
+    );
+    println!("bincode_size_bytes: {}", bincode_bytes.len());
+    println!(
+        "json_roundtrip_total: {:?} ({:?}/iter)",
+        json_roundtrip,
+        per_iter(json_roundtrip, ITERS)
+    );
+    println!(
+        "bincode_roundtrip_total: {:?} ({:?}/iter, {:.2}x faster)",
+        bincode_roundtrip,
+        per_iter(bincode_roundtrip, ITERS),
+        json_roundtrip.as_secs_f64() / bincode_roundtrip.as_secs_f64()
+    );
+}
+
+fn sample_ops() -> Vec<Op> {
+    let node = NodeId::new("bench-node");
+    (0..OPS)
+        .map(|i| Op::gcounter_increment(node.clone(), format!("counter:{i}"), i as u64 + 1))
+        .collect()
+}
+
+fn measure_roundtrip(msg: &Message, format: SerializationFormat, iterations: usize) -> Duration {
+    let started = Instant::now();
+    for _ in 0..iterations {
+        let bytes = black_box(msg.to_bytes_with_format(format).unwrap());
+        let parsed = Message::from_bytes(black_box(&bytes[4..])).unwrap();
+        black_box(parsed);
+    }
+    started.elapsed()
+}
+
+fn per_iter(total: Duration, iterations: usize) -> Duration {
+    Duration::from_secs_f64(total.as_secs_f64() / iterations as f64)
+}

--- a/crates/nx-net/src/error.rs
+++ b/crates/nx-net/src/error.rs
@@ -10,6 +10,9 @@ pub enum NetError {
     #[error("serialization error: {0}")]
     Serialization(#[from] serde_json::Error),
 
+    #[error("bincode serialization error: {0}")]
+    BincodeSerialization(#[from] Box<bincode::ErrorKind>),
+
     #[error("connection failed: {0}")]
     ConnectionFailed(String),
 

--- a/crates/nx-net/src/lib.rs
+++ b/crates/nx-net/src/lib.rs
@@ -5,7 +5,7 @@ mod peer;
 mod tls;
 
 pub use error::{NetError, NetResult};
-pub use message::{Message, MessageKind};
+pub use message::{Message, MessageKind, SerializationFormat};
 pub use node::{
     DEFAULT_MAX_MESSAGE_SIZE, DEFAULT_MAX_PEERS, DEFAULT_SOCKET_TIMEOUT, Node, NodeConfig,
     NodeEvent,

--- a/crates/nx-net/src/lib.rs
+++ b/crates/nx-net/src/lib.rs
@@ -5,7 +5,7 @@ mod peer;
 mod tls;
 
 pub use error::{NetError, NetResult};
-pub use message::{Message, MessageKind, SerializationFormat};
+pub use message::{Message, MessageKind, PROTOCOL_VERSION, SerializationFormat};
 pub use node::{
     DEFAULT_MAX_MESSAGE_SIZE, DEFAULT_MAX_PEERS, DEFAULT_SOCKET_TIMEOUT, Node, NodeConfig,
     NodeEvent,

--- a/crates/nx-net/src/message.rs
+++ b/crates/nx-net/src/message.rs
@@ -3,7 +3,7 @@ use nx_sync::{NodeId, Op};
 use serde::{Deserialize, Serialize};
 
 /// Protocol version.
-pub const PROTOCOL_VERSION: u32 = 1;
+pub const PROTOCOL_VERSION: u32 = 2;
 
 const FORMAT_JSON: u8 = 0x01;
 const FORMAT_BINCODE: u8 = 0x02;
@@ -148,8 +148,13 @@ impl Message {
         }
     }
 
-    /// Serialize to bytes using the default wire format.
+    /// Serialize to bytes using the default production wire format.
     pub fn to_bytes(&self) -> NetResult<Vec<u8>> {
+        self.to_bytes_with_format(SerializationFormat::Bincode)
+    }
+
+    /// Serialize to bytes using the JSON debug wire format.
+    pub fn to_json_bytes(&self) -> NetResult<Vec<u8>> {
         self.to_bytes_with_format(SerializationFormat::Json)
     }
 

--- a/crates/nx-net/src/message.rs
+++ b/crates/nx-net/src/message.rs
@@ -1,23 +1,65 @@
+use crate::{NetError, NetResult};
 use nx_sync::{NodeId, Op};
 use serde::{Deserialize, Serialize};
 
 /// Protocol version.
 pub const PROTOCOL_VERSION: u32 = 1;
 
+const FORMAT_JSON: u8 = 0x01;
+const FORMAT_BINCODE: u8 = 0x02;
+
+/// Wire payload serialization format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SerializationFormat {
+    Json,
+    Bincode,
+}
+
+impl SerializationFormat {
+    fn to_wire_byte(self) -> u8 {
+        match self {
+            Self::Json => FORMAT_JSON,
+            Self::Bincode => FORMAT_BINCODE,
+        }
+    }
+
+    fn from_wire_byte(byte: u8) -> NetResult<Self> {
+        match byte {
+            FORMAT_JSON => Ok(Self::Json),
+            FORMAT_BINCODE => Ok(Self::Bincode),
+            other => Err(NetError::InvalidMessage(format!(
+                "unknown serialization format byte: {other}"
+            ))),
+        }
+    }
+}
+
+pub const DEFAULT_SUPPORTED_FORMATS: &[SerializationFormat] =
+    &[SerializationFormat::Bincode, SerializationFormat::Json];
+
 /// Message type.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum MessageKind {
     /// Initial handshake.
-    Hello { node_id: NodeId, version: u32 },
+    Hello {
+        node_id: NodeId,
+        version: u32,
+        supported_formats: Vec<SerializationFormat>,
+        preferred_format: SerializationFormat,
+    },
 
     /// Response to Hello.
-    HelloAck { node_id: NodeId, version: u32 },
+    HelloAck {
+        node_id: NodeId,
+        version: u32,
+        selected_format: SerializationFormat,
+    },
 
     /// Send CRDT operations.
     PushOps { ops: Vec<Op> },
 
     /// Acknowledge ops reception.
-    PushOpsAck { received_count: usize },
+    PushOpsAck { received_count: u64 },
 
     /// Request operations from a certain point.
     /// `since_op_id` is the last known op_id (None = I want everything).
@@ -31,26 +73,45 @@ pub enum MessageKind {
 }
 
 /// Complete message with metadata.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Message {
     pub kind: MessageKind,
 }
 
 impl Message {
     pub fn hello(node_id: NodeId) -> Self {
+        Self::hello_with_formats(
+            node_id,
+            DEFAULT_SUPPORTED_FORMATS.to_vec(),
+            SerializationFormat::Bincode,
+        )
+    }
+
+    pub fn hello_with_formats(
+        node_id: NodeId,
+        supported_formats: Vec<SerializationFormat>,
+        preferred_format: SerializationFormat,
+    ) -> Self {
         Self {
             kind: MessageKind::Hello {
                 node_id,
                 version: PROTOCOL_VERSION,
+                supported_formats,
+                preferred_format,
             },
         }
     }
 
     pub fn hello_ack(node_id: NodeId) -> Self {
+        Self::hello_ack_with_format(node_id, SerializationFormat::Bincode)
+    }
+
+    pub fn hello_ack_with_format(node_id: NodeId, selected_format: SerializationFormat) -> Self {
         Self {
             kind: MessageKind::HelloAck {
                 node_id,
                 version: PROTOCOL_VERSION,
+                selected_format,
             },
         }
     }
@@ -63,7 +124,9 @@ impl Message {
 
     pub fn push_ops_ack(received_count: usize) -> Self {
         Self {
-            kind: MessageKind::PushOpsAck { received_count },
+            kind: MessageKind::PushOpsAck {
+                received_count: received_count as u64,
+            },
         }
     }
 
@@ -85,19 +148,50 @@ impl Message {
         }
     }
 
-    /// Serialize to bytes (length-prefixed JSON).
-    pub fn to_bytes(&self) -> Result<Vec<u8>, serde_json::Error> {
-        let json = serde_json::to_vec(self)?;
-        let len = (json.len() as u32).to_be_bytes();
-        let mut buf = Vec::with_capacity(4 + json.len());
+    /// Serialize to bytes using the default wire format.
+    pub fn to_bytes(&self) -> NetResult<Vec<u8>> {
+        self.to_bytes_with_format(SerializationFormat::Json)
+    }
+
+    /// Serialize to bytes (length-prefixed format byte + payload).
+    pub fn to_bytes_with_format(&self, format: SerializationFormat) -> NetResult<Vec<u8>> {
+        let payload = match format {
+            SerializationFormat::Json => serde_json::to_vec(self)?,
+            SerializationFormat::Bincode => bincode::serialize(self)?,
+        };
+        let len = payload
+            .len()
+            .checked_add(1)
+            .and_then(|len| u32::try_from(len).ok())
+            .ok_or_else(|| NetError::InvalidMessage("message payload exceeds u32".to_string()))?;
+        let len = len.to_be_bytes();
+        let mut buf = Vec::with_capacity(4 + 1 + payload.len());
         buf.extend_from_slice(&len);
-        buf.extend_from_slice(&json);
+        buf.push(format.to_wire_byte());
+        buf.extend_from_slice(&payload);
         Ok(buf)
     }
 
-    /// Deserialize from JSON bytes (without length prefix).
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, serde_json::Error> {
-        serde_json::from_slice(bytes)
+    /// Deserialize from bytes without the length prefix.
+    pub fn from_bytes(bytes: &[u8]) -> NetResult<Self> {
+        let (_, msg) = Self::from_bytes_with_format(bytes)?;
+        Ok(msg)
+    }
+
+    /// Deserialize from bytes without the length prefix, returning the detected format.
+    pub fn from_bytes_with_format(bytes: &[u8]) -> NetResult<(SerializationFormat, Self)> {
+        let Some((&format_byte, payload)) = bytes.split_first() else {
+            return Err(NetError::InvalidMessage(
+                "message payload is missing serialization format byte".to_string(),
+            ));
+        };
+
+        let format = SerializationFormat::from_wire_byte(format_byte)?;
+        let msg = match format {
+            SerializationFormat::Json => serde_json::from_slice(payload)?,
+            SerializationFormat::Bincode => bincode::deserialize(payload)?,
+        };
+        Ok((format, msg))
     }
 }
 
@@ -114,30 +208,54 @@ mod tests {
             MessageKind::Hello {
                 node_id: id,
                 version,
+                supported_formats,
+                preferred_format,
             } => {
                 assert_eq!(id, &node_id);
                 assert_eq!(*version, PROTOCOL_VERSION);
+                assert_eq!(supported_formats, DEFAULT_SUPPORTED_FORMATS);
+                assert_eq!(*preferred_format, SerializationFormat::Bincode);
             }
             _ => panic!("wrong message kind"),
         }
     }
 
     #[test]
-    fn test_message_roundtrip() {
+    fn test_message_roundtrip_json() {
         let node_id = NodeId::new("node-1");
         let msg = Message::hello(node_id);
 
-        let bytes = msg.to_bytes().unwrap();
+        let bytes = msg.to_bytes_with_format(SerializationFormat::Json).unwrap();
 
         // Skip 4-byte length prefix
-        let parsed = Message::from_bytes(&bytes[4..]).unwrap();
+        let (format, parsed) = Message::from_bytes_with_format(&bytes[4..]).unwrap();
 
-        match (&msg.kind, &parsed.kind) {
-            (MessageKind::Hello { node_id: id1, .. }, MessageKind::Hello { node_id: id2, .. }) => {
-                assert_eq!(id1, id2);
-            }
-            _ => panic!("mismatch"),
-        }
+        assert_eq!(format, SerializationFormat::Json);
+        assert_eq!(parsed, msg);
+    }
+
+    #[test]
+    fn test_message_roundtrip_bincode() {
+        let node = NodeId::new("node-1");
+        let op = Op::gcounter_increment(node, "counter:test", 5);
+        let msg = Message::push_ops(vec![op]);
+
+        let bytes = msg
+            .to_bytes_with_format(SerializationFormat::Bincode)
+            .unwrap();
+
+        // Skip 4-byte length prefix
+        let (format, parsed) = Message::from_bytes_with_format(&bytes[4..]).unwrap();
+
+        assert_eq!(format, SerializationFormat::Bincode);
+        assert_eq!(parsed, msg);
+    }
+
+    #[test]
+    fn rejects_unknown_serialization_format() {
+        let err = Message::from_bytes(&[0xff, b'{', b'}']).unwrap_err();
+
+        assert!(matches!(err, NetError::InvalidMessage(_)));
     }
 
     #[test]

--- a/crates/nx-net/src/node.rs
+++ b/crates/nx-net/src/node.rs
@@ -114,6 +114,13 @@ pub enum NodeEvent {
     /// received new operations from a peer.
     OpsReceived { from: NodeId, ops: Vec<Op> },
 
+    /// Peer requested operations from a known point.
+    PullRequested {
+        from: NodeId,
+        addr: String,
+        since_op_id: Option<String>,
+    },
+
     /// Peer connected.
     PeerConnected {
         node_id: NodeId,
@@ -389,6 +396,7 @@ impl Node {
             if let Err(e) = read_loop(
                 reader,
                 peer_node_id.clone(),
+                addr_owned.clone(),
                 event_tx.clone(),
                 max_message_size,
                 socket_timeout,
@@ -430,7 +438,26 @@ impl Node {
 
     /// Send ops to all connected peers.
     pub async fn broadcast_ops(&self, ops: Vec<Op>) -> NetResult<()> {
-        let msg = Message::push_ops(ops);
+        self.broadcast_message(Message::push_ops(ops)).await
+    }
+
+    /// Send ops to a specific connected peer.
+    pub async fn send_ops_to_addr(&self, addr: &str, ops: Vec<Op>) -> NetResult<()> {
+        self.send_message_to_addr(addr, Message::push_ops(ops))
+            .await
+    }
+
+    /// Request ops from a specific connected peer.
+    pub async fn send_pull_since_to_addr(
+        &self,
+        addr: &str,
+        since_op_id: Option<String>,
+    ) -> NetResult<()> {
+        self.send_message_to_addr(addr, Message::pull_since(since_op_id))
+            .await
+    }
+
+    async fn broadcast_message(&self, msg: Message) -> NetResult<()> {
         let bytes = msg.to_bytes()?;
 
         let writers = {
@@ -470,6 +497,40 @@ impl Node {
 
         if !failed.is_empty() {
             return Err(NetError::PeerDisconnected(failed.join(",")));
+        }
+
+        Ok(())
+    }
+
+    async fn send_message_to_addr(&self, addr: &str, msg: Message) -> NetResult<()> {
+        let bytes = msg.to_bytes()?;
+        let writer = {
+            let peers = self.peers.read().await;
+            peers.get(addr).and_then(|conn| {
+                (conn.state == PeerState::Connected)
+                    .then(|| conn.writer.as_ref().map(Arc::clone))
+                    .flatten()
+            })
+        };
+
+        let Some(writer) = writer else {
+            return Err(NetError::PeerDisconnected(addr.to_string()));
+        };
+
+        let mut writer = writer.lock().await;
+        if let Err(e) = write_bytes(&mut *writer, &bytes, self.config.socket_timeout).await {
+            warn!(%addr, error = %e, "failed to send message to peer");
+            if let Some((node_id, peers_connected)) = self.mark_peer_failed(addr).await {
+                let _ = self
+                    .event_tx
+                    .send(NodeEvent::PeerDisconnected {
+                        node_id,
+                        addr: addr.to_string(),
+                        peers_connected,
+                    })
+                    .await;
+            }
+            return Err(e);
         }
 
         Ok(())
@@ -646,6 +707,7 @@ async fn handle_incoming(
     let read_result = read_loop(
         reader,
         peer_node_id.clone(),
+        addr.clone(),
         event_tx.clone(),
         limits.max_message_size,
         limits.socket_timeout,
@@ -708,6 +770,7 @@ fn ensure_peer_slot_available(
 async fn read_loop(
     mut reader: tokio::io::ReadHalf<NetStream>,
     peer_node_id: NodeId,
+    addr: String,
     event_tx: mpsc::Sender<NodeEvent>,
     max_message_size: usize,
     socket_timeout: Duration,
@@ -742,6 +805,16 @@ async fn read_loop(
                     .send(NodeEvent::OpsReceived {
                         from: peer_node_id.clone(),
                         ops,
+                    })
+                    .await;
+            }
+            MessageKind::PullSince { since_op_id } => {
+                debug!(peer = %peer_node_id, addr = %addr, ?since_op_id, "received pull request");
+                let _ = event_tx
+                    .send(NodeEvent::PullRequested {
+                        from: peer_node_id.clone(),
+                        addr: addr.clone(),
+                        since_op_id,
                     })
                     .await;
             }

--- a/crates/nx-net/src/node.rs
+++ b/crates/nx-net/src/node.rs
@@ -340,11 +340,7 @@ impl Node {
                 selected_format,
             } => {
                 if version != PROTOCOL_VERSION {
-                    warn!(
-                        their_version = version,
-                        our_version = PROTOCOL_VERSION,
-                        "protocol version mismatch"
-                    );
+                    return Err(protocol_version_mismatch(version));
                 }
                 if !supported_formats_for(self.config.serialization_format)
                     .contains(&selected_format)
@@ -674,7 +670,7 @@ async fn handle_incoming(
             preferred_format,
         } => {
             if version != PROTOCOL_VERSION {
-                warn!(their_version = version, "protocol mismatch");
+                return Err(protocol_version_mismatch(version));
             }
             let negotiated_format =
                 negotiate_serialization_format(limits.serialization_format, &supported_formats)
@@ -845,6 +841,12 @@ fn negotiate_serialization_format(
     local_supported
         .into_iter()
         .find(|format| peer_supported.contains(format))
+}
+
+fn protocol_version_mismatch(their_version: u32) -> NetError {
+    NetError::InvalidMessage(format!(
+        "protocol version mismatch: expected {PROTOCOL_VERSION}, got {their_version}"
+    ))
 }
 
 /// Loop for reading messages from a peer until disconnection
@@ -1181,6 +1183,73 @@ mod tests {
 
         assert!(matches!(err, NetError::Timeout));
         accept_task.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn connect_to_peer_rejects_protocol_version_mismatch() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let accept_task = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut stream = NetStream::Plain(stream);
+            let mut len_buf = [0u8; 4];
+            stream.read_exact(&mut len_buf).await.unwrap();
+            let len = u32::from_be_bytes(len_buf) as usize;
+            let mut buf = vec![0u8; len];
+            stream.read_exact(&mut buf).await.unwrap();
+
+            let ack = Message {
+                kind: MessageKind::HelloAck {
+                    node_id: NodeId::new("old-peer"),
+                    version: PROTOCOL_VERSION - 1,
+                    selected_format: SerializationFormat::Bincode,
+                },
+            };
+            let bytes = ack.to_bytes().unwrap();
+            stream.write_all(&bytes).await.unwrap();
+            stream.flush().await.unwrap();
+        });
+
+        let node = Node::new(
+            NodeConfig::new(NodeId::new("test"), "127.0.0.1:0")
+                .with_socket_timeout(Duration::from_secs(1)),
+        );
+
+        let err = node.connect_to_peer(&addr.to_string()).await.unwrap_err();
+
+        assert!(
+            matches!(err, NetError::InvalidMessage(msg) if msg.contains("protocol version mismatch"))
+        );
+        accept_task.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn incoming_rejects_protocol_version_mismatch() {
+        let mut node = Node::new(
+            NodeConfig::new(NodeId::new("node-a"), "127.0.0.1:0")
+                .with_socket_timeout(Duration::from_secs(1)),
+        );
+        let mut events = node.take_event_receiver().unwrap();
+        let addr = node.start_listener().await.unwrap();
+
+        let mut stream = TcpStream::connect(addr).await.unwrap();
+        let hello = Message {
+            kind: MessageKind::Hello {
+                node_id: NodeId::new("old-peer"),
+                version: PROTOCOL_VERSION - 1,
+                supported_formats: vec![SerializationFormat::Bincode, SerializationFormat::Json],
+                preferred_format: SerializationFormat::Bincode,
+            },
+        };
+        let bytes = hello.to_bytes().unwrap();
+        stream.write_all(&bytes).await.unwrap();
+        stream.flush().await.unwrap();
+
+        let event = timeout(Duration::from_millis(200), events.recv()).await;
+        assert!(event.is_err(), "old protocol peer must not connect");
+
+        node.shutdown().await;
     }
 
     #[tokio::test]

--- a/crates/nx-net/src/node.rs
+++ b/crates/nx-net/src/node.rs
@@ -117,12 +117,14 @@ pub enum NodeEvent {
     /// Peer connected.
     PeerConnected {
         node_id: NodeId,
+        addr: String,
         peers_connected: usize,
     },
 
     /// Peer disconnected.
     PeerDisconnected {
         node_id: NodeId,
+        addr: String,
         peers_connected: usize,
     },
 }
@@ -370,6 +372,7 @@ impl Node {
             .event_tx
             .send(NodeEvent::PeerConnected {
                 node_id: peer_node_id.clone(),
+                addr: addr.to_string(),
                 peers_connected,
             })
             .await;
@@ -400,15 +403,21 @@ impl Node {
             let disconnected = {
                 let mut peers = peers.write().await;
                 peers.remove(&addr_owned).and_then(|removed| {
-                    (removed.state == PeerState::Connected)
-                        .then(|| (peer_node_id.clone(), connected_peer_count(&peers)))
+                    (removed.state == PeerState::Connected).then(|| {
+                        (
+                            peer_node_id.clone(),
+                            addr_owned.clone(),
+                            connected_peer_count(&peers),
+                        )
+                    })
                 })
             };
 
-            if let Some((node_id, peers_connected)) = disconnected {
+            if let Some((node_id, addr, peers_connected)) = disconnected {
                 let _ = event_tx
                     .send(NodeEvent::PeerDisconnected {
                         node_id,
+                        addr,
                         peers_connected,
                     })
                     .await;
@@ -451,6 +460,7 @@ impl Node {
                         .event_tx
                         .send(NodeEvent::PeerDisconnected {
                             node_id,
+                            addr: addr.clone(),
                             peers_connected,
                         })
                         .await;
@@ -627,6 +637,7 @@ async fn handle_incoming(
     let _ = event_tx
         .send(NodeEvent::PeerConnected {
             node_id: peer_node_id.clone(),
+            addr: addr.clone(),
             peers_connected,
         })
         .await;
@@ -647,14 +658,20 @@ async fn handle_incoming(
         let Some(removed) = peers.remove(&addr) else {
             return read_result;
         };
-        (removed.state == PeerState::Connected)
-            .then(|| (peer_node_id.clone(), connected_peer_count(&peers)))
+        (removed.state == PeerState::Connected).then(|| {
+            (
+                peer_node_id.clone(),
+                addr.clone(),
+                connected_peer_count(&peers),
+            )
+        })
     };
 
-    if let Some((node_id, peers_connected)) = disconnected {
+    if let Some((node_id, addr, peers_connected)) = disconnected {
         let _ = event_tx
             .send(NodeEvent::PeerDisconnected {
                 node_id,
+                addr,
                 peers_connected,
             })
             .await;

--- a/crates/nx-net/src/node.rs
+++ b/crates/nx-net/src/node.rs
@@ -259,8 +259,9 @@ impl Node {
             .try_acquire_owned()
             .map_err(|_| NetError::PeerLimitReached(self.config.max_peers))?;
 
-        let tcp = TcpStream::connect(addr)
+        let tcp = timeout(self.config.socket_timeout, TcpStream::connect(addr))
             .await
+            .map_err(|_| NetError::Timeout)?
             .map_err(|e| NetError::ConnectionFailed(format!("{}: {}", addr, e)))?;
 
         let stream: NetStream = if let Some(tls_cfg) = &self.config.tls {
@@ -955,6 +956,26 @@ mod tests {
         .unwrap_err();
 
         assert!(matches!(err, NetError::Timeout));
+    }
+
+    #[tokio::test]
+    async fn connect_to_peer_times_out_during_handshake() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let accept_task = tokio::spawn(async move {
+            let (_stream, _addr) = listener.accept().await.unwrap();
+            tokio::time::sleep(Duration::from_millis(200)).await;
+        });
+
+        let node = Node::new(
+            NodeConfig::new(NodeId::new("test"), "127.0.0.1:0")
+                .with_socket_timeout(Duration::from_millis(10)),
+        );
+
+        let err = node.connect_to_peer(&addr.to_string()).await.unwrap_err();
+
+        assert!(matches!(err, NetError::Timeout));
+        accept_task.await.unwrap();
     }
 
     #[tokio::test]

--- a/crates/nx-net/src/node.rs
+++ b/crates/nx-net/src/node.rs
@@ -11,7 +11,9 @@ use tokio::time::timeout;
 use tracing::{debug, error, info, warn};
 
 use crate::error::{NetError, NetResult};
-use crate::message::{Message, MessageKind, PROTOCOL_VERSION};
+use crate::message::{
+    DEFAULT_SUPPORTED_FORMATS, Message, MessageKind, PROTOCOL_VERSION, SerializationFormat,
+};
 use crate::peer::{PeerInfo, PeerState};
 use crate::tls::{NetStream, TlsConfig};
 
@@ -32,6 +34,7 @@ struct NodeLimits {
     max_peers: usize,
     max_message_size: usize,
     socket_timeout: Duration,
+    serialization_format: SerializationFormat,
 }
 
 struct IncomingContext {
@@ -67,6 +70,9 @@ pub struct NodeConfig {
 
     /// Timeout for socket reads and writes.
     pub socket_timeout: Duration,
+
+    /// Serialization format used for outgoing messages.
+    pub serialization_format: SerializationFormat,
 }
 
 impl NodeConfig {
@@ -79,6 +85,7 @@ impl NodeConfig {
             max_peers: DEFAULT_MAX_PEERS,
             max_message_size: DEFAULT_MAX_MESSAGE_SIZE,
             socket_timeout: DEFAULT_SOCKET_TIMEOUT,
+            serialization_format: SerializationFormat::Bincode,
         }
     }
 
@@ -104,6 +111,11 @@ impl NodeConfig {
 
     pub fn with_socket_timeout(mut self, socket_timeout: Duration) -> Self {
         self.socket_timeout = socket_timeout;
+        self
+    }
+
+    pub fn with_serialization_format(mut self, serialization_format: SerializationFormat) -> Self {
+        self.serialization_format = serialization_format;
         self
     }
 }
@@ -141,6 +153,7 @@ pub enum NodeEvent {
 struct PeerConnection {
     info: PeerInfo,
     state: PeerState,
+    serialization_format: SerializationFormat,
     writer: Option<Arc<tokio::sync::Mutex<tokio::io::WriteHalf<crate::tls::NetStream>>>>,
     _slot: OwnedSemaphorePermit,
 }
@@ -198,6 +211,7 @@ impl Node {
             max_peers: self.config.max_peers,
             max_message_size: self.config.max_message_size,
             socket_timeout: self.config.socket_timeout,
+            serialization_format: self.config.serialization_format,
         };
         let mut shutdown_rx = self.shutdown_tx.subscribe();
         let shutdown_tx = self.shutdown_tx.clone();
@@ -298,8 +312,19 @@ impl Node {
         let (mut reader, mut writer) = tokio::io::split(stream);
 
         // Send HELLO
-        let hello = Message::hello(self.config.node_id.clone());
-        write_message(&mut writer, &hello, self.config.socket_timeout).await?;
+        let supported_formats = supported_formats_for(self.config.serialization_format);
+        let hello = Message::hello_with_formats(
+            self.config.node_id.clone(),
+            supported_formats,
+            self.config.serialization_format,
+        );
+        write_message(
+            &mut writer,
+            &hello,
+            self.config.serialization_format,
+            self.config.socket_timeout,
+        )
+        .await?;
 
         // Wait HELLO_ACK
         let response = read_message(
@@ -308,8 +333,12 @@ impl Node {
             self.config.socket_timeout,
         )
         .await?;
-        let peer_node_id = match response.kind {
-            MessageKind::HelloAck { node_id, version } => {
+        let (peer_node_id, negotiated_format) = match response.kind {
+            MessageKind::HelloAck {
+                node_id,
+                version,
+                selected_format,
+            } => {
                 if version != PROTOCOL_VERSION {
                     warn!(
                         their_version = version,
@@ -317,8 +346,15 @@ impl Node {
                         "protocol version mismatch"
                     );
                 }
-                info!(peer = %node_id, "handshake complete");
-                node_id
+                if !supported_formats_for(self.config.serialization_format)
+                    .contains(&selected_format)
+                {
+                    return Err(NetError::InvalidMessage(format!(
+                        "peer selected unsupported serialization format: {selected_format:?}"
+                    )));
+                }
+                info!(peer = %node_id, serialization_format = ?selected_format, "handshake complete");
+                (node_id, selected_format)
             }
             _ => {
                 return Err(NetError::InvalidMessage("expected HelloAck".into()));
@@ -367,6 +403,7 @@ impl Node {
                 PeerConnection {
                     info: PeerInfo::new(addr).with_node_id(peer_node_id.clone()),
                     state: PeerState::Connected,
+                    serialization_format: negotiated_format,
                     writer: Some(Arc::new(tokio::sync::Mutex::new(writer))),
                     _slot: slot,
                 },
@@ -458,8 +495,6 @@ impl Node {
     }
 
     async fn broadcast_message(&self, msg: Message) -> NetResult<()> {
-        let bytes = msg.to_bytes()?;
-
         let writers = {
             let peers = self.peers.read().await;
             peers
@@ -467,9 +502,9 @@ impl Node {
                 .filter_map(|(addr, conn)| {
                     (conn.state == PeerState::Connected)
                         .then(|| {
-                            conn.writer
-                                .as_ref()
-                                .map(|writer| (addr.clone(), Arc::clone(writer)))
+                            conn.writer.as_ref().map(|writer| {
+                                (addr.clone(), Arc::clone(writer), conn.serialization_format)
+                            })
                         })
                         .flatten()
                 })
@@ -477,7 +512,8 @@ impl Node {
         };
 
         let mut failed = Vec::new();
-        for (addr, writer) in writers {
+        for (addr, writer, serialization_format) in writers {
+            let bytes = msg.to_bytes_with_format(serialization_format)?;
             let mut writer = writer.lock().await;
             if let Err(e) = write_bytes(&mut *writer, &bytes, self.config.socket_timeout).await {
                 warn!(%addr, error = %e, "failed to send ops");
@@ -503,20 +539,24 @@ impl Node {
     }
 
     async fn send_message_to_addr(&self, addr: &str, msg: Message) -> NetResult<()> {
-        let bytes = msg.to_bytes()?;
-        let writer = {
+        let peer_writer = {
             let peers = self.peers.read().await;
             peers.get(addr).and_then(|conn| {
                 (conn.state == PeerState::Connected)
-                    .then(|| conn.writer.as_ref().map(Arc::clone))
+                    .then(|| {
+                        conn.writer
+                            .as_ref()
+                            .map(|writer| (Arc::clone(writer), conn.serialization_format))
+                    })
                     .flatten()
             })
         };
 
-        let Some(writer) = writer else {
+        let Some((writer, serialization_format)) = peer_writer else {
             return Err(NetError::PeerDisconnected(addr.to_string()));
         };
 
+        let bytes = msg.to_bytes_with_format(serialization_format)?;
         let mut writer = writer.lock().await;
         if let Err(e) = write_bytes(&mut *writer, &bytes, self.config.socket_timeout).await {
             warn!(%addr, error = %e, "failed to send message to peer");
@@ -626,12 +666,32 @@ async fn handle_incoming(
 
     // Wait for HELLO
     let msg = read_message(&mut reader, limits.max_message_size, limits.socket_timeout).await?;
-    let peer_node_id = match msg.kind {
-        MessageKind::Hello { node_id, version } => {
+    let (peer_node_id, negotiated_format) = match msg.kind {
+        MessageKind::Hello {
+            node_id,
+            version,
+            supported_formats,
+            preferred_format,
+        } => {
             if version != PROTOCOL_VERSION {
                 warn!(their_version = version, "protocol mismatch");
             }
-            node_id
+            let negotiated_format =
+                negotiate_serialization_format(limits.serialization_format, &supported_formats)
+                    .ok_or_else(|| {
+                        NetError::InvalidMessage(
+                            "no mutually supported serialization format".to_string(),
+                        )
+                    })?;
+            if negotiated_format != preferred_format {
+                debug!(
+                    peer = %node_id,
+                    peer_preferred_format = ?preferred_format,
+                    selected_format = ?negotiated_format,
+                    "selected alternate serialization format"
+                );
+            }
+            (node_id, negotiated_format)
         }
         _ => {
             return Err(NetError::InvalidMessage("expected Hello".into()));
@@ -674,8 +734,8 @@ async fn handle_incoming(
         ensure_peer_slot_available(&peers, limits.max_peers, Some(&addr))?;
     }
 
-    let ack = Message::hello_ack(our_node_id);
-    write_message(&mut writer, &ack, limits.socket_timeout).await?;
+    let ack = Message::hello_ack_with_format(our_node_id, negotiated_format);
+    write_message(&mut writer, &ack, negotiated_format, limits.socket_timeout).await?;
 
     let peers_connected = {
         let mut peers = peers.write().await;
@@ -685,6 +745,7 @@ async fn handle_incoming(
             PeerConnection {
                 info: PeerInfo::new(&addr).with_node_id(peer_node_id.clone()),
                 state: PeerState::Connected,
+                serialization_format: negotiated_format,
                 writer: Some(Arc::new(tokio::sync::Mutex::new(writer))),
                 _slot: slot,
             },
@@ -692,7 +753,7 @@ async fn handle_incoming(
         connected_peer_count(&peers)
     };
 
-    info!(peer = %peer_node_id, "incoming peer connected");
+    info!(peer = %peer_node_id, serialization_format = ?negotiated_format, "incoming peer connected");
 
     // Notify Event
     let _ = event_tx
@@ -766,6 +827,26 @@ fn ensure_peer_slot_available(
     Ok(())
 }
 
+fn supported_formats_for(preferred: SerializationFormat) -> Vec<SerializationFormat> {
+    match preferred {
+        SerializationFormat::Json => vec![SerializationFormat::Json],
+        SerializationFormat::Bincode => DEFAULT_SUPPORTED_FORMATS.to_vec(),
+    }
+}
+
+fn negotiate_serialization_format(
+    preferred: SerializationFormat,
+    peer_supported: &[SerializationFormat],
+) -> Option<SerializationFormat> {
+    let local_supported = supported_formats_for(preferred);
+    if peer_supported.contains(&preferred) && local_supported.contains(&preferred) {
+        return Some(preferred);
+    }
+    local_supported
+        .into_iter()
+        .find(|format| peer_supported.contains(format))
+}
+
 /// Loop for reading messages from a peer until disconnection
 async fn read_loop(
     mut reader: tokio::io::ReadHalf<NetStream>,
@@ -835,9 +916,10 @@ async fn read_loop(
 async fn write_message<W: AsyncWriteExt + Unpin>(
     writer: &mut W,
     msg: &Message,
+    serialization_format: SerializationFormat,
     socket_timeout: Duration,
 ) -> NetResult<()> {
-    let bytes = msg.to_bytes()?;
+    let bytes = msg.to_bytes_with_format(serialization_format)?;
     write_bytes(writer, &bytes, socket_timeout).await?;
     Ok(())
 }
@@ -883,7 +965,7 @@ async fn read_message<R: AsyncReadExt + Unpin>(
         .await
         .map_err(|_| NetError::Timeout)??;
 
-    Message::from_bytes(&buf).map_err(|e| e.into())
+    Message::from_bytes(&buf)
 }
 
 #[cfg(test)]
@@ -914,6 +996,33 @@ mod tests {
     }
 
     #[test]
+    fn negotiation_prefers_local_format_when_peer_supports_it() {
+        let selected = negotiate_serialization_format(
+            SerializationFormat::Bincode,
+            &[SerializationFormat::Json, SerializationFormat::Bincode],
+        );
+
+        assert_eq!(selected, Some(SerializationFormat::Bincode));
+    }
+
+    #[test]
+    fn negotiation_falls_back_to_json_for_debug_peer() {
+        let selected = negotiate_serialization_format(
+            SerializationFormat::Bincode,
+            &[SerializationFormat::Json],
+        );
+
+        assert_eq!(selected, Some(SerializationFormat::Json));
+    }
+
+    #[test]
+    fn negotiation_rejects_empty_peer_formats() {
+        let selected = negotiate_serialization_format(SerializationFormat::Bincode, &[]);
+
+        assert_eq!(selected, None);
+    }
+
+    #[test]
     fn peer_slot_limit_rejects_new_peer_when_full() {
         let mut peers = HashMap::new();
         peers.insert(
@@ -921,6 +1030,7 @@ mod tests {
             PeerConnection {
                 info: PeerInfo::new("127.0.0.1:9001"),
                 state: PeerState::Connected,
+                serialization_format: SerializationFormat::Bincode,
                 writer: None,
                 _slot: test_slot(),
             },
@@ -939,6 +1049,7 @@ mod tests {
             PeerConnection {
                 info: PeerInfo::new("127.0.0.1:9001"),
                 state: PeerState::Connected,
+                serialization_format: SerializationFormat::Bincode,
                 writer: None,
                 _slot: test_slot(),
             },
@@ -957,6 +1068,7 @@ mod tests {
                 PeerConnection {
                     info: PeerInfo::new("127.0.0.1:9001").with_node_id(NodeId::new("peer-a")),
                     state: PeerState::Connected,
+                    serialization_format: SerializationFormat::Bincode,
                     writer: None,
                     _slot: test_slot(),
                 },
@@ -966,6 +1078,7 @@ mod tests {
                 PeerConnection {
                     info: PeerInfo::new("127.0.0.1:9002").with_node_id(NodeId::new("peer-b")),
                     state: PeerState::Connected,
+                    serialization_format: SerializationFormat::Bincode,
                     writer: None,
                     _slot: test_slot(),
                 },
@@ -988,6 +1101,7 @@ mod tests {
                 PeerConnection {
                     info: PeerInfo::new("127.0.0.1:9001").with_node_id(NodeId::new("peer-a")),
                     state: PeerState::Connected,
+                    serialization_format: SerializationFormat::Bincode,
                     writer: None,
                     _slot: test_slot(),
                 },
@@ -997,6 +1111,7 @@ mod tests {
                 PeerConnection {
                     info: PeerInfo::new("127.0.0.1:9002").with_node_id(NodeId::new("peer-b")),
                     state: PeerState::Failed,
+                    serialization_format: SerializationFormat::Bincode,
                     writer: None,
                     _slot: test_slot(),
                 },
@@ -1140,6 +1255,39 @@ mod tests {
         );
 
         node_a.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn bincode_node_negotiates_json_with_debug_peer() {
+        let node_a = Node::new(NodeConfig::new(NodeId::new("node-a"), "127.0.0.1:0"));
+        node_a.start_listener().await.unwrap();
+
+        let mut node_b = Node::new(
+            NodeConfig::new(NodeId::new("node-b"), "127.0.0.1:0")
+                .with_serialization_format(SerializationFormat::Json),
+        );
+        let mut events_b = node_b.take_event_receiver().unwrap();
+        let addr_b = node_b.start_listener().await.unwrap();
+
+        node_a.connect_to_peer(&addr_b.to_string()).await.unwrap();
+
+        timeout(Duration::from_secs(1), async {
+            loop {
+                if matches!(events_b.recv().await, Some(NodeEvent::PeerConnected { .. })) {
+                    break;
+                }
+            }
+        })
+        .await
+        .unwrap();
+
+        let peers = node_a.peers.read().await;
+        let peer = peers.get(&addr_b.to_string()).expect("connected peer");
+        assert_eq!(peer.serialization_format, SerializationFormat::Json);
+
+        drop(peers);
+        node_a.shutdown().await;
+        node_b.shutdown().await;
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/crates/nx-net/src/node.rs
+++ b/crates/nx-net/src/node.rs
@@ -470,6 +470,14 @@ impl Node {
         connected_peer_count(&peers)
     }
 
+    /// Returns true when the configured peer address currently has an active connection.
+    pub async fn is_connected_addr(&self, addr: &str) -> bool {
+        let peers = self.peers.read().await;
+        peers
+            .get(addr)
+            .is_some_and(|conn| conn.state == PeerState::Connected)
+    }
+
     async fn ensure_peer_slot_available(&self) -> NetResult<()> {
         let peers = self.peers.read().await;
         ensure_peer_slot_available(&peers, self.config.max_peers, None)
@@ -877,6 +885,36 @@ mod tests {
 
         assert_eq!(node_id, NodeId::new("peer-a"));
         assert_eq!(connected, 1);
+    }
+
+    #[tokio::test]
+    async fn is_connected_addr_tracks_connected_state() {
+        let node = Node::new(NodeConfig::new(NodeId::new("test"), "127.0.0.1:9000"));
+        {
+            let mut peers = node.peers.write().await;
+            peers.insert(
+                "127.0.0.1:9001".to_string(),
+                PeerConnection {
+                    info: PeerInfo::new("127.0.0.1:9001").with_node_id(NodeId::new("peer-a")),
+                    state: PeerState::Connected,
+                    writer: None,
+                    _slot: test_slot(),
+                },
+            );
+            peers.insert(
+                "127.0.0.1:9002".to_string(),
+                PeerConnection {
+                    info: PeerInfo::new("127.0.0.1:9002").with_node_id(NodeId::new("peer-b")),
+                    state: PeerState::Failed,
+                    writer: None,
+                    _slot: test_slot(),
+                },
+            );
+        }
+
+        assert!(node.is_connected_addr("127.0.0.1:9001").await);
+        assert!(!node.is_connected_addr("127.0.0.1:9002").await);
+        assert!(!node.is_connected_addr("127.0.0.1:9003").await);
     }
 
     #[test]

--- a/crates/nx-net/tests/node_id_mismatch.rs
+++ b/crates/nx-net/tests/node_id_mismatch.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use nx_net::{Message, MessageKind, Node, NodeConfig, TestPki};
+use nx_net::{Message, MessageKind, Node, NodeConfig, SerializationFormat, TestPki};
 use tokio::io::AsyncWriteExt;
 use tokio::net::TcpStream;
 use tokio::time::timeout;
@@ -41,6 +41,8 @@ async fn node_id_mismatch_disconnects_immediately() {
             kind: MessageKind::Hello {
                 node_id: forged,
                 version: 1,
+                supported_formats: vec![SerializationFormat::Bincode, SerializationFormat::Json],
+                preferred_format: SerializationFormat::Bincode,
             },
         };
 

--- a/crates/nx-net/tests/node_id_mismatch.rs
+++ b/crates/nx-net/tests/node_id_mismatch.rs
@@ -1,6 +1,8 @@
 use std::time::Duration;
 
-use nx_net::{Message, MessageKind, Node, NodeConfig, SerializationFormat, TestPki};
+use nx_net::{
+    Message, MessageKind, Node, NodeConfig, PROTOCOL_VERSION, SerializationFormat, TestPki,
+};
 use tokio::io::AsyncWriteExt;
 use tokio::net::TcpStream;
 use tokio::time::timeout;
@@ -40,7 +42,7 @@ async fn node_id_mismatch_disconnects_immediately() {
         let hello = Message {
             kind: MessageKind::Hello {
                 node_id: forged,
-                version: 1,
+                version: PROTOCOL_VERSION,
                 supported_formats: vec![SerializationFormat::Bincode, SerializationFormat::Json],
                 preferred_format: SerializationFormat::Bincode,
             },

--- a/crates/nx-store/src/lib.rs
+++ b/crates/nx-store/src/lib.rs
@@ -68,6 +68,23 @@ mod tests {
     }
 
     #[test]
+    fn test_apply_batch_sets_and_deletes_atomically() {
+        let dir = tempdir().unwrap();
+        let store = Store::open(dir.path()).unwrap();
+
+        store.set(b"old", b"value").unwrap();
+        store
+            .apply_batch(
+                &[(b"new".as_slice(), b"value".as_slice())],
+                &[b"old".as_slice()],
+            )
+            .unwrap();
+
+        assert_eq!(store.get(b"new").unwrap(), Some(b"value".to_vec()));
+        assert_eq!(store.get(b"old").unwrap(), None);
+    }
+
+    #[test]
     fn test_stats_counts_keys_and_bytes() {
         let dir = tempdir().unwrap();
         let store = Store::open(dir.path()).unwrap();

--- a/crates/nx-store/src/store.rs
+++ b/crates/nx-store/src/store.rs
@@ -45,6 +45,22 @@ impl Store {
         Ok(())
     }
 
+    pub fn apply_batch(
+        &self,
+        sets: &[(&[u8], &[u8])],
+        deletes: &[&[u8]],
+    ) -> Result<(), StoreError> {
+        let mut batch = sled::Batch::default();
+        for (key, value) in sets {
+            batch.insert(*key, *value);
+        }
+        for key in deletes {
+            batch.remove(*key);
+        }
+        self.db.apply_batch(batch)?;
+        Ok(())
+    }
+
     pub fn delete(&self, key: &[u8]) -> Result<(), StoreError> {
         self.db.remove(key)?;
         Ok(())

--- a/examples/distributed_counter/README.md
+++ b/examples/distributed_counter/README.md
@@ -43,6 +43,8 @@ Each invocation runs the guest once, waits for the configured settle window,
 prints the final materialized GCounter value, flushes the local store and exits:
 - each run performs one local increment (`crdt::gcounter::inc(key, 1)`)
 - the increment is broadcast to peers asynchronously
+- missed pushes can be recovered by periodic anti-entropy while peers remain
+  configured and reconnect
 - `--wait-before-run` gives both processes time to connect before the guest
   emits its increment
 - `--settle-for` gives PushOps and remote apply time to complete before exit
@@ -68,10 +70,13 @@ counter:visits = 2
   will log a message and exit, since `crdt::*` APIs require replication
   to be enabled on the runtime.
 - Each node has its own datastore (`./data-a`, `./data-b`). Counter totals are
-  materialized to sled after local and remote updates, flushed on shutdown and
-  hydrated back into the in-memory registry on startup.
+  materialized to sled after local and remote updates. Durable CRDT state/op-log
+  metadata and bounded dedup metadata are also persisted, then hydrated back
+  into the in-memory registry on startup.
 - Without `--settle-for`, a sync-enabled runtime stays alive until it receives
   SIGINT/SIGTERM/SIGHUP.
 - The `-v` flag enables verbose logs to observe lifecycle, broadcast and apply
   paths. Use `--log-format json` for structured logs, and
   `--observability-listen 127.0.0.1:9300` to expose the local metrics endpoint.
+- The production sync wire format is bincode. Add `--debug-protocol` to use
+  JSON for local wire inspection.


### PR DESCRIPTION
## v0.1.0-alpha.4

Hi! `v0.1.0-alpha.4` concludes **Phase 10** and **Phase 11**: the runtime now stays resilient under an unstable network and speaks a compact binary wire protocol by default.

---

### What changed

**Phase 10 – Network Resilience**
- Automatic reconnect with exponential backoff for configured peers.
- Peer health tracking: suspect → dead after N consecutive failures, reset to healthy on reconnect.
- Peer rotation: when the active peer dies, a slot opens for the next configured peer.
- Periodic anti-entropy (`PullSince`) so nodes catch up on missed ops after reconnects or long disconnections.
- Bounded OpId deduplication backed by a durable op-log in sled, recent duplicate remote ops after restart do not double-count.
- Durable CRDT state/op-log hydration on startup; materialized sled totals are retained as a fallback.

**Phase 11 – Dual-mode Wire Serialization**
- `bincode` is now the default production wire format (~50 % smaller, ~10× faster to parse than JSON).
- JSON is still available via `--debug-protocol` for local wire inspection.
- Format negotiation in `Hello`/`HelloAck`; protocol version bumped to `2`.
- Version mismatches are now rejected at handshake instead of logged and silently tolerated.
- Serialization benchmark added (`cargo bench -p nx-net`).

---

### Why it matters

`alpha.3` proved the runtime holds up under load and tells you what it's doing.  
`alpha.4` answers the next honest question: *what happens when the network is unreliable?*  
Network resilience without durable state recovery means a restarted node silently diverges. Durable state without a compact wire format means you pay the JSON tax on every sync message. They belong in the same release.

---

### Known limitations

- K-fanout gossip and full dynamic peer discovery remain future work; peers are still configured explicitly.
- Deduplication is bounded, not an infinite causal history.
- API and wire format may change before `v0.1.0`.

---

### What is next

`v0.1.0-alpha.5` will continue the hardening path. The roadmap tracks Phase 12 (extended Host API), Phase 13 (load testing) and the remaining `v0.1.0` release criteria.

Thank you everyone! 