### PR TITLE
V0.1.2

### DIFF
--- a/.github/workflows/benchmark-baseline.yml
+++ b/.github/workflows/benchmark-baseline.yml
@@ -1,0 +1,77 @@
+name: Benchmark Baseline Calibration
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: benchmark-baseline-calibration
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  calibrate:
+    name: Generate Ubuntu baseline candidate
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@9d7e65c320fdb52dcd45ffaa68deb6c02c8754d9 # v1.10.1
+        with:
+          toolchain: stable
+          rustflags: ""
+      - name: Test benchmark comparator
+        run: node scripts/compare-benchmark-report.test.mjs
+      - name: Run five calibration benchmarks
+        run: |
+          mkdir -p reports/baseline-candidate reports/baseline-runs
+          for run in 1 2 3 4 5; do
+            cargo bench -p nx-core --bench three_node_sync_load -- \
+              --duration-secs 10 \
+              --target-ops-sec-per-node 1000 \
+              --settle-secs 10 \
+              --report "reports/baseline-runs/three-node-sync-smoke-${run}.json"
+          done
+      - name: Generate median baseline candidate
+        run: |
+          set +e
+          node scripts/compare-benchmark-report.mjs \
+            --baseline crates/nx-core/reports/baselines/three-node-sync-smoke.json \
+            --current reports/baseline-runs/three-node-sync-smoke-1.json \
+            --current reports/baseline-runs/three-node-sync-smoke-2.json \
+            --current reports/baseline-runs/three-node-sync-smoke-3.json \
+            --current reports/baseline-runs/three-node-sync-smoke-4.json \
+            --current reports/baseline-runs/three-node-sync-smoke-5.json \
+            --write-aggregate reports/baseline-candidate/three-node-sync-smoke.json \
+            --mode shadow \
+            --p99-threshold 10 \
+            --p99-min-delta-ms 0.1 \
+            --throughput-threshold 5 \
+            --rss-threshold 10 \
+            --rss-min-delta-bytes 16777216 \
+            2>&1 | tee reports/baseline-candidate/comparison.txt
+          status=${PIPESTATUS[0]}
+          set -e
+          {
+            echo "### Benchmark baseline candidate"
+            echo '```text'
+            cat reports/baseline-candidate/comparison.txt
+            echo '```'
+          } >> "${GITHUB_STEP_SUMMARY}"
+          exit "${status}"
+      - name: Validate candidate RSS
+        run: |
+          node -e "const r=JSON.parse(require('node:fs').readFileSync(process.argv[1], 'utf8')); if(!Number.isFinite(r.resources?.rss_bytes)) throw new Error('candidate rss_bytes is missing')" \
+            reports/baseline-candidate/three-node-sync-smoke.json
+      - name: Upload baseline candidate and raw reports
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-baseline-candidate-ubuntu-24.04
+          path: |
+            reports/baseline-candidate/
+            reports/baseline-runs/
+          if-no-files-found: error

--- a/.github/workflows/benchmark-baseline.yml
+++ b/.github/workflows/benchmark-baseline.yml
@@ -16,6 +16,7 @@ env:
 jobs:
   calibrate:
     name: Generate Ubuntu baseline candidate
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
@@ -68,6 +69,7 @@ jobs:
           node -e "const r=JSON.parse(require('node:fs').readFileSync(process.argv[1], 'utf8')); if(!Number.isFinite(r.resources?.rss_bytes)) throw new Error('candidate rss_bytes is missing')" \
             reports/baseline-candidate/three-node-sync-smoke.json
       - name: Upload baseline candidate and raw reports
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
           name: benchmark-baseline-candidate-ubuntu-24.04

--- a/.github/workflows/benchmark-baseline.yml
+++ b/.github/workflows/benchmark-baseline.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions-rust-lang/setup-rust-toolchain@9d7e65c320fdb52dcd45ffaa68deb6c02c8754d9 # v1.10.1
         with:
           toolchain: stable
@@ -35,7 +35,7 @@ jobs:
               --duration-secs 10 \
               --target-ops-sec-per-node 1000 \
               --settle-secs 10 \
-              --report "reports/baseline-runs/three-node-sync-smoke-${run}.json"
+              --report "${GITHUB_WORKSPACE}/reports/baseline-runs/three-node-sync-smoke-${run}.json"
           done
       - name: Generate median baseline candidate
         run: |
@@ -70,7 +70,7 @@ jobs:
             reports/baseline-candidate/three-node-sync-smoke.json
       - name: Upload baseline candidate and raw reports
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: benchmark-baseline-candidate-ubuntu-24.04
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,11 @@ jobs:
           cargo --version
       - name: Check
         run: cargo check --workspace --all-targets
+      - name: Check tokio-console integration
+        if: matrix.os == 'ubuntu-latest'
+        env:
+          RUSTFLAGS: --cfg tokio_unstable
+        run: cargo check -p nx-cli --features tokio-console
 
   fmt:
     name: Format

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,9 +113,44 @@ jobs:
           NUMAX_PREVIOUS_NX_BIN: ${{ runner.temp }}/numax-v0.1.0/target/release/nx
         run: cargo test -p nx-cli --test multiprocess_smoke -- --ignored
 
+  benchmark-regression:
+    name: Benchmark Regression Gate
+    runs-on: ubuntu-latest
+    env:
+      NUMAX_BENCH_GATE_MODE: ${{ vars.NUMAX_BENCH_GATE_MODE || 'shadow' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@9d7e65c320fdb52dcd45ffaa68deb6c02c8754d9 # v1.10.1
+        with:
+          toolchain: stable
+          rustflags: ""
+      - name: Run sync load benchmark
+        run: |
+          mkdir -p reports/bench
+          cargo bench -p nx-core --bench three_node_sync_load -- \
+            --duration-secs 10 \
+            --target-ops-sec-per-node 1000 \
+            --settle-secs 10 \
+            --report reports/bench/three-node-sync-smoke.json
+      - name: Compare against baseline
+        run: |
+          node scripts/compare-benchmark-report.mjs \
+            --baseline crates/nx-core/reports/baselines/three-node-sync-smoke.json \
+            --current reports/bench/three-node-sync-smoke.json \
+            --mode "${NUMAX_BENCH_GATE_MODE}" \
+            --p99-threshold 5 \
+            --throughput-threshold 5 \
+            --rss-threshold 5
+      - name: Upload benchmark report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-regression-report
+          path: reports/bench/three-node-sync-smoke.json
+
   ci-success:
     name: CI Success
-    needs: [check, fmt, clippy, test, build-wasm, cli-smoke]
+    needs: [check, fmt, clippy, test, build-wasm, cli-smoke, benchmark-regression]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -126,7 +161,8 @@ jobs:
              [[ "${{ needs.clippy.result }}" != "success" ]] || \
              [[ "${{ needs.test.result }}" != "success" ]] || \
              [[ "${{ needs.build-wasm.result }}" != "success" ]] || \
-             [[ "${{ needs.cli-smoke.result }}" != "success" ]]; then
+             [[ "${{ needs.cli-smoke.result }}" != "success" ]] || \
+             [[ "${{ needs.benchmark-regression.result }}" != "success" ]]; then
             echo "One or more jobs failed"
             exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,12 +2,16 @@ name: CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 env:
   CARGO_TERM_COLOR: always
+
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   check:
@@ -118,9 +122,19 @@ jobs:
           NUMAX_PREVIOUS_NX_BIN: ${{ runner.temp }}/numax-v0.1.0/target/release/nx
         run: cargo test -p nx-cli --test multiprocess_smoke -- --ignored
 
+  benchmark-tools:
+    name: Benchmark Comparator Tests
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test benchmark comparator
+        run: node scripts/compare-benchmark-report.test.mjs
+
   benchmark-regression:
     name: Benchmark Regression Gate
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    needs: benchmark-tools
     env:
       NUMAX_BENCH_GATE_MODE: ${{ vars.NUMAX_BENCH_GATE_MODE || 'shadow' }}
     steps:
@@ -129,23 +143,59 @@ jobs:
         with:
           toolchain: stable
           rustflags: ""
-      - name: Run sync load benchmark
+      - name: Run sync load benchmark three times
         run: |
           mkdir -p reports/bench
-          cargo bench -p nx-core --bench three_node_sync_load -- \
-            --duration-secs 10 \
-            --target-ops-sec-per-node 1000 \
-            --settle-secs 10 \
-            --report reports/bench/three-node-sync-smoke.json
-      - name: Compare against baseline
+          for run in 1 2 3; do
+            cargo bench -p nx-core --bench three_node_sync_load -- \
+              --duration-secs 10 \
+              --target-ops-sec-per-node 1000 \
+              --settle-secs 10 \
+              --report "reports/bench/three-node-sync-smoke-${run}.json"
+          done
+      - name: Compare median against baseline
         run: |
+          set +e
           node scripts/compare-benchmark-report.mjs \
             --baseline crates/nx-core/reports/baselines/three-node-sync-smoke.json \
-            --current reports/bench/three-node-sync-smoke.json \
+            --current reports/bench/three-node-sync-smoke-1.json \
+            --current reports/bench/three-node-sync-smoke-2.json \
+            --current reports/bench/three-node-sync-smoke-3.json \
+            --write-aggregate reports/bench/three-node-sync-smoke-median.json \
             --mode "${NUMAX_BENCH_GATE_MODE}" \
-            --p99-threshold 5 \
+            --p99-threshold 10 \
+            --p99-min-delta-ms 0.1 \
             --throughput-threshold 5 \
-            --rss-threshold 5
+            --rss-threshold 10 \
+            --rss-min-delta-bytes 16777216 \
+            2>&1 | tee reports/bench/comparison.txt
+          status=${PIPESTATUS[0]}
+          set -e
+          {
+            echo "### Benchmark regression gate"
+            echo '```text'
+            cat reports/bench/comparison.txt
+            echo '```'
+          } >> "${GITHUB_STEP_SUMMARY}"
+          exit "${status}"
+      - name: Upload benchmark reports
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-regression-report
+          path: reports/bench/
+          if-no-files-found: error
+
+  profiling-artifacts:
+    name: Ubuntu Profiling Artifacts
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@9d7e65c320fdb52dcd45ffaa68deb6c02c8754d9 # v1.10.1
+        with:
+          toolchain: stable
+          rustflags: ""
       - name: Generate Ubuntu CPU flamegraph
         run: |
           mkdir -p reports/profiling
@@ -170,12 +220,6 @@ jobs:
           test -s reports/profiling/three-node-sync-load-heap.json
           node -e "const p=JSON.parse(require('node:fs').readFileSync(process.argv[1], 'utf8')); if(p.mode!=='rust-heap'||!Array.isArray(p.pps))process.exit(1)" \
             reports/profiling/three-node-sync-load-heap.json
-      - name: Upload benchmark report
-        if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: benchmark-regression-report
-          path: reports/bench/three-node-sync-smoke.json
       - name: Upload Ubuntu CPU flamegraph
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
@@ -193,7 +237,16 @@ jobs:
 
   ci-success:
     name: CI Success
-    needs: [check, fmt, clippy, test, build-wasm, cli-smoke, benchmark-regression]
+    needs:
+      - check
+      - fmt
+      - clippy
+      - test
+      - build-wasm
+      - cli-smoke
+      - benchmark-tools
+      - benchmark-regression
+      - profiling-artifacts
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -205,7 +258,9 @@ jobs:
              [[ "${{ needs.test.result }}" != "success" ]] || \
              [[ "${{ needs.build-wasm.result }}" != "success" ]] || \
              [[ "${{ needs.cli-smoke.result }}" != "success" ]] || \
-             [[ "${{ needs.benchmark-regression.result }}" != "success" ]]; then
+             [[ "${{ needs.benchmark-tools.result }}" != "success" ]] || \
+             [[ "${{ needs.benchmark-regression.result }}" != "success" ]] || \
+             [[ "${{ needs.profiling-artifacts.result }}" != "success" ]]; then
             echo "One or more jobs failed"
             exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,18 @@ jobs:
             --cpu-profile reports/profiling/three-node-sync-load.svg
           test -s reports/profiling/three-node-sync-load.svg
           grep -q '<svg' reports/profiling/three-node-sync-load.svg
+      - name: Generate Ubuntu heap profile
+        run: |
+          cargo bench --profile profiling -p nx-core \
+            --features heap-profiling \
+            --bench three_node_sync_load -- \
+            --duration-secs 5 \
+            --target-ops-sec-per-node 250 \
+            --settle-secs 5 \
+            --heap-profile reports/profiling/three-node-sync-load-heap.json
+          test -s reports/profiling/three-node-sync-load-heap.json
+          node -e "const p=JSON.parse(require('node:fs').readFileSync(process.argv[1], 'utf8')); if(p.mode!=='rust-heap'||!Array.isArray(p.pps))process.exit(1)" \
+            reports/profiling/three-node-sync-load-heap.json
       - name: Upload benchmark report
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
@@ -170,6 +182,13 @@ jobs:
         with:
           name: cpu-flamegraph-ubuntu
           path: reports/profiling/three-node-sync-load.svg
+          if-no-files-found: error
+      - name: Upload Ubuntu heap profile
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: heap-profile-ubuntu
+          path: reports/profiling/three-node-sync-load-heap.json
           if-no-files-found: error
 
   ci-success:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,12 +146,31 @@ jobs:
             --p99-threshold 5 \
             --throughput-threshold 5 \
             --rss-threshold 5
+      - name: Generate Ubuntu CPU flamegraph
+        run: |
+          mkdir -p reports/profiling
+          cargo bench --profile profiling -p nx-core \
+            --features cpu-profiling \
+            --bench three_node_sync_load -- \
+            --duration-secs 10 \
+            --target-ops-sec-per-node 1000 \
+            --settle-secs 10 \
+            --cpu-profile reports/profiling/three-node-sync-load.svg
+          test -s reports/profiling/three-node-sync-load.svg
+          grep -q '<svg' reports/profiling/three-node-sync-load.svg
       - name: Upload benchmark report
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
           name: benchmark-regression-report
           path: reports/bench/three-node-sync-smoke.json
+      - name: Upload Ubuntu CPU flamegraph
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: cpu-flamegraph-ubuntu
+          path: reports/profiling/three-node-sync-load.svg
+          if-no-files-found: error
 
   ci-success:
     name: CI Success

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions-rust-lang/setup-rust-toolchain@9d7e65c320fdb52dcd45ffaa68deb6c02c8754d9 # v1.10.1
         with:
           toolchain: stable
@@ -42,7 +42,7 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions-rust-lang/setup-rust-toolchain@9d7e65c320fdb52dcd45ffaa68deb6c02c8754d9 # v1.10.1
         with:
           toolchain: stable
@@ -58,7 +58,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions-rust-lang/setup-rust-toolchain@9d7e65c320fdb52dcd45ffaa68deb6c02c8754d9 # v1.10.1
         with:
           toolchain: stable
@@ -74,7 +74,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions-rust-lang/setup-rust-toolchain@9d7e65c320fdb52dcd45ffaa68deb6c02c8754d9 # v1.10.1
         with:
           toolchain: stable
@@ -86,7 +86,7 @@ jobs:
     name: Build WASM Examples
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions-rust-lang/setup-rust-toolchain@9d7e65c320fdb52dcd45ffaa68deb6c02c8754d9 # v1.10.1
         with:
           toolchain: stable
@@ -103,7 +103,7 @@ jobs:
     name: CLI Multi-process Smoke
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: actions-rust-lang/setup-rust-toolchain@9d7e65c320fdb52dcd45ffaa68deb6c02c8754d9 # v1.10.1
@@ -126,7 +126,7 @@ jobs:
     name: Benchmark Comparator Tests
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Test benchmark comparator
         run: node scripts/compare-benchmark-report.test.mjs
 
@@ -138,7 +138,7 @@ jobs:
     env:
       NUMAX_BENCH_GATE_MODE: ${{ vars.NUMAX_BENCH_GATE_MODE || 'shadow' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions-rust-lang/setup-rust-toolchain@9d7e65c320fdb52dcd45ffaa68deb6c02c8754d9 # v1.10.1
         with:
           toolchain: stable
@@ -151,7 +151,7 @@ jobs:
               --duration-secs 10 \
               --target-ops-sec-per-node 1000 \
               --settle-secs 10 \
-              --report "reports/bench/three-node-sync-smoke-${run}.json"
+              --report "${GITHUB_WORKSPACE}/reports/bench/three-node-sync-smoke-${run}.json"
           done
       - name: Compare median against baseline
         run: |
@@ -180,7 +180,7 @@ jobs:
           exit "${status}"
       - name: Upload benchmark reports
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: benchmark-regression-report
           path: reports/bench/
@@ -191,7 +191,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions-rust-lang/setup-rust-toolchain@9d7e65c320fdb52dcd45ffaa68deb6c02c8754d9 # v1.10.1
         with:
           toolchain: stable
@@ -205,7 +205,7 @@ jobs:
             --duration-secs 10 \
             --target-ops-sec-per-node 1000 \
             --settle-secs 10 \
-            --cpu-profile reports/profiling/three-node-sync-load.svg
+            --cpu-profile "${GITHUB_WORKSPACE}/reports/profiling/three-node-sync-load.svg"
           test -s reports/profiling/three-node-sync-load.svg
           grep -q '<svg' reports/profiling/three-node-sync-load.svg
       - name: Generate Ubuntu heap profile
@@ -216,24 +216,24 @@ jobs:
             --duration-secs 5 \
             --target-ops-sec-per-node 250 \
             --settle-secs 5 \
-            --heap-profile reports/profiling/three-node-sync-load-heap.json
+            --heap-profile "${GITHUB_WORKSPACE}/reports/profiling/three-node-sync-load-heap.json"
           test -s reports/profiling/three-node-sync-load-heap.json
           node -e "const p=JSON.parse(require('node:fs').readFileSync(process.argv[1], 'utf8')); if(p.mode!=='rust-heap'||!Array.isArray(p.pps))process.exit(1)" \
             reports/profiling/three-node-sync-load-heap.json
       - name: Upload Ubuntu CPU flamegraph
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cpu-flamegraph-ubuntu
           path: reports/profiling/three-node-sync-load.svg
-          if-no-files-found: error
+          if-no-files-found: warn
       - name: Upload Ubuntu heap profile
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: heap-profile-ubuntu
           path: reports/profiling/three-node-sync-load-heap.json
-          if-no-files-found: error
+          if-no-files-found: warn
 
   ci-success:
     name: CI Success

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
     name: Build docs site
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ docs/nx-site/.astro/
 docs/nx-site/.npm/
 docs/nx-site/.yarn/
 docs/nx-site/.pnpm-store/
+
+# Local benchmark and profiling output (committed baselines live under crates/*/reports/baselines)
+/reports/bench/
+/reports/profiling/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -166,6 +172,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -192,6 +204,55 @@ dependencies = [
  "dunce",
  "fs_extra",
 ]
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "sync_wrapper",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -443,6 +504,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "console-api"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8599749b6667e2f0c910c1d0dff6901163ff698a52d5a39720f61b5be4b20d3"
+dependencies = [
+ "futures-core",
+ "prost",
+ "prost-types",
+ "tonic",
+ "tonic-prost",
+ "tracing-core",
+]
+
+[[package]]
+name = "console-subscriber"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb4915b7d8dd960457a1b6c380114c2944f728e7c65294ab247ae6b6f1f37592"
+dependencies = [
+ "console-api",
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "futures-task",
+ "hdrhistogram",
+ "humantime",
+ "hyper-util",
+ "prost",
+ "prost-types",
+ "serde",
+ "serde_json",
+ "thread_local",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -636,6 +737,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -852,6 +962,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1033,6 +1153,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1050,6 +1189,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
+name = "hdrhistogram"
+version = "7.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
+dependencies = [
+ "base64 0.21.7",
+ "byteorder",
+ "flate2",
+ "nom",
+ "num-traits",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1062,12 +1214,118 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "http"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "humantime"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
 dependencies = [
  "typenum",
+]
+
+[[package]]
+name = "hyper"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "libc",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1412,6 +1670,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "maybe-owned"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1433,10 +1697,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "mio"
@@ -1508,6 +1788,7 @@ version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap",
+ "console-subscriber",
  "nx-core",
  "serde",
  "tokio",
@@ -1644,7 +1925,7 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde_core",
 ]
 
@@ -1662,6 +1943,26 @@ checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
  "indexmap",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1725,6 +2026,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -2146,6 +2479,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
 name = "sized-chunks"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2224,6 +2563,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "synstructure"
@@ -2383,6 +2728,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.61.2",
 ]
 
@@ -2430,6 +2776,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "toml"
 version = "0.9.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2467,6 +2826,77 @@ name = "toml_writer"
 version = "1.0.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+
+[[package]]
+name = "tonic"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
+dependencies = [
+ "async-trait",
+ "axum",
+ "base64 0.22.1",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "socket2",
+ "sync_wrapper",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap",
+ "pin-project-lite",
+ "slab",
+ "sync_wrapper",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -2541,6 +2971,12 @@ dependencies = [
  "tracing-log",
  "tracing-serde",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
@@ -2625,6 +3061,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
 
 [[package]]
 name = "wasi"
@@ -2852,7 +3297,7 @@ version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e4fd4103ba413c0da2e636f73490c6c8e446d708cbde7573703941bc3d6a448"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "directories-next",
  "log",
  "postcard",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,11 +4,20 @@ version = 4
 
 [[package]]
 name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli 0.32.3",
+]
+
+[[package]]
+name = "addr2line"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59317f77929f0e679d39364702289274de2f0f0b22cbf50b2b8cff2169a0b27a"
 dependencies = [
- "gimli",
+ "gimli 0.33.0",
 ]
 
 [[package]]
@@ -18,12 +27,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "aligned-vec"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
+dependencies = [
+ "equator",
 ]
 
 [[package]]
@@ -249,6 +280,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line 0.25.1",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object 0.37.3",
+ "rustc-demangle",
+ "windows-link",
+]
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -330,6 +376,12 @@ checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 dependencies = [
  "allocator-api2",
 ]
+
+[[package]]
+name = "bytemuck"
+version = "1.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6aedf8ae72766347502cf3cb4f41cf5e9cc37d28bee90f1fdaaae15f9cf9424"
 
 [[package]]
 name = "byteorder"
@@ -642,7 +694,7 @@ dependencies = [
  "cranelift-control",
  "cranelift-entity",
  "cranelift-isle",
- "gimli",
+ "gimli 0.33.0",
  "hashbrown 0.16.1",
  "libm",
  "log",
@@ -917,6 +969,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "equator"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -954,6 +1026,18 @@ name = "find-msvc-tools"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
+
+[[package]]
+name = "findshlibs"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
+dependencies = [
+ "cc",
+ "lazy_static",
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "fixedbitset"
@@ -1142,6 +1226,12 @@ dependencies = [
 
 [[package]]
 name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
+name = "gimli"
 version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
@@ -1206,6 +1296,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1487,6 +1583,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "inferno"
+version = "0.11.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "232929e1d75fe899576a3d5c7416ad0d88dbfbb3c3d6aa00873a7408a50ddb88"
+dependencies = [
+ "ahash",
+ "indexmap",
+ "is-terminal",
+ "itoa",
+ "log",
+ "num-format",
+ "once_cell",
+ "quick-xml",
+ "rgb",
+ "str_stack",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1516,6 +1630,17 @@ name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -1697,6 +1822,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memmap2"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1727,6 +1861,17 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -1763,6 +1908,16 @@ name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
+name = "num-format"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
+dependencies = [
+ "arrayvec",
+ "itoa",
+]
 
 [[package]]
 name = "num-integer"
@@ -1807,6 +1962,7 @@ dependencies = [
  "nx-net",
  "nx-store",
  "nx-sync",
+ "pprof",
  "serde_json",
  "sha2 0.11.0",
  "tempfile",
@@ -1859,6 +2015,15 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "uuid",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2011,6 +2176,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "pprof"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38a01da47675efa7673b032bf8efd8214f1917d89685e07e395ab125ea42b187"
+dependencies = [
+ "aligned-vec",
+ "backtrace",
+ "cfg-if",
+ "findshlibs",
+ "inferno",
+ "libc",
+ "log",
+ "nix",
+ "once_cell",
+ "smallvec",
+ "spin",
+ "symbolic-demangle",
+ "tempfile",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2081,6 +2268,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2221,6 +2417,15 @@ name = "regex-syntax"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+
+[[package]]
+name = "rgb"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "ring"
@@ -2536,10 +2741,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "str_stack"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f446288b699d66d0fd2e30d1cfe7869194312524b3b9252594868ed26ef056a"
 
 [[package]]
 name = "strsim"
@@ -2552,6 +2772,28 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "symbolic-common"
+version = "12.18.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "332615d90111d8eeaf86a84dc9bbe9f65d0d8c5cf11b4caccedc37754eb0dcfd"
+dependencies = [
+ "debugid",
+ "memmap2",
+ "stable_deref_trait",
+ "uuid",
+]
+
+[[package]]
+name = "symbolic-demangle"
+version = "12.18.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "912017718eb4d21930546245af9a3475c9dccf15675a5c215664e76621afc471"
+dependencies = [
+ "rustc-demangle",
+ "symbolic-common",
+]
 
 [[package]]
 name = "syn"
@@ -3213,7 +3455,7 @@ version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce205cd643d661b5ba5ba4717e13730262e8cdbc8f2eacbc7b906d45c1a74026"
 dependencies = [
- "addr2line",
+ "addr2line 0.26.1",
  "async-trait",
  "bitflags 2.10.0",
  "bumpalo",
@@ -3222,13 +3464,13 @@ dependencies = [
  "encoding_rs",
  "futures",
  "fxprof-processed-profile",
- "gimli",
+ "gimli 0.33.0",
  "ittapi",
  "libc",
  "log",
  "mach2",
  "memfd",
- "object",
+ "object 0.38.1",
  "once_cell",
  "postcard",
  "pulley-interpreter",
@@ -3271,11 +3513,11 @@ dependencies = [
  "cranelift-bforest",
  "cranelift-bitset",
  "cranelift-entity",
- "gimli",
+ "gimli 0.33.0",
  "hashbrown 0.16.1",
  "indexmap",
  "log",
- "object",
+ "object 0.38.1",
  "postcard",
  "rustc-demangle",
  "semver",
@@ -3356,10 +3598,10 @@ dependencies = [
  "cranelift-entity",
  "cranelift-frontend",
  "cranelift-native",
- "gimli",
+ "gimli 0.33.0",
  "itertools",
  "log",
- "object",
+ "object 0.38.1",
  "pulley-interpreter",
  "smallvec",
  "target-lexicon",
@@ -3393,7 +3635,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d950310d07391d34369f62c48336ebb14eacbd4d6f772bb5f349c24e838e0664"
 dependencies = [
  "cc",
- "object",
+ "object 0.38.1",
  "rustix 1.1.3",
  "wasmtime-internal-versioned-export-macros",
 ]
@@ -3419,7 +3661,7 @@ dependencies = [
  "cfg-if",
  "cranelift-codegen",
  "log",
- "object",
+ "object 0.38.1",
  "wasmtime-environ",
 ]
 
@@ -3441,9 +3683,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8007342bd12ff400293a817973f7ecd6f1d9a8549a53369a9c1af357166f1f1e"
 dependencies = [
  "cranelift-codegen",
- "gimli",
+ "gimli 0.33.0",
  "log",
- "object",
+ "object 0.38.1",
  "target-lexicon",
  "wasmparser 0.245.1",
  "wasmtime-environ",
@@ -3617,7 +3859,7 @@ checksum = "eb9f45f7172a2628c8317766e427babc0a400f9d10b1c0f0b0617c5ed5b79de6"
 dependencies = [
  "cranelift-assembler-x64",
  "cranelift-codegen",
- "gimli",
+ "gimli 0.33.0",
  "regalloc2",
  "smallvec",
  "target-lexicon",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -700,7 +700,7 @@ dependencies = [
  "log",
  "pulley-interpreter",
  "regalloc2",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "serde",
  "smallvec",
  "target-lexicon",
@@ -880,6 +880,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "dhat"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cd11d84628e233de0ce467de10b8633f4ddaecafadefc86e13b84b8739b827"
+dependencies = [
+ "backtrace",
+ "lazy_static",
+ "mintex",
+ "parking_lot 0.12.5",
+ "rustc-hash 1.1.0",
+ "serde",
+ "serde_json",
+ "thousands",
 ]
 
 [[package]]
@@ -1185,7 +1201,7 @@ checksum = "25234f20a3ec0a962a61770cfe39ecf03cb529a6e474ad8cff025ed497eda557"
 dependencies = [
  "bitflags 2.10.0",
  "debugid",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1853,6 +1869,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mintex"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c505b3e17ed6b70a7ed2e67fbb2c560ee327353556120d6e72f5232b6880d536"
+
+[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1958,6 +1980,7 @@ version = "0.1.1"
 dependencies = [
  "anyhow",
  "blake3",
+ "dhat",
  "getrandom 0.3.4",
  "nx-net",
  "nx-store",
@@ -2067,7 +2090,17 @@ checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.8.6",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core 0.9.12",
 ]
 
 [[package]]
@@ -2079,9 +2112,22 @@ dependencies = [
  "cfg-if",
  "instant",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "smallvec",
  "winapi",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.5.18",
+ "smallvec",
+ "windows-link",
 ]
 
 [[package]]
@@ -2377,6 +2423,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.10.0",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2397,7 +2452,7 @@ dependencies = [
  "bumpalo",
  "hashbrown 0.17.0",
  "log",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "smallvec",
 ]
 
@@ -2446,6 +2501,12 @@ name = "rustc-demangle"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -2718,7 +2779,7 @@ dependencies = [
  "fxhash",
  "libc",
  "log",
- "parking_lot",
+ "parking_lot 0.11.2",
 ]
 
 [[package]]
@@ -2906,6 +2967,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "thousands"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
 name = "thread_local"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,8 @@ members = [
 exclude = [
   "examples/*"
 ]
+
+[profile.profiling]
+inherits = "release"
+debug = true
+strip = false

--- a/README.md
+++ b/README.md
@@ -19,9 +19,6 @@ Three things, and only three:
 
 You write a WASM module. numax runs it. The state is there. Sync just happens.
 
-> **Status:** `v0.1.0` - first stable Numax release line for controlled, non-critical workloads.
-> It works, it's tested, and the remaining limits are documented. See the [`Roadmap`](https://gianiac.github.io/numax/roadmap/).
-
 ---
 
 ## Why

--- a/crates/nx-cli/Cargo.toml
+++ b/crates/nx-cli/Cargo.toml
@@ -3,9 +3,14 @@ name = "nx-cli"
 version = "0.1.1"
 edition = "2024"
 
+[features]
+default = []
+tokio-console = ["dep:console-subscriber", "tokio/tracing"]
+
 [dependencies]
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
+console-subscriber = { version = "0.5", optional = true }
 nx-core = { version = "0.1.1", path = "../nx-core" }
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }

--- a/crates/nx-cli/src/config.rs
+++ b/crates/nx-cli/src/config.rs
@@ -9,6 +9,8 @@ use nx_core::runtime::RuntimeConfig;
 use nx_core::{ObservabilityConfig, SerializationFormat, SyncConfig, TlsConfig};
 use serde::Deserialize;
 use tracing::warn;
+#[cfg(feature = "tokio-console")]
+use tracing_subscriber::prelude::*;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, ValueEnum)]
 #[serde(rename_all = "lowercase")]
@@ -758,22 +760,58 @@ fn validate_optional_duration(name: &str, value: Option<&str>) -> Result<()> {
     Ok(())
 }
 
-pub(crate) fn init_logging(log_level: &str, log_format: LogFormat) {
+pub(crate) fn init_logging(
+    log_level: &str,
+    log_format: LogFormat,
+    tokio_console: bool,
+) -> Result<()> {
+    let env_filter = || {
+        tracing_subscriber::EnvFilter::try_from_default_env()
+            .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new(log_level))
+    };
+
+    #[cfg(feature = "tokio-console")]
+    if tokio_console {
+        let console_layer = console_subscriber::spawn();
+        match log_format {
+            LogFormat::Text => tracing_subscriber::registry()
+                .with(console_layer)
+                .with(tracing_subscriber::fmt::layer().with_filter(env_filter()))
+                .try_init()
+                .map_err(|e| anyhow::anyhow!("initialize tracing subscriber: {e}"))?,
+            LogFormat::Json => tracing_subscriber::registry()
+                .with(console_layer)
+                .with(
+                    tracing_subscriber::fmt::layer()
+                        .json()
+                        .with_filter(env_filter()),
+                )
+                .try_init()
+                .map_err(|e| anyhow::anyhow!("initialize tracing subscriber: {e}"))?,
+        }
+        return Ok(());
+    }
+
+    #[cfg(not(feature = "tokio-console"))]
+    if tokio_console {
+        bail!(
+            "--tokio-console requires a binary built with --features tokio-console and RUSTFLAGS=\"--cfg tokio_unstable\""
+        );
+    }
+
     match log_format {
         LogFormat::Text => tracing_subscriber::fmt()
-            .with_env_filter(
-                tracing_subscriber::EnvFilter::try_from_default_env()
-                    .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new(log_level)),
-            )
-            .init(),
+            .with_env_filter(env_filter())
+            .try_init()
+            .map_err(|e| anyhow::anyhow!("initialize tracing subscriber: {e}"))?,
         LogFormat::Json => tracing_subscriber::fmt()
             .json()
-            .with_env_filter(
-                tracing_subscriber::EnvFilter::try_from_default_env()
-                    .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new(log_level)),
-            )
-            .init(),
+            .with_env_filter(env_filter())
+            .try_init()
+            .map_err(|e| anyhow::anyhow!("initialize tracing subscriber: {e}"))?,
     }
+
+    Ok(())
 }
 
 pub(crate) fn resolve_log_level(

--- a/crates/nx-cli/src/main.rs
+++ b/crates/nx-cli/src/main.rs
@@ -95,6 +95,10 @@ enum Cli {
         #[arg(long, value_name = "ADDR")]
         observability_listen: Option<String>,
 
+        /// Expose Tokio task diagnostics to tokio-console (requires the tokio-console feature).
+        #[arg(long)]
+        tokio_console: bool,
+
         /// Path to this node's TLS certificate (PEM)
         #[arg(long, value_name = "PATH")]
         tls_cert: Option<PathBuf>,
@@ -209,6 +213,7 @@ async fn real_main() -> Result<()> {
             log_level,
             log_format,
             observability_listen,
+            tokio_console,
             tls_cert,
             tls_key,
             tls_ca,
@@ -235,7 +240,7 @@ async fn real_main() -> Result<()> {
             let effective = EffectiveRunConfig::resolve(cli, &file_config)?;
 
             // Setup logging
-            init_logging(&effective.log_level, effective.log_format);
+            init_logging(&effective.log_level, effective.log_format, tokio_console)?;
 
             validate_settle_mode(&effective.sync, settle_for)?;
             validate_wait_before_run(&effective.sync, wait_before_run)?;
@@ -1438,6 +1443,15 @@ mod tests {
                     assert_eq!(log_level.as_deref(), Some("debug"));
                     assert_eq!(log_format, Some(LogFormat::Json));
                 }
+                _ => panic!("expected run command"),
+            }
+        }
+
+        #[test]
+        fn tokio_console_flag_parsed() {
+            let cli = Cli::try_parse_from(["nx", "run", "x.wasm", "--tokio-console"]).unwrap();
+            match cli {
+                Cli::Run { tokio_console, .. } => assert!(tokio_console),
                 _ => panic!("expected run command"),
             }
         }

--- a/crates/nx-core/Cargo.toml
+++ b/crates/nx-core/Cargo.toml
@@ -3,6 +3,9 @@ name = "nx-core"
 version = "0.1.1"
 edition = "2024"
 
+[features]
+cpu-profiling = ["dep:pprof"]
+
 [dependencies]
 anyhow = "1"
 blake3 = "1"
@@ -16,6 +19,9 @@ nx-sync = { version = "0.1.1", path = "../nx-sync" }
 nx-net = { version = "0.1.1", path = "../nx-net" }
 tokio = { version = "1", features = ["io-util", "net", "signal", "sync", "time"] }
 tracing = "0.1"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+pprof = { version = "0.15", optional = true, default-features = false, features = ["flamegraph"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/nx-core/Cargo.toml
+++ b/crates/nx-core/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [features]
 cpu-profiling = ["dep:pprof"]
+heap-profiling = ["dep:dhat"]
 
 [dependencies]
 anyhow = "1"
@@ -21,6 +22,7 @@ tokio = { version = "1", features = ["io-util", "net", "signal", "sync", "time"]
 tracing = "0.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
+dhat = { version = "0.3.3", optional = true }
 pprof = { version = "0.15", optional = true, default-features = false, features = ["flamegraph"] }
 
 [dev-dependencies]

--- a/crates/nx-core/benches/chaos_sync_load.rs
+++ b/crates/nx-core/benches/chaos_sync_load.rs
@@ -23,6 +23,7 @@ const HISTOGRAM_MAX_MICROS: usize = 1_000_000;
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(10);
 const LOAD_LIMIT_HEADROOM_OPS: u64 = 100_000;
 const LOAD_TEST_MAX_MESSAGE_SIZE: usize = 256 * 1024 * 1024;
+const REPORT_SCHEMA_VERSION: u32 = 1;
 
 #[derive(Debug)]
 struct Config {
@@ -38,6 +39,8 @@ struct Config {
 struct Report {
     scenario: &'static str,
     nodes: usize,
+    duration_secs: u64,
+    restart_every_secs: u64,
     load_duration_secs: f64,
     total_duration_secs: f64,
     target_ops_sec: u64,
@@ -52,6 +55,7 @@ struct Report {
     observed_counters: Vec<u64>,
     converged: bool,
     convergence_wait_secs: f64,
+    rss_bytes: Option<u64>,
     latency: LatencySnapshot,
 }
 
@@ -239,6 +243,8 @@ async fn run_async(config: Config) -> Result<(), String> {
     let report = Report {
         scenario: "chaos-sync-restart-gcounter",
         nodes: nodes.len(),
+        duration_secs: config.duration.as_secs(),
+        restart_every_secs: config.restart_every.as_secs(),
         load_duration_secs: load_elapsed.as_secs_f64(),
         total_duration_secs: started.elapsed().as_secs_f64(),
         target_ops_sec: config.target_ops_sec,
@@ -253,6 +259,7 @@ async fn run_async(config: Config) -> Result<(), String> {
         observed_counters,
         converged,
         convergence_wait_secs: convergence_started.elapsed().as_secs_f64(),
+        rss_bytes: current_rss_bytes(),
         latency: latencies.snapshot(),
     };
     let json = report.to_json();
@@ -499,7 +506,16 @@ impl Report {
         format!(
             concat!(
                 "{{\n",
+                "  \"report_schema_version\": {},\n",
+                "  \"crate\": \"nx-core\",\n",
+                "  \"benchmark\": \"chaos_sync_load\",\n",
                 "  \"scenario\": \"{}\",\n",
+                "  \"profile\": {{\n",
+                "    \"nodes\": {},\n",
+                "    \"duration_secs\": {},\n",
+                "    \"target_ops_sec\": {},\n",
+                "    \"restart_every_secs\": {}\n",
+                "  }},\n",
                 "  \"nodes\": {},\n",
                 "  \"load_duration_secs\": {:.3},\n",
                 "  \"total_duration_secs\": {:.3},\n",
@@ -515,6 +531,9 @@ impl Report {
                 "  \"observed_counters\": [{}],\n",
                 "  \"converged\": {},\n",
                 "  \"convergence_wait_secs\": {:.3},\n",
+                "  \"resources\": {{\n",
+                "    \"rss_bytes\": {}\n",
+                "  }},\n",
                 "  \"latency_ms\": {{\n",
                 "    \"p50\": {:.3},\n",
                 "    \"p95\": {:.3},\n",
@@ -524,7 +543,12 @@ impl Report {
                 "  }}\n",
                 "}}"
             ),
+            REPORT_SCHEMA_VERSION,
             self.scenario,
+            self.nodes,
+            self.duration_secs,
+            self.target_ops_sec,
+            self.restart_every_secs,
             self.nodes,
             self.load_duration_secs,
             self.total_duration_secs,
@@ -540,6 +564,7 @@ impl Report {
             join_u64s(&self.observed_counters),
             self.converged,
             self.convergence_wait_secs,
+            json_option_u64(self.rss_bytes),
             self.latency.p50_ms,
             self.latency.p95_ms,
             self.latency.p99_ms,
@@ -590,6 +615,31 @@ fn next_value(args: &mut impl Iterator<Item = String>, name: &str) -> Result<Str
 
 fn micros_to_ms(micros: u64) -> f64 {
     micros as f64 / 1_000.0
+}
+
+fn json_option_u64(value: Option<u64>) -> String {
+    match value {
+        Some(value) => value.to_string(),
+        None => "null".to_string(),
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn current_rss_bytes() -> Option<u64> {
+    let status = fs::read_to_string("/proc/self/status").ok()?;
+    for line in status.lines() {
+        let Some(rest) = line.strip_prefix("VmRSS:") else {
+            continue;
+        };
+        let kb = rest.split_whitespace().next()?.parse::<u64>().ok()?;
+        return kb.checked_mul(1024);
+    }
+    None
+}
+
+#[cfg(not(target_os = "linux"))]
+fn current_rss_bytes() -> Option<u64> {
+    None
 }
 
 fn print_help() {

--- a/crates/nx-core/benches/three_node_sync_load.rs
+++ b/crates/nx-core/benches/three_node_sync_load.rs
@@ -16,6 +16,10 @@ use nx_sync::{GCounter, NodeId, Op};
 use tokio::task::JoinHandle;
 use tokio::time::{MissedTickBehavior, interval, sleep, timeout};
 
+#[cfg(all(feature = "heap-profiling", target_os = "linux"))]
+#[global_allocator]
+static HEAP_PROFILING_ALLOCATOR: dhat::Alloc = dhat::Alloc;
+
 const DEFAULT_DURATION_SECS: u64 = 30;
 const DEFAULT_TARGET_OPS_SEC_PER_NODE: u64 = 1_000;
 const DEFAULT_SETTLE_SECS: u64 = 10;
@@ -41,6 +45,7 @@ struct Config {
     anti_entropy_interval: Duration,
     report: Option<PathBuf>,
     cpu_profile: Option<PathBuf>,
+    heap_profile: Option<PathBuf>,
 }
 
 #[cfg(all(feature = "cpu-profiling", target_os = "linux"))]
@@ -55,6 +60,18 @@ enum CpuProfiler {
 
 #[cfg(not(all(feature = "cpu-profiling", target_os = "linux")))]
 struct CpuProfiler;
+
+#[cfg(all(feature = "heap-profiling", target_os = "linux"))]
+enum HeapProfiler {
+    Disabled,
+    Enabled {
+        profiler: dhat::Profiler,
+        output: PathBuf,
+    },
+}
+
+#[cfg(not(all(feature = "heap-profiling", target_os = "linux")))]
+struct HeapProfiler;
 
 #[derive(Debug)]
 struct Report {
@@ -188,6 +205,7 @@ async fn run_async(config: Config) -> Result<(), String> {
     wait_for_full_mesh(&nodes).await?;
 
     let cpu_profiler = CpuProfiler::start(config.cpu_profile.clone())?;
+    let heap_profiler = HeapProfiler::start(config.heap_profile.clone())?;
     let started = Instant::now();
     let mut producers = Vec::new();
     for node in &nodes {
@@ -214,6 +232,7 @@ async fn run_async(config: Config) -> Result<(), String> {
 
     let load_elapsed = started.elapsed();
     cpu_profiler.finish()?;
+    heap_profiler.finish()?;
     let expected_counter = ops_total - errors_total;
     let convergence_started = Instant::now();
     let converged = wait_for_convergence(&nodes, key, expected_counter, config.settle).await;
@@ -484,6 +503,7 @@ impl Config {
             anti_entropy_interval: Duration::ZERO,
             report: None,
             cpu_profile: None,
+            heap_profile: None,
         };
 
         let mut args = args.peekable();
@@ -511,6 +531,9 @@ impl Config {
                 "--cpu-profile" => {
                     config.cpu_profile = Some(PathBuf::from(next_value(&mut args, &arg)?));
                 }
+                "--heap-profile" => {
+                    config.heap_profile = Some(PathBuf::from(next_value(&mut args, &arg)?));
+                }
                 "--bench" => {}
                 "--help" | "-h" => {
                     print_help();
@@ -529,10 +552,20 @@ impl Config {
         if config.target_ops_sec_per_node == 0 {
             return Err("--target-ops-sec-per-node must be greater than zero".to_string());
         }
+        if config.cpu_profile.is_some() && config.heap_profile.is_some() {
+            return Err(
+                "--cpu-profile and --heap-profile must run in separate processes".to_string(),
+            );
+        }
         if config.cpu_profile.is_some()
             && !cfg!(all(feature = "cpu-profiling", target_os = "linux"))
         {
             return Err("--cpu-profile requires the cpu-profiling feature on Linux".to_string());
+        }
+        if config.heap_profile.is_some()
+            && !cfg!(all(feature = "heap-profiling", target_os = "linux"))
+        {
+            return Err("--heap-profile requires the heap-profiling feature on Linux".to_string());
         }
         if config.anti_entropy_interval.is_zero() {
             config.anti_entropy_interval = config
@@ -587,6 +620,63 @@ impl CpuProfiler {
             .flamegraph(file)
             .map_err(|e| format!("write CPU flamegraph {}: {e}", output.display()))?;
         println!("CPU flamegraph written to {}", output.display());
+        Ok(())
+    }
+}
+
+#[cfg(all(feature = "heap-profiling", target_os = "linux"))]
+impl HeapProfiler {
+    fn start(output: Option<PathBuf>) -> Result<Self, String> {
+        let Some(output) = output else {
+            return Ok(Self::Disabled);
+        };
+        if let Some(parent) = output
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+        {
+            fs::create_dir_all(parent)
+                .map_err(|e| format!("create heap profile directory: {e}"))?;
+        }
+        let profiler = dhat::Profiler::builder().file_name(&output).build();
+        Ok(Self::Enabled { profiler, output })
+    }
+
+    fn finish(self) -> Result<(), String> {
+        let Self::Enabled { profiler, output } = self else {
+            return Ok(());
+        };
+        let stats = dhat::HeapStats::get();
+        drop(profiler);
+        let profile_size = fs::metadata(&output)
+            .map_err(|e| format!("read heap profile {}: {e}", output.display()))?
+            .len();
+        if profile_size == 0 {
+            return Err(format!("heap profile {} is empty", output.display()));
+        }
+        println!(
+            "Heap profile written to {} (total: {} bytes in {} allocations; peak: {} bytes in {} allocations; retained: {} bytes in {} allocations)",
+            output.display(),
+            stats.total_bytes,
+            stats.total_blocks,
+            stats.max_bytes,
+            stats.max_blocks,
+            stats.curr_bytes,
+            stats.curr_blocks
+        );
+        Ok(())
+    }
+}
+
+#[cfg(not(all(feature = "heap-profiling", target_os = "linux")))]
+impl HeapProfiler {
+    fn start(output: Option<PathBuf>) -> Result<Self, String> {
+        if output.is_some() {
+            return Err("--heap-profile requires the heap-profiling feature on Linux".to_string());
+        }
+        Ok(Self)
+    }
+
+    fn finish(self) -> Result<(), String> {
         Ok(())
     }
 }
@@ -761,12 +851,16 @@ Options:
   --anti-entropy-secs N             Periodic pull interval; default keeps repair traffic outside the run window
   --report PATH                     Write JSON report to PATH
   --cpu-profile PATH                Write a load-phase CPU flamegraph (Linux, requires feature cpu-profiling)
+  --heap-profile PATH               Write a load-phase DHAT heap profile (Linux, requires feature heap-profiling)
 
 Smoke example:
   cargo bench -p nx-core --bench three_node_sync_load -- --duration-secs 10 --target-ops-sec-per-node 1000
 
 CPU profiling example (Linux):
   cargo bench --profile profiling -p nx-core --features cpu-profiling --bench three_node_sync_load -- --duration-secs 10 --target-ops-sec-per-node 1000 --cpu-profile reports/profiling/three-node-sync-load.svg
+
+Heap profiling example (Linux):
+  cargo bench --profile profiling -p nx-core --features heap-profiling --bench three_node_sync_load -- --duration-secs 5 --target-ops-sec-per-node 250 --heap-profile reports/profiling/three-node-sync-load-heap.json
 "
     );
 }

--- a/crates/nx-core/benches/three_node_sync_load.rs
+++ b/crates/nx-core/benches/three_node_sync_load.rs
@@ -1,5 +1,7 @@
 use std::env;
 use std::fs;
+#[cfg(all(feature = "cpu-profiling", target_os = "linux"))]
+use std::fs::File;
 use std::net::TcpListener;
 use std::path::PathBuf;
 use std::process;
@@ -25,6 +27,10 @@ const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(10);
 const LOAD_LIMIT_HEADROOM_OPS: u64 = 100_000;
 const LOAD_TEST_MAX_MESSAGE_SIZE: usize = 256 * 1024 * 1024;
 const REPORT_SCHEMA_VERSION: u32 = 1;
+#[cfg(all(feature = "cpu-profiling", target_os = "linux"))]
+const CPU_PROFILE_FREQUENCY_HZ: i32 = 100;
+#[cfg(all(feature = "cpu-profiling", target_os = "linux"))]
+const CPU_PROFILE_BLOCKLIST: &[&str] = &["libc", "libgcc", "pthread", "vdso"];
 
 #[derive(Debug)]
 struct Config {
@@ -34,7 +40,21 @@ struct Config {
     settle: Duration,
     anti_entropy_interval: Duration,
     report: Option<PathBuf>,
+    cpu_profile: Option<PathBuf>,
 }
+
+#[cfg(all(feature = "cpu-profiling", target_os = "linux"))]
+enum CpuProfiler {
+    Disabled,
+    Enabled {
+        guard: pprof::ProfilerGuard<'static>,
+        output: PathBuf,
+        file: File,
+    },
+}
+
+#[cfg(not(all(feature = "cpu-profiling", target_os = "linux")))]
+struct CpuProfiler;
 
 #[derive(Debug)]
 struct Report {
@@ -167,6 +187,7 @@ async fn run_async(config: Config) -> Result<(), String> {
     let mut nodes = start_full_mesh(&addrs, limits, config.anti_entropy_interval).await?;
     wait_for_full_mesh(&nodes).await?;
 
+    let cpu_profiler = CpuProfiler::start(config.cpu_profile.clone())?;
     let started = Instant::now();
     let mut producers = Vec::new();
     for node in &nodes {
@@ -192,6 +213,7 @@ async fn run_async(config: Config) -> Result<(), String> {
     }
 
     let load_elapsed = started.elapsed();
+    cpu_profiler.finish()?;
     let expected_counter = ops_total - errors_total;
     let convergence_started = Instant::now();
     let converged = wait_for_convergence(&nodes, key, expected_counter, config.settle).await;
@@ -461,6 +483,7 @@ impl Config {
             settle: Duration::from_secs(DEFAULT_SETTLE_SECS),
             anti_entropy_interval: Duration::ZERO,
             report: None,
+            cpu_profile: None,
         };
 
         let mut args = args.peekable();
@@ -485,6 +508,9 @@ impl Config {
                 "--report" => {
                     config.report = Some(PathBuf::from(next_value(&mut args, &arg)?));
                 }
+                "--cpu-profile" => {
+                    config.cpu_profile = Some(PathBuf::from(next_value(&mut args, &arg)?));
+                }
                 "--bench" => {}
                 "--help" | "-h" => {
                     print_help();
@@ -503,6 +529,11 @@ impl Config {
         if config.target_ops_sec_per_node == 0 {
             return Err("--target-ops-sec-per-node must be greater than zero".to_string());
         }
+        if config.cpu_profile.is_some()
+            && !cfg!(all(feature = "cpu-profiling", target_os = "linux"))
+        {
+            return Err("--cpu-profile requires the cpu-profiling feature on Linux".to_string());
+        }
         if config.anti_entropy_interval.is_zero() {
             config.anti_entropy_interval = config
                 .duration
@@ -510,6 +541,67 @@ impl Config {
                 .saturating_add(Duration::from_secs(60));
         }
         Ok(config)
+    }
+}
+
+#[cfg(all(feature = "cpu-profiling", target_os = "linux"))]
+impl CpuProfiler {
+    fn start(output: Option<PathBuf>) -> Result<Self, String> {
+        let Some(output) = output else {
+            return Ok(Self::Disabled);
+        };
+        if let Some(parent) = output
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+        {
+            fs::create_dir_all(parent).map_err(|e| format!("create CPU profile directory: {e}"))?;
+        }
+        let file = File::create(&output)
+            .map_err(|e| format!("create CPU profile {}: {e}", output.display()))?;
+        let guard = pprof::ProfilerGuardBuilder::default()
+            .frequency(CPU_PROFILE_FREQUENCY_HZ)
+            .blocklist(CPU_PROFILE_BLOCKLIST)
+            .build()
+            .map_err(|e| format!("start CPU profiler: {e}"))?;
+        Ok(Self::Enabled {
+            guard,
+            output,
+            file,
+        })
+    }
+
+    fn finish(self) -> Result<(), String> {
+        let Self::Enabled {
+            guard,
+            output,
+            file,
+        } = self
+        else {
+            return Ok(());
+        };
+        let report = guard
+            .report()
+            .build()
+            .map_err(|e| format!("build CPU profile report: {e}"))?;
+        report
+            .flamegraph(file)
+            .map_err(|e| format!("write CPU flamegraph {}: {e}", output.display()))?;
+        println!("CPU flamegraph written to {}", output.display());
+        Ok(())
+    }
+}
+
+#[cfg(not(all(feature = "cpu-profiling", target_os = "linux")))]
+impl CpuProfiler {
+    fn start(output: Option<PathBuf>) -> Result<Self, String> {
+        if output.is_some() {
+            return Err("--cpu-profile requires the cpu-profiling feature on Linux".to_string());
+        }
+        Ok(Self)
+    }
+
+    fn finish(self) -> Result<(), String> {
+        Ok(())
     }
 }
 
@@ -668,9 +760,13 @@ Options:
   --settle-secs N                   Time allowed for final convergence (default: {DEFAULT_SETTLE_SECS})
   --anti-entropy-secs N             Periodic pull interval; default keeps repair traffic outside the run window
   --report PATH                     Write JSON report to PATH
+  --cpu-profile PATH                Write a load-phase CPU flamegraph (Linux, requires feature cpu-profiling)
 
 Smoke example:
   cargo bench -p nx-core --bench three_node_sync_load -- --duration-secs 10 --target-ops-sec-per-node 1000
+
+CPU profiling example (Linux):
+  cargo bench --profile profiling -p nx-core --features cpu-profiling --bench three_node_sync_load -- --duration-secs 10 --target-ops-sec-per-node 1000 --cpu-profile reports/profiling/three-node-sync-load.svg
 "
     );
 }

--- a/crates/nx-core/benches/three_node_sync_load.rs
+++ b/crates/nx-core/benches/three_node_sync_load.rs
@@ -24,6 +24,7 @@ const SEND_TIMEOUT: Duration = Duration::from_secs(5);
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(10);
 const LOAD_LIMIT_HEADROOM_OPS: u64 = 100_000;
 const LOAD_TEST_MAX_MESSAGE_SIZE: usize = 256 * 1024 * 1024;
+const REPORT_SCHEMA_VERSION: u32 = 1;
 
 #[derive(Debug)]
 struct Config {
@@ -39,6 +40,7 @@ struct Config {
 struct Report {
     scenario: &'static str,
     nodes: usize,
+    duration_secs: u64,
     load_duration_secs: f64,
     total_duration_secs: f64,
     target_ops_sec_per_node: u64,
@@ -54,6 +56,7 @@ struct Report {
     observed_counters: Vec<u64>,
     converged: bool,
     convergence_wait_secs: f64,
+    rss_bytes: Option<u64>,
     latency: LatencySnapshot,
 }
 
@@ -197,6 +200,7 @@ async fn run_async(config: Config) -> Result<(), String> {
     let report = Report {
         scenario: "multi-node-sync-gcounter",
         nodes: nodes.len(),
+        duration_secs: config.duration.as_secs(),
         load_duration_secs: load_elapsed.as_secs_f64(),
         total_duration_secs: started.elapsed().as_secs_f64(),
         target_ops_sec_per_node: config.target_ops_sec_per_node,
@@ -212,6 +216,7 @@ async fn run_async(config: Config) -> Result<(), String> {
         observed_counters,
         converged,
         convergence_wait_secs: convergence_started.elapsed().as_secs_f64(),
+        rss_bytes: current_rss_bytes(),
         latency: latencies.snapshot(),
     };
     let json = report.to_json();
@@ -513,7 +518,16 @@ impl Report {
         format!(
             concat!(
                 "{{\n",
+                "  \"report_schema_version\": {},\n",
+                "  \"crate\": \"nx-core\",\n",
+                "  \"benchmark\": \"three_node_sync_load\",\n",
                 "  \"scenario\": \"{}\",\n",
+                "  \"profile\": {{\n",
+                "    \"nodes\": {},\n",
+                "    \"duration_secs\": {},\n",
+                "    \"target_ops_sec_per_node\": {},\n",
+                "    \"anti_entropy_interval_secs\": {}\n",
+                "  }},\n",
                 "  \"nodes\": {},\n",
                 "  \"load_duration_secs\": {:.3},\n",
                 "  \"total_duration_secs\": {:.3},\n",
@@ -530,6 +544,9 @@ impl Report {
                 "  \"observed_counters\": [{}],\n",
                 "  \"converged\": {},\n",
                 "  \"convergence_wait_secs\": {:.3},\n",
+                "  \"resources\": {{\n",
+                "    \"rss_bytes\": {}\n",
+                "  }},\n",
                 "  \"latency_ms\": {{\n",
                 "    \"p50\": {:.3},\n",
                 "    \"p95\": {:.3},\n",
@@ -539,7 +556,12 @@ impl Report {
                 "  }}\n",
                 "}}"
             ),
+            REPORT_SCHEMA_VERSION,
             self.scenario,
+            self.nodes,
+            self.duration_secs,
+            self.target_ops_sec_per_node,
+            self.anti_entropy_interval_secs,
             self.nodes,
             self.load_duration_secs,
             self.total_duration_secs,
@@ -556,6 +578,7 @@ impl Report {
             join_u64s(&self.observed_counters),
             self.converged,
             self.convergence_wait_secs,
+            json_option_u64(self.rss_bytes),
             self.latency.p50_ms,
             self.latency.p95_ms,
             self.latency.p99_ms,
@@ -606,6 +629,31 @@ fn next_value(args: &mut impl Iterator<Item = String>, name: &str) -> Result<Str
 
 fn micros_to_ms(micros: u64) -> f64 {
     micros as f64 / 1_000.0
+}
+
+fn json_option_u64(value: Option<u64>) -> String {
+    match value {
+        Some(value) => value.to_string(),
+        None => "null".to_string(),
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn current_rss_bytes() -> Option<u64> {
+    let status = fs::read_to_string("/proc/self/status").ok()?;
+    for line in status.lines() {
+        let Some(rest) = line.strip_prefix("VmRSS:") else {
+            continue;
+        };
+        let kb = rest.split_whitespace().next()?.parse::<u64>().ok()?;
+        return kb.checked_mul(1024);
+    }
+    None
+}
+
+#[cfg(not(target_os = "linux"))]
+fn current_rss_bytes() -> Option<u64> {
+    None
 }
 
 fn print_help() {

--- a/crates/nx-core/reports/baselines/README.md
+++ b/crates/nx-core/reports/baselines/README.md
@@ -1,0 +1,14 @@
+Baseline reports for `nx-core` load benchmarks.
+
+These files use `report_schema_version = 1` and are the inputs future
+regression checks compare against. They are intentionally separate from
+`reports/load/`, which remains historical benchmark output.
+
+Naming convention:
+
+- `<scenario-profile>.json` for committed baselines;
+- `*-smoke.json` for short PR or shadow-CI scenarios;
+- longer release-gate scenarios can be added beside them once they are stable.
+
+Initial baselines are normalized from existing committed load reports, so
+`resources.rss_bytes` is `null` until fresh v1 reports replace them.

--- a/crates/nx-core/reports/baselines/README.md
+++ b/crates/nx-core/reports/baselines/README.md
@@ -12,3 +12,33 @@ Naming convention:
 
 Initial baselines are normalized from existing committed load reports, so
 `resources.rss_bytes` is `null` until fresh v1 reports replace them.
+
+## Regression gate
+
+Pull-request CI runs the three-node smoke profile three times on
+`ubuntu-24.04` and compares the median p99 latency, throughput, and RSS against
+`three-node-sync-smoke.json`. Raw runs, the median report, and the comparison
+summary are uploaded as the `benchmark-regression-report` artifact.
+
+The gate starts in `shadow` mode. Set the repository variable
+`NUMAX_BENCH_GATE_MODE=blocking` only after committing a reviewed CI-generated
+baseline with a non-null RSS value.
+
+## Baseline calibration
+
+Run the manual **Benchmark Baseline Calibration** workflow. It executes five
+identical benchmark runs, writes their median to
+`reports/baseline-candidate/three-node-sync-smoke.json`, and uploads the
+candidate together with every raw report. The workflow never modifies the
+repository automatically.
+
+Before replacing the committed baseline:
+
+1. inspect all five raw reports for outliers and errors;
+2. verify that the candidate has a finite `resources.rss_bytes`;
+3. review the p99, throughput, and RSS deltas in the workflow summary;
+4. commit the candidate through a normal pull request.
+
+The initial shadow thresholds are 10% plus 0.1 ms for p99, 5% for throughput,
+and 10% plus 16 MiB for RSS. Both the relative and absolute threshold must be
+exceeded for p99 or RSS to count as a regression.

--- a/crates/nx-core/reports/baselines/chaos-sync-smoke.json
+++ b/crates/nx-core/reports/baselines/chaos-sync-smoke.json
@@ -1,0 +1,37 @@
+{
+  "report_schema_version": 1,
+  "crate": "nx-core",
+  "benchmark": "chaos_sync_load",
+  "scenario": "chaos-sync-restart-gcounter",
+  "profile": {
+    "nodes": 3,
+    "duration_secs": 30,
+    "target_ops_sec": 100,
+    "restart_every_secs": 10
+  },
+  "nodes": 3,
+  "load_duration_secs": 30.001,
+  "total_duration_secs": 30.103,
+  "target_ops_sec": 100,
+  "ops_total": 3000,
+  "ops_sec_avg": 100.00,
+  "errors_total": 0,
+  "restarts_total": 2,
+  "queued_ops_limit": 103000,
+  "op_log_limit": 103000,
+  "seen_ops_limit": 309000,
+  "expected_counter": 3000,
+  "observed_counters": [3000, 3000, 3000],
+  "converged": true,
+  "convergence_wait_secs": 0.102,
+  "resources": {
+    "rss_bytes": null
+  },
+  "latency_ms": {
+    "p50": 0.002,
+    "p95": 0.032,
+    "p99": 0.043,
+    "max": 0.070,
+    "avg": 0.005
+  }
+}

--- a/crates/nx-core/reports/baselines/ten-node-sync-smoke.json
+++ b/crates/nx-core/reports/baselines/ten-node-sync-smoke.json
@@ -1,0 +1,38 @@
+{
+  "report_schema_version": 1,
+  "crate": "nx-core",
+  "benchmark": "three_node_sync_load",
+  "scenario": "multi-node-sync-gcounter",
+  "profile": {
+    "nodes": 10,
+    "duration_secs": 30,
+    "target_ops_sec_per_node": 100,
+    "anti_entropy_interval_secs": 110
+  },
+  "nodes": 10,
+  "load_duration_secs": 30.021,
+  "total_duration_secs": 30.021,
+  "target_ops_sec_per_node": 100,
+  "target_ops_sec_total": 1000,
+  "ops_total": 30000,
+  "ops_sec_avg": 999.31,
+  "errors_total": 0,
+  "queued_ops_limit": 103000,
+  "op_log_limit": 103000,
+  "seen_ops_limit": 1030000,
+  "anti_entropy_interval_secs": 110,
+  "expected_counter": 30000,
+  "observed_counters": [30000, 30000, 30000, 30000, 30000, 30000, 30000, 30000, 30000, 30000],
+  "converged": true,
+  "convergence_wait_secs": 0.000,
+  "resources": {
+    "rss_bytes": null
+  },
+  "latency_ms": {
+    "p50": 0.005,
+    "p95": 0.017,
+    "p99": 0.028,
+    "max": 0.558,
+    "avg": 0.006
+  }
+}

--- a/crates/nx-core/reports/baselines/three-node-sync-smoke.json
+++ b/crates/nx-core/reports/baselines/three-node-sync-smoke.json
@@ -1,0 +1,38 @@
+{
+  "report_schema_version": 1,
+  "crate": "nx-core",
+  "benchmark": "three_node_sync_load",
+  "scenario": "multi-node-sync-gcounter",
+  "profile": {
+    "nodes": 3,
+    "duration_secs": 10,
+    "target_ops_sec_per_node": 1000,
+    "anti_entropy_interval_secs": 80
+  },
+  "nodes": 3,
+  "load_duration_secs": 10.024,
+  "total_duration_secs": 10.024,
+  "target_ops_sec_per_node": 1000,
+  "target_ops_sec_total": 3000,
+  "ops_total": 30000,
+  "ops_sec_avg": 2992.69,
+  "errors_total": 0,
+  "queued_ops_limit": 110000,
+  "op_log_limit": 110000,
+  "seen_ops_limit": 330000,
+  "anti_entropy_interval_secs": 80,
+  "expected_counter": 30000,
+  "observed_counters": [30000, 30000, 30000],
+  "converged": true,
+  "convergence_wait_secs": 0.000,
+  "resources": {
+    "rss_bytes": null
+  },
+  "latency_ms": {
+    "p50": 0.004,
+    "p95": 0.008,
+    "p99": 0.226,
+    "max": 25.563,
+    "avg": 0.057
+  }
+}

--- a/crates/nx-core/src/observability.rs
+++ b/crates/nx-core/src/observability.rs
@@ -1,6 +1,7 @@
+use std::collections::BTreeMap;
 use std::net::SocketAddr;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use anyhow::{Result, anyhow};
@@ -13,6 +14,8 @@ use tokio::time::timeout;
 use tracing::{debug, warn};
 
 pub const DEFAULT_OBSERVABILITY_REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+const MAX_WASM_MODULE_METRIC_LABELS: usize = 128;
+const WASM_MODULE_OVERFLOW_LABEL: &str = "overflow";
 
 #[derive(Debug, Clone)]
 pub struct ObservabilityConfig {
@@ -46,7 +49,24 @@ pub struct RuntimeMetrics {
     peer_disconnects_total: AtomicU64,
     broadcast_batches_total: AtomicU64,
     broadcast_ops_total: AtomicU64,
+    wasm_modules: Mutex<BTreeMap<String, WasmModuleMetrics>>,
     ready: AtomicBool,
+}
+
+#[derive(Clone, Default)]
+struct WasmModuleMetrics {
+    invocations_ok: u64,
+    invocations_error: u64,
+    cache_hits: u64,
+    cache_misses: u64,
+    compilation_duration_ns: u64,
+    instantiations: u64,
+    instantiation_duration_ns: u64,
+    executions: u64,
+    execution_duration_ns: u64,
+    linear_memory_current_bytes: u64,
+    linear_memory_peak_bytes: u64,
+    linear_memory_growth_bytes: u64,
 }
 
 impl RuntimeMetrics {
@@ -91,6 +111,85 @@ impl RuntimeMetrics {
             .fetch_add(ops as u64, Ordering::Relaxed);
     }
 
+    pub(crate) fn record_wasm_cache_lookup(&self, module: &str, hit: bool) {
+        self.update_wasm_module(module, |metrics| {
+            if hit {
+                metrics.cache_hits = metrics.cache_hits.saturating_add(1);
+            } else {
+                metrics.cache_misses = metrics.cache_misses.saturating_add(1);
+            }
+        });
+    }
+
+    pub(crate) fn record_wasm_compilation(&self, module: &str, duration: Duration) {
+        self.update_wasm_module(module, |metrics| {
+            metrics.compilation_duration_ns = metrics
+                .compilation_duration_ns
+                .saturating_add(duration_ns(duration));
+        });
+    }
+
+    pub(crate) fn record_wasm_instantiation(&self, module: &str, duration: Duration) {
+        self.update_wasm_module(module, |metrics| {
+            metrics.instantiations = metrics.instantiations.saturating_add(1);
+            metrics.instantiation_duration_ns = metrics
+                .instantiation_duration_ns
+                .saturating_add(duration_ns(duration));
+        });
+    }
+
+    pub(crate) fn record_wasm_execution(
+        &self,
+        module: &str,
+        duration: Duration,
+        initial_memory_bytes: u64,
+        final_memory_bytes: u64,
+    ) {
+        self.update_wasm_module(module, |metrics| {
+            metrics.executions = metrics.executions.saturating_add(1);
+            metrics.execution_duration_ns = metrics
+                .execution_duration_ns
+                .saturating_add(duration_ns(duration));
+            metrics.linear_memory_current_bytes = final_memory_bytes;
+            metrics.linear_memory_peak_bytes =
+                metrics.linear_memory_peak_bytes.max(final_memory_bytes);
+            metrics.linear_memory_growth_bytes = metrics
+                .linear_memory_growth_bytes
+                .saturating_add(final_memory_bytes.saturating_sub(initial_memory_bytes));
+        });
+    }
+
+    pub(crate) fn record_wasm_invocation(&self, module: &str, success: bool) {
+        self.update_wasm_module(module, |metrics| {
+            if success {
+                metrics.invocations_ok = metrics.invocations_ok.saturating_add(1);
+            } else {
+                metrics.invocations_error = metrics.invocations_error.saturating_add(1);
+            }
+        });
+    }
+
+    fn update_wasm_module(&self, module: &str, update: impl FnOnce(&mut WasmModuleMetrics)) {
+        let mut modules = self
+            .wasm_modules
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let label =
+            if modules.contains_key(module) || modules.len() < MAX_WASM_MODULE_METRIC_LABELS - 1 {
+                module
+            } else {
+                WASM_MODULE_OVERFLOW_LABEL
+            };
+        if let Some(metrics) = modules.get_mut(label) {
+            update(metrics);
+            return;
+        }
+
+        let mut metrics = WasmModuleMetrics::default();
+        update(&mut metrics);
+        modules.insert(label.to_string(), metrics);
+    }
+
     pub fn set_ready(&self, ready: bool) {
         self.ready.store(ready, Ordering::Relaxed);
     }
@@ -103,6 +202,12 @@ impl RuntimeMetrics {
                 nx_store::StoreStats { keys: 0, bytes: 0 }
             }
         };
+
+        let wasm_modules = self
+            .wasm_modules
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone();
 
         MetricsSnapshot {
             ops_total: self.ops_total.load(Ordering::Relaxed),
@@ -117,12 +222,22 @@ impl RuntimeMetrics {
             broadcast_ops_total: self.broadcast_ops_total.load(Ordering::Relaxed),
             store_keys: store_stats.keys,
             store_bytes: store_stats.bytes,
+            wasm_modules,
         }
     }
 
     fn is_ready(&self) -> bool {
         self.ready.load(Ordering::Relaxed)
     }
+
+    #[cfg(test)]
+    pub(crate) fn render_for_test(&self, store: &NxStore) -> String {
+        render_metrics(self.snapshot(store))
+    }
+}
+
+fn duration_ns(duration: Duration) -> u64 {
+    u64::try_from(duration.as_nanos()).unwrap_or(u64::MAX)
 }
 
 struct MetricsSnapshot {
@@ -138,6 +253,7 @@ struct MetricsSnapshot {
     broadcast_ops_total: u64,
     store_keys: u64,
     store_bytes: u64,
+    wasm_modules: BTreeMap<String, WasmModuleMetrics>,
 }
 
 pub struct ObservabilityServer {
@@ -255,7 +371,7 @@ async fn handle_connection(
 }
 
 fn render_metrics(snapshot: MetricsSnapshot) -> String {
-    format!(
+    let mut rendered = format!(
         "# HELP numax_ops_total Operations processed\n\
          # TYPE numax_ops_total counter\n\
          numax_ops_total {}\n\
@@ -304,7 +420,65 @@ fn render_metrics(snapshot: MetricsSnapshot) -> String {
         snapshot.broadcast_ops_total,
         snapshot.store_keys,
         snapshot.store_bytes
-    )
+    );
+
+    rendered.push_str(
+        "# HELP numax_wasm_invocations_total WASM module invocations by outcome\n\
+         # TYPE numax_wasm_invocations_total counter\n\
+         # HELP numax_wasm_module_cache_lookups_total WASM module cache lookups by result\n\
+         # TYPE numax_wasm_module_cache_lookups_total counter\n\
+         # HELP numax_wasm_compilation_duration_seconds_total Time spent compiling WASM modules\n\
+         # TYPE numax_wasm_compilation_duration_seconds_total counter\n\
+         # HELP numax_wasm_instantiation_duration_seconds_total Time spent instantiating WASM modules\n\
+         # TYPE numax_wasm_instantiation_duration_seconds_total counter\n\
+         # HELP numax_wasm_instantiations_total WASM module instantiations\n\
+         # TYPE numax_wasm_instantiations_total counter\n\
+         # HELP numax_wasm_execution_duration_seconds_total Time spent executing WASM entrypoints\n\
+         # TYPE numax_wasm_execution_duration_seconds_total counter\n\
+         # HELP numax_wasm_executions_total WASM entrypoint executions\n\
+         # TYPE numax_wasm_executions_total counter\n\
+         # HELP numax_wasm_linear_memory_current_bytes Linear memory after the latest WASM invocation\n\
+         # TYPE numax_wasm_linear_memory_current_bytes gauge\n\
+         # HELP numax_wasm_linear_memory_peak_bytes Highest observed WASM linear-memory size\n\
+         # TYPE numax_wasm_linear_memory_peak_bytes gauge\n\
+         # HELP numax_wasm_linear_memory_growth_bytes_total Cumulative WASM linear-memory growth\n\
+         # TYPE numax_wasm_linear_memory_growth_bytes_total counter\n",
+    );
+
+    for (module, metrics) in snapshot.wasm_modules {
+        rendered.push_str(&format!(
+            "numax_wasm_invocations_total{{module=\"{module}\",status=\"ok\"}} {}\n\
+             numax_wasm_invocations_total{{module=\"{module}\",status=\"error\"}} {}\n\
+             numax_wasm_module_cache_lookups_total{{module=\"{module}\",result=\"hit\"}} {}\n\
+             numax_wasm_module_cache_lookups_total{{module=\"{module}\",result=\"miss\"}} {}\n\
+             numax_wasm_compilation_duration_seconds_total{{module=\"{module}\"}} {:.9}\n\
+             numax_wasm_instantiation_duration_seconds_total{{module=\"{module}\"}} {:.9}\n\
+             numax_wasm_instantiations_total{{module=\"{module}\"}} {}\n\
+             numax_wasm_execution_duration_seconds_total{{module=\"{module}\"}} {:.9}\n\
+             numax_wasm_executions_total{{module=\"{module}\"}} {}\n\
+             numax_wasm_linear_memory_current_bytes{{module=\"{module}\"}} {}\n\
+             numax_wasm_linear_memory_peak_bytes{{module=\"{module}\"}} {}\n\
+             numax_wasm_linear_memory_growth_bytes_total{{module=\"{module}\"}} {}\n",
+            metrics.invocations_ok,
+            metrics.invocations_error,
+            metrics.cache_hits,
+            metrics.cache_misses,
+            seconds(metrics.compilation_duration_ns),
+            seconds(metrics.instantiation_duration_ns),
+            metrics.instantiations,
+            seconds(metrics.execution_duration_ns),
+            metrics.executions,
+            metrics.linear_memory_current_bytes,
+            metrics.linear_memory_peak_bytes,
+            metrics.linear_memory_growth_bytes,
+        ));
+    }
+
+    rendered
+}
+
+fn seconds(nanoseconds: u64) -> f64 {
+    nanoseconds as f64 / 1_000_000_000.0
 }
 
 #[cfg(test)]
@@ -336,6 +510,7 @@ mod tests {
             broadcast_ops_total: 8,
             store_keys: 3,
             store_bytes: 42,
+            wasm_modules: BTreeMap::new(),
         };
         let rendered = render_metrics(snapshot);
 
@@ -351,6 +526,63 @@ mod tests {
         assert!(rendered.contains("numax_broadcast_ops_total 8"));
         assert!(rendered.contains("numax_store_keys 3"));
         assert!(rendered.contains("numax_store_bytes 42"));
+    }
+
+    #[test]
+    fn wasm_module_metrics_are_rendered_with_a_stable_module_label() {
+        let metrics = RuntimeMetrics::default();
+        let store = temp_store();
+        let module = "0123456789abcdef";
+
+        metrics.record_wasm_cache_lookup(module, false);
+        metrics.record_wasm_cache_lookup(module, true);
+        metrics.record_wasm_compilation(module, Duration::from_millis(4));
+        metrics.record_wasm_instantiation(module, Duration::from_millis(2));
+        metrics.record_wasm_execution(module, Duration::from_millis(3), 65_536, 131_072);
+        metrics.record_wasm_invocation(module, true);
+        metrics.record_wasm_invocation(module, false);
+
+        let rendered = metrics.render_for_test(&store);
+
+        assert!(rendered.contains(&format!(
+            "numax_wasm_invocations_total{{module=\"{module}\",status=\"ok\"}} 1"
+        )));
+        assert!(rendered.contains(&format!(
+            "numax_wasm_invocations_total{{module=\"{module}\",status=\"error\"}} 1"
+        )));
+        assert!(rendered.contains(&format!(
+            "numax_wasm_module_cache_lookups_total{{module=\"{module}\",result=\"hit\"}} 1"
+        )));
+        assert!(rendered.contains(&format!(
+            "numax_wasm_execution_duration_seconds_total{{module=\"{module}\"}} 0.003000000"
+        )));
+        assert!(rendered.contains(&format!(
+            "numax_wasm_linear_memory_current_bytes{{module=\"{module}\"}} 131072"
+        )));
+        assert!(rendered.contains(&format!(
+            "numax_wasm_linear_memory_growth_bytes_total{{module=\"{module}\"}} 65536"
+        )));
+    }
+
+    #[test]
+    fn wasm_module_metrics_bound_label_cardinality() {
+        let metrics = RuntimeMetrics::default();
+        let store = temp_store();
+
+        for module in 0..MAX_WASM_MODULE_METRIC_LABELS + 10 {
+            metrics.record_wasm_invocation(&format!("module-{module}"), true);
+        }
+
+        let snapshot = metrics.snapshot(&store);
+        assert_eq!(snapshot.wasm_modules.len(), MAX_WASM_MODULE_METRIC_LABELS);
+        assert_eq!(
+            snapshot
+                .wasm_modules
+                .get(WASM_MODULE_OVERFLOW_LABEL)
+                .unwrap()
+                .invocations_ok,
+            11
+        );
     }
 
     #[tokio::test]

--- a/crates/nx-core/src/observability.rs
+++ b/crates/nx-core/src/observability.rs
@@ -16,6 +16,23 @@ use tracing::{debug, warn};
 pub const DEFAULT_OBSERVABILITY_REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
 const MAX_WASM_MODULE_METRIC_LABELS: usize = 128;
 const WASM_MODULE_OVERFLOW_LABEL: &str = "overflow";
+const REMOTE_OP_APPLY_BUCKETS: [(&str, u64); 15] = [
+    ("0.0001", 100_000),
+    ("0.00025", 250_000),
+    ("0.0005", 500_000),
+    ("0.001", 1_000_000),
+    ("0.0025", 2_500_000),
+    ("0.005", 5_000_000),
+    ("0.01", 10_000_000),
+    ("0.025", 25_000_000),
+    ("0.05", 50_000_000),
+    ("0.1", 100_000_000),
+    ("0.25", 250_000_000),
+    ("0.5", 500_000_000),
+    ("1", 1_000_000_000),
+    ("2.5", 2_500_000_000),
+    ("5", 5_000_000_000),
+];
 
 #[derive(Debug, Clone)]
 pub struct ObservabilityConfig {
@@ -49,6 +66,12 @@ pub struct RuntimeMetrics {
     peer_disconnects_total: AtomicU64,
     broadcast_batches_total: AtomicU64,
     broadcast_ops_total: AtomicU64,
+    remote_ops_received_total: AtomicU64,
+    remote_ops_applied_total: AtomicU64,
+    remote_ops_duplicate_total: AtomicU64,
+    remote_op_batches_total: AtomicU64,
+    remote_op_apply_errors_total: AtomicU64,
+    remote_op_batch_apply_duration: DurationHistogram,
     wasm_modules: Mutex<BTreeMap<String, WasmModuleMetrics>>,
     ready: AtomicBool,
 }
@@ -67,6 +90,44 @@ struct WasmModuleMetrics {
     linear_memory_current_bytes: u64,
     linear_memory_peak_bytes: u64,
     linear_memory_growth_bytes: u64,
+}
+
+#[derive(Default)]
+struct DurationHistogram {
+    buckets: [AtomicU64; REMOTE_OP_APPLY_BUCKETS.len()],
+    sum_ns: AtomicU64,
+    count: AtomicU64,
+}
+
+impl DurationHistogram {
+    fn record(&self, duration: Duration) {
+        let nanoseconds = duration_ns(duration);
+        // Increment count before the finite bucket so a concurrent scrape
+        // never observes a bucket value greater than the +Inf bucket.
+        self.count.fetch_add(1, Ordering::Relaxed);
+        self.sum_ns.fetch_add(nanoseconds, Ordering::Relaxed);
+        if let Some(index) = REMOTE_OP_APPLY_BUCKETS
+            .iter()
+            .position(|(_, upper_bound_ns)| nanoseconds <= *upper_bound_ns)
+        {
+            self.buckets[index].fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    fn snapshot(&self) -> DurationHistogramSnapshot {
+        DurationHistogramSnapshot {
+            buckets: std::array::from_fn(|index| self.buckets[index].load(Ordering::Relaxed)),
+            sum_ns: self.sum_ns.load(Ordering::Relaxed),
+            count: self.count.load(Ordering::Relaxed),
+        }
+    }
+}
+
+#[derive(Default)]
+struct DurationHistogramSnapshot {
+    buckets: [u64; REMOTE_OP_APPLY_BUCKETS.len()],
+    sum_ns: u64,
+    count: u64,
 }
 
 impl RuntimeMetrics {
@@ -109,6 +170,28 @@ impl RuntimeMetrics {
         self.broadcast_batches_total.fetch_add(1, Ordering::Relaxed);
         self.broadcast_ops_total
             .fetch_add(ops as u64, Ordering::Relaxed);
+    }
+
+    pub(crate) fn record_remote_op_batch(
+        &self,
+        received: usize,
+        applied: usize,
+        duplicates: usize,
+        duration: Duration,
+        failed: bool,
+    ) {
+        self.remote_ops_received_total
+            .fetch_add(received as u64, Ordering::Relaxed);
+        self.remote_ops_applied_total
+            .fetch_add(applied as u64, Ordering::Relaxed);
+        self.remote_ops_duplicate_total
+            .fetch_add(duplicates as u64, Ordering::Relaxed);
+        self.remote_op_batches_total.fetch_add(1, Ordering::Relaxed);
+        if failed {
+            self.remote_op_apply_errors_total
+                .fetch_add(1, Ordering::Relaxed);
+        }
+        self.remote_op_batch_apply_duration.record(duration);
     }
 
     pub(crate) fn record_wasm_cache_lookup(&self, module: &str, hit: bool) {
@@ -220,6 +303,12 @@ impl RuntimeMetrics {
             peer_disconnects_total: self.peer_disconnects_total.load(Ordering::Relaxed),
             broadcast_batches_total: self.broadcast_batches_total.load(Ordering::Relaxed),
             broadcast_ops_total: self.broadcast_ops_total.load(Ordering::Relaxed),
+            remote_ops_received_total: self.remote_ops_received_total.load(Ordering::Relaxed),
+            remote_ops_applied_total: self.remote_ops_applied_total.load(Ordering::Relaxed),
+            remote_ops_duplicate_total: self.remote_ops_duplicate_total.load(Ordering::Relaxed),
+            remote_op_batches_total: self.remote_op_batches_total.load(Ordering::Relaxed),
+            remote_op_apply_errors_total: self.remote_op_apply_errors_total.load(Ordering::Relaxed),
+            remote_op_batch_apply_duration: self.remote_op_batch_apply_duration.snapshot(),
             store_keys: store_stats.keys,
             store_bytes: store_stats.bytes,
             wasm_modules,
@@ -251,6 +340,12 @@ struct MetricsSnapshot {
     peer_disconnects_total: u64,
     broadcast_batches_total: u64,
     broadcast_ops_total: u64,
+    remote_ops_received_total: u64,
+    remote_ops_applied_total: u64,
+    remote_ops_duplicate_total: u64,
+    remote_op_batches_total: u64,
+    remote_op_apply_errors_total: u64,
+    remote_op_batch_apply_duration: DurationHistogramSnapshot,
     store_keys: u64,
     store_bytes: u64,
     wasm_modules: BTreeMap<String, WasmModuleMetrics>,
@@ -402,6 +497,21 @@ fn render_metrics(snapshot: MetricsSnapshot) -> String {
          # HELP numax_broadcast_ops_total Broadcast ops sent\n\
          # TYPE numax_broadcast_ops_total counter\n\
          numax_broadcast_ops_total {}\n\
+         # HELP numax_remote_ops_received_total Remote operations received before deduplication\n\
+         # TYPE numax_remote_ops_received_total counter\n\
+         numax_remote_ops_received_total {}\n\
+         # HELP numax_remote_ops_applied_total Remote operations successfully applied\n\
+         # TYPE numax_remote_ops_applied_total counter\n\
+         numax_remote_ops_applied_total {}\n\
+         # HELP numax_remote_ops_duplicate_total Duplicate remote operations skipped\n\
+         # TYPE numax_remote_ops_duplicate_total counter\n\
+         numax_remote_ops_duplicate_total {}\n\
+         # HELP numax_remote_op_batches_total Non-empty remote operation batches processed\n\
+         # TYPE numax_remote_op_batches_total counter\n\
+         numax_remote_op_batches_total {}\n\
+         # HELP numax_remote_op_apply_errors_total Remote operation batches that failed during apply or persistence\n\
+         # TYPE numax_remote_op_apply_errors_total counter\n\
+         numax_remote_op_apply_errors_total {}\n\
          # HELP numax_store_keys Keys in the local store\n\
          # TYPE numax_store_keys gauge\n\
          numax_store_keys {}\n\
@@ -418,8 +528,20 @@ fn render_metrics(snapshot: MetricsSnapshot) -> String {
         snapshot.peer_disconnects_total,
         snapshot.broadcast_batches_total,
         snapshot.broadcast_ops_total,
+        snapshot.remote_ops_received_total,
+        snapshot.remote_ops_applied_total,
+        snapshot.remote_ops_duplicate_total,
+        snapshot.remote_op_batches_total,
+        snapshot.remote_op_apply_errors_total,
         snapshot.store_keys,
         snapshot.store_bytes
+    );
+
+    render_duration_histogram(
+        &mut rendered,
+        "numax_remote_op_batch_apply_duration_seconds",
+        "Time to deduplicate, apply, persist, and commit a remote operation batch",
+        &snapshot.remote_op_batch_apply_duration,
     );
 
     rendered.push_str(
@@ -481,6 +603,28 @@ fn seconds(nanoseconds: u64) -> f64 {
     nanoseconds as f64 / 1_000_000_000.0
 }
 
+fn render_duration_histogram(
+    rendered: &mut String,
+    name: &str,
+    help: &str,
+    histogram: &DurationHistogramSnapshot,
+) {
+    rendered.push_str(&format!("# HELP {name} {help}\n# TYPE {name} histogram\n"));
+    let mut cumulative = 0u64;
+    for ((upper_bound, _), count) in REMOTE_OP_APPLY_BUCKETS.iter().zip(&histogram.buckets) {
+        cumulative = cumulative.saturating_add(*count);
+        rendered.push_str(&format!(
+            "{name}_bucket{{le=\"{upper_bound}\"}} {cumulative}\n"
+        ));
+    }
+    rendered.push_str(&format!(
+        "{name}_bucket{{le=\"+Inf\"}} {}\n{name}_sum {:.9}\n{name}_count {}\n",
+        histogram.count,
+        seconds(histogram.sum_ns),
+        histogram.count,
+    ));
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -508,6 +652,12 @@ mod tests {
             peer_disconnects_total: 2,
             broadcast_batches_total: 4,
             broadcast_ops_total: 8,
+            remote_ops_received_total: 6,
+            remote_ops_applied_total: 4,
+            remote_ops_duplicate_total: 2,
+            remote_op_batches_total: 3,
+            remote_op_apply_errors_total: 1,
+            remote_op_batch_apply_duration: DurationHistogramSnapshot::default(),
             store_keys: 3,
             store_bytes: 42,
             wasm_modules: BTreeMap::new(),
@@ -524,8 +674,40 @@ mod tests {
         assert!(rendered.contains("numax_peer_disconnects_total 2"));
         assert!(rendered.contains("numax_broadcast_batches_total 4"));
         assert!(rendered.contains("numax_broadcast_ops_total 8"));
+        assert!(rendered.contains("numax_remote_ops_received_total 6"));
+        assert!(rendered.contains("numax_remote_ops_applied_total 4"));
+        assert!(rendered.contains("numax_remote_ops_duplicate_total 2"));
+        assert!(rendered.contains("numax_remote_op_batches_total 3"));
+        assert!(rendered.contains("numax_remote_op_apply_errors_total 1"));
         assert!(rendered.contains("numax_store_keys 3"));
         assert!(rendered.contains("numax_store_bytes 42"));
+    }
+
+    #[test]
+    fn remote_op_batch_histogram_renders_cumulative_buckets_sum_and_count() {
+        let metrics = RuntimeMetrics::default();
+        let store = temp_store();
+
+        metrics.record_remote_op_batch(4, 3, 1, Duration::from_millis(3), false);
+        metrics.record_remote_op_batch(2, 0, 0, Duration::from_secs(2), true);
+
+        let rendered = metrics.render_for_test(&store);
+        assert!(
+            rendered
+                .contains("numax_remote_op_batch_apply_duration_seconds_bucket{le=\"0.0025\"} 0")
+        );
+        assert!(
+            rendered
+                .contains("numax_remote_op_batch_apply_duration_seconds_bucket{le=\"0.005\"} 1")
+        );
+        assert!(
+            rendered.contains("numax_remote_op_batch_apply_duration_seconds_bucket{le=\"2.5\"} 2")
+        );
+        assert!(
+            rendered.contains("numax_remote_op_batch_apply_duration_seconds_bucket{le=\"+Inf\"} 2")
+        );
+        assert!(rendered.contains("numax_remote_op_batch_apply_duration_seconds_sum 2.003000000"));
+        assert!(rendered.contains("numax_remote_op_batch_apply_duration_seconds_count 2"));
     }
 
     #[test]

--- a/crates/nx-core/src/runtime.rs
+++ b/crates/nx-core/src/runtime.rs
@@ -345,6 +345,9 @@ impl Runtime {
     }
 
     pub async fn run_module(&self, wasm_bytes: &[u8]) -> Result<()> {
+        let module_hash = blake3::hash(wasm_bytes);
+        let module_key = module_hash.to_hex().to_string();
+
         // handle shared to the DB
         let store_db = Arc::clone(&self.store);
         let module_id: Arc<str> = Arc::from(self.config.module_id.as_str());
@@ -386,33 +389,76 @@ impl Runtime {
         // Form completion / validation. Compiled modules are cached in-memory
         // so embedded runtimes can call run_module repeatedly without paying
         // Wasmtime compilation cost for identical bytes.
-        let module = self.compile_or_get_cached_module(wasm_bytes)?;
+        let compilation_started = Instant::now();
+        let (module, cache_hit) =
+            match self.compile_or_get_cached_module(wasm_bytes, *module_hash.as_bytes()) {
+                Ok(result) => result,
+                Err(error) => {
+                    self.metrics.record_wasm_cache_lookup(&module_key, false);
+                    self.metrics
+                        .record_wasm_compilation(&module_key, compilation_started.elapsed());
+                    self.metrics.record_wasm_invocation(&module_key, false);
+                    return Err(error);
+                }
+            };
+        self.metrics
+            .record_wasm_cache_lookup(&module_key, cache_hit);
+        if !cache_hit {
+            self.metrics
+                .record_wasm_compilation(&module_key, compilation_started.elapsed());
+        }
 
         // Instantiation
-        let instance = self
-            .linker
-            .instantiate_async(&mut store, &module)
-            .await
-            .map_err(|e| anyhow!("Link error while instantiating module: {e}"))?;
+        let instantiation_started = Instant::now();
+        let instance = match self.linker.instantiate_async(&mut store, &module).await {
+            Ok(instance) => instance,
+            Err(error) => {
+                self.metrics
+                    .record_wasm_instantiation(&module_key, instantiation_started.elapsed());
+                self.metrics.record_wasm_invocation(&module_key, false);
+                return Err(anyhow!("Link error while instantiating module: {error}"));
+            }
+        };
+        self.metrics
+            .record_wasm_instantiation(&module_key, instantiation_started.elapsed());
 
         // Entrypoint: run / _start
-        let run = instance
+        let run = match instance
             .get_typed_func::<(), ()>(&mut store, "run")
             .or_else(|_| instance.get_typed_func::<(), ()>(&mut store, "_start"))
-            .map_err(|e| anyhow!("No entrypoint found (expected `run` or `_start`): {e}"))?;
+        {
+            Ok(run) => run,
+            Err(error) => {
+                self.metrics.record_wasm_invocation(&module_key, false);
+                return Err(anyhow!(
+                    "No entrypoint found (expected `run` or `_start`): {error}"
+                ));
+            }
+        };
 
         // Execution
-        run.call_async(&mut store, ())
-            .await
-            .map_err(|e| anyhow!("Error while executing module: {e}"))?;
+        let initial_memory_bytes = exported_linear_memory_bytes(&instance, &mut store);
+        let execution_started = Instant::now();
+        let result = run.call_async(&mut store, ()).await;
+        let execution_duration = execution_started.elapsed();
+        let final_memory_bytes = exported_linear_memory_bytes(&instance, &mut store);
+        self.metrics.record_wasm_execution(
+            &module_key,
+            execution_duration,
+            initial_memory_bytes,
+            final_memory_bytes,
+        );
+        self.metrics
+            .record_wasm_invocation(&module_key, result.is_ok());
 
-        Ok(())
+        result.map_err(|error| anyhow!("Error while executing module: {error}"))
     }
 
-    fn compile_or_get_cached_module(&self, wasm_bytes: &[u8]) -> Result<Module> {
-        let hash = blake3::hash(wasm_bytes);
-        let cache_key = *hash.as_bytes();
-
+    fn compile_or_get_cached_module(
+        &self,
+        wasm_bytes: &[u8],
+        cache_key: [u8; 32],
+    ) -> Result<(Module, bool)> {
         if let Some(module) = self
             .module_cache
             .lock()
@@ -420,7 +466,7 @@ impl Runtime {
             .get(&cache_key)
             .cloned()
         {
-            return Ok(module);
+            return Ok((module, true));
         }
 
         let module = Module::new(&self.engine, wasm_bytes)
@@ -430,13 +476,23 @@ impl Runtime {
             .map_err(|_| anyhow!("module cache lock poisoned"))?
             .insert(cache_key, module.clone());
 
-        Ok(module)
+        Ok((module, false))
     }
 
     #[cfg(test)]
     fn cached_module_count(&self) -> usize {
         self.module_cache.lock().unwrap().len()
     }
+}
+
+fn exported_linear_memory_bytes(
+    instance: &wasmtime::Instance,
+    store: &mut Store<HostState>,
+) -> u64 {
+    instance
+        .get_memory(&mut *store, "memory")
+        .map(|memory| u64::try_from(memory.data_size(&*store)).unwrap_or(u64::MAX))
+        .unwrap_or(0)
 }
 
 fn load_or_create_node_id(store: &NxStore) -> Result<NodeId> {
@@ -531,6 +587,17 @@ mod tests {
             0x07, 0x07, 0x01, 0x03, b'r', b'u', b'n', 0x00, 0x00, // export run
             0x0a, 0x04, 0x01, 0x02, 0x00, 0x0b, // body
         ]
+    }
+
+    fn memory_growing_module() -> &'static [u8] {
+        br#"(module
+            (memory (export "memory") 1)
+            (func (export "run")
+                (drop (memory.grow (i32.const 1)))))"#
+    }
+
+    fn trapping_module() -> &'static [u8] {
+        br#"(module (func (export "run") unreachable))"#
     }
 
     #[tokio::test]
@@ -666,6 +733,67 @@ mod tests {
         runtime.run_module(&wasm).await.unwrap();
 
         assert_eq!(runtime.cached_module_count(), 1);
+        let module = blake3::hash(&wasm).to_hex().to_string();
+        let rendered = runtime.metrics.render_for_test(&runtime.store);
+        assert!(rendered.contains(&format!(
+            "numax_wasm_module_cache_lookups_total{{module=\"{module}\",result=\"hit\"}} 1"
+        )));
+        assert!(rendered.contains(&format!(
+            "numax_wasm_module_cache_lookups_total{{module=\"{module}\",result=\"miss\"}} 1"
+        )));
+    }
+
+    #[tokio::test]
+    async fn run_module_records_execution_and_linear_memory_growth() {
+        let config = RuntimeConfig {
+            datastore_path: temp_datastore_path("numax-runtime-module-metrics-test"),
+            enable_wasi: false,
+            ..RuntimeConfig::default()
+        };
+        let runtime = Runtime::new(config).unwrap();
+        let wasm = memory_growing_module();
+        let module = blake3::hash(wasm).to_hex().to_string();
+
+        runtime.run_module(wasm).await.unwrap();
+
+        let rendered = runtime.metrics.render_for_test(&runtime.store);
+        assert!(rendered.contains(&format!(
+            "numax_wasm_invocations_total{{module=\"{module}\",status=\"ok\"}} 1"
+        )));
+        assert!(rendered.contains(&format!(
+            "numax_wasm_executions_total{{module=\"{module}\"}} 1"
+        )));
+        assert!(rendered.contains(&format!(
+            "numax_wasm_linear_memory_current_bytes{{module=\"{module}\"}} 131072"
+        )));
+        assert!(rendered.contains(&format!(
+            "numax_wasm_linear_memory_peak_bytes{{module=\"{module}\"}} 131072"
+        )));
+        assert!(rendered.contains(&format!(
+            "numax_wasm_linear_memory_growth_bytes_total{{module=\"{module}\"}} 65536"
+        )));
+    }
+
+    #[tokio::test]
+    async fn run_module_records_traps_as_failed_invocations() {
+        let config = RuntimeConfig {
+            datastore_path: temp_datastore_path("numax-runtime-module-error-metrics-test"),
+            enable_wasi: false,
+            ..RuntimeConfig::default()
+        };
+        let runtime = Runtime::new(config).unwrap();
+        let wasm = trapping_module();
+        let module = blake3::hash(wasm).to_hex().to_string();
+
+        assert!(runtime.run_module(wasm).await.is_err());
+
+        let rendered = runtime.metrics.render_for_test(&runtime.store);
+        assert!(rendered.contains(&format!(
+            "numax_wasm_invocations_total{{module=\"{module}\",status=\"error\"}} 1"
+        )));
+        assert!(rendered.contains(&format!(
+            "numax_wasm_executions_total{{module=\"{module}\"}} 1"
+        )));
     }
 
     #[test]

--- a/crates/nx-core/src/sync_manager/apply.rs
+++ b/crates/nx-core/src/sync_manager/apply.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::sync::atomic::Ordering;
+use std::time::Instant;
 
 use nx_sync::{GCounter, LwwMap, LwwRegister, ORSet, Op, OpKind, PNCounter, Rga};
 use tracing::debug;
@@ -18,6 +19,8 @@ pub(super) async fn apply_remote_ops(
     if ops.is_empty() {
         return Ok(());
     }
+
+    let apply_started = Instant::now();
 
     let mut seen = context.seen_ops.write().await;
     let mut log = context.op_log.write().await;
@@ -92,7 +95,8 @@ pub(super) async fn apply_remote_ops(
         next_op_log_sequence = next_op_log_sequence.saturating_add(1);
     }
 
-    persist_remote_ops_batch(
+    let duplicate_count = ops.len().saturating_sub(inserted_ops.len());
+    if let Err(error) = persist_remote_ops_batch(
         context.store,
         &plans,
         RemoteCrdtUpdateBatch {
@@ -103,9 +107,18 @@ pub(super) async fn apply_remote_ops(
             orsets: &orset_updates,
             rgas: &rga_updates,
         },
-    )?;
+    ) {
+        context.metrics.record_remote_op_batch(
+            ops.len(),
+            0,
+            duplicate_count,
+            apply_started.elapsed(),
+            true,
+        );
+        return Err(error);
+    }
 
-    let applied_count = plans.len() as u64;
+    let applied_count = plans.len();
     apply_seen_insertions(&mut seen, &inserted_ids, &seen_evicted);
     log.extend(inserted_ops);
     prune_op_log_and_return_evicted(&mut log, context.op_log_limit);
@@ -135,9 +148,16 @@ pub(super) async fn apply_remote_ops(
         .store(next_op_log_sequence, Ordering::Relaxed);
 
     if applied_count > 0 {
-        context.metrics.record_ops(applied_count);
+        context.metrics.record_ops(applied_count as u64);
         debug!(count = applied_count, "applied remote ops batch");
     }
+    context.metrics.record_remote_op_batch(
+        ops.len(),
+        applied_count,
+        duplicate_count,
+        apply_started.elapsed(),
+        false,
+    );
 
     Ok(())
 }
@@ -487,7 +507,7 @@ mod tests {
         op_log: &Arc<RwLock<Vec<Op>>>,
         op_log_next_sequence: &Arc<AtomicU64>,
         store: &Arc<NxStore>,
-    ) {
+    ) -> Arc<RuntimeMetrics> {
         let pncounters = Arc::new(RwLock::new(HashMap::new()));
         let lww_registers = Arc::new(RwLock::new(HashMap::new()));
         let lww_maps = Arc::new(RwLock::new(HashMap::new()));
@@ -512,6 +532,7 @@ mod tests {
         apply_remote_ops(std::slice::from_ref(op), &context)
             .await
             .unwrap();
+        metrics
     }
 
     #[tokio::test]
@@ -569,7 +590,7 @@ mod tests {
             &store,
         )
         .await;
-        apply_remote_gcounter_op_for_test(
+        let duplicate_metrics = apply_remote_gcounter_op_for_test(
             &op,
             &counters,
             &seen_ops,
@@ -586,5 +607,12 @@ mod tests {
         buf.copy_from_slice(&bytes);
 
         assert_eq!(u64::from_le_bytes(buf), 3);
+        let rendered = duplicate_metrics.render_for_test(&store);
+        assert!(rendered.contains("numax_remote_ops_received_total 1"));
+        assert!(rendered.contains("numax_remote_ops_applied_total 0"));
+        assert!(rendered.contains("numax_remote_ops_duplicate_total 1"));
+        assert!(rendered.contains("numax_remote_op_batches_total 1"));
+        assert!(rendered.contains("numax_remote_op_apply_errors_total 0"));
+        assert!(rendered.contains("numax_remote_op_batch_apply_duration_seconds_count 1"));
     }
 }

--- a/crates/nx-store/benches/single_node_load.rs
+++ b/crates/nx-store/benches/single_node_load.rs
@@ -13,6 +13,7 @@ const DEFAULT_VALUE_SIZE: usize = 256;
 const DEFAULT_KEY_SPACE: u64 = 1_000_000;
 const TICK: Duration = Duration::from_millis(100);
 const HISTOGRAM_MAX_MICROS: usize = 1_000_000;
+const REPORT_SCHEMA_VERSION: u32 = 1;
 
 #[derive(Debug)]
 struct Config {
@@ -27,6 +28,7 @@ struct Config {
 #[derive(Debug)]
 struct Report {
     scenario: &'static str,
+    requested_duration_secs: u64,
     duration_secs: f64,
     target_ops_sec: u64,
     ops_total: u64,
@@ -35,6 +37,7 @@ struct Report {
     value_size: usize,
     key_space: u64,
     data_dir: String,
+    rss_bytes: Option<u64>,
     latency: LatencySnapshot,
 }
 
@@ -161,6 +164,7 @@ fn run() -> Result<(), String> {
     let elapsed = started.elapsed();
     let report = Report {
         scenario: "single-node-store-write",
+        requested_duration_secs: config.duration.as_secs(),
         duration_secs: elapsed.as_secs_f64(),
         target_ops_sec: config.target_ops_sec,
         ops_total: op_index,
@@ -169,6 +173,7 @@ fn run() -> Result<(), String> {
         value_size: config.value_size,
         key_space: config.key_space,
         data_dir: data_dir.display().to_string(),
+        rss_bytes: current_rss_bytes(),
         latency: latencies.snapshot(),
     };
     let json = report.to_json();
@@ -247,7 +252,16 @@ impl Report {
         format!(
             concat!(
                 "{{\n",
+                "  \"report_schema_version\": {},\n",
+                "  \"crate\": \"nx-store\",\n",
+                "  \"benchmark\": \"single_node_load\",\n",
                 "  \"scenario\": \"{}\",\n",
+                "  \"profile\": {{\n",
+                "    \"duration_secs\": {},\n",
+                "    \"target_ops_sec\": {},\n",
+                "    \"value_size\": {},\n",
+                "    \"key_space\": {}\n",
+                "  }},\n",
                 "  \"duration_secs\": {:.3},\n",
                 "  \"target_ops_sec\": {},\n",
                 "  \"ops_total\": {},\n",
@@ -256,6 +270,9 @@ impl Report {
                 "  \"value_size\": {},\n",
                 "  \"key_space\": {},\n",
                 "  \"data_dir\": \"{}\",\n",
+                "  \"resources\": {{\n",
+                "    \"rss_bytes\": {}\n",
+                "  }},\n",
                 "  \"latency_ms\": {{\n",
                 "    \"p50\": {:.3},\n",
                 "    \"p95\": {:.3},\n",
@@ -265,7 +282,12 @@ impl Report {
                 "  }}\n",
                 "}}"
             ),
+            REPORT_SCHEMA_VERSION,
             self.scenario,
+            self.requested_duration_secs,
+            self.target_ops_sec,
+            self.value_size,
+            self.key_space,
             self.duration_secs,
             self.target_ops_sec,
             self.ops_total,
@@ -274,6 +296,7 @@ impl Report {
             self.value_size,
             self.key_space,
             json_escape(&self.data_dir),
+            json_option_u64(self.rss_bytes),
             self.latency.p50_ms,
             self.latency.p95_ms,
             self.latency.p99_ms,
@@ -308,6 +331,31 @@ fn micros_to_ms(micros: u64) -> f64 {
 
 fn json_escape(value: &str) -> String {
     value.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+fn json_option_u64(value: Option<u64>) -> String {
+    match value {
+        Some(value) => value.to_string(),
+        None => "null".to_string(),
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn current_rss_bytes() -> Option<u64> {
+    let status = fs::read_to_string("/proc/self/status").ok()?;
+    for line in status.lines() {
+        let Some(rest) = line.strip_prefix("VmRSS:") else {
+            continue;
+        };
+        let kb = rest.split_whitespace().next()?.parse::<u64>().ok()?;
+        return kb.checked_mul(1024);
+    }
+    None
+}
+
+#[cfg(not(target_os = "linux"))]
+fn current_rss_bytes() -> Option<u64> {
+    None
 }
 
 fn print_help() {

--- a/crates/nx-store/reports/baselines/README.md
+++ b/crates/nx-store/reports/baselines/README.md
@@ -1,0 +1,8 @@
+Baseline reports for `nx-store` load benchmarks.
+
+These files use `report_schema_version = 1` and are the inputs future
+regression checks compare against. They are intentionally separate from
+`reports/load/`, which remains historical benchmark output.
+
+Initial baselines are normalized from existing committed load reports, so
+`resources.rss_bytes` is `null` until fresh v1 reports replace them.

--- a/crates/nx-store/reports/baselines/single-node-10k-1h.json
+++ b/crates/nx-store/reports/baselines/single-node-10k-1h.json
@@ -1,0 +1,30 @@
+{
+  "report_schema_version": 1,
+  "crate": "nx-store",
+  "benchmark": "single_node_load",
+  "scenario": "single-node-store-write",
+  "profile": {
+    "duration_secs": 3600,
+    "target_ops_sec": 10000,
+    "value_size": 256,
+    "key_space": 1000000
+  },
+  "duration_secs": 3600.036,
+  "target_ops_sec": 10000,
+  "ops_total": 35966000,
+  "ops_sec_avg": 9990.45,
+  "errors_total": 0,
+  "value_size": 256,
+  "key_space": 1000000,
+  "data_dir": "/tmp/.tmpgE3XxR",
+  "resources": {
+    "rss_bytes": null
+  },
+  "latency_ms": {
+    "p50": 0.001,
+    "p95": 0.004,
+    "p99": 0.009,
+    "max": 34.155,
+    "avg": 0.001
+  }
+}

--- a/docs/nx-site/src/content/docs/blog/v0-1-2-performance-profiling.md
+++ b/docs/nx-site/src/content/docs/blog/v0-1-2-performance-profiling.md
@@ -92,7 +92,7 @@ The roadmap calls out three new metrics:
 
 - `numax_module_cpu_ms` - per-WASM-module CPU time
 - `numax_module_memory_bytes` - per-WASM-module memory
-- `numax_op_apply_duration_ms` - CRDT op apply latency distribution
+- `numax_remote_op_batch_apply_duration_seconds` - remote CRDT batch apply latency distribution
 
 These aren't picked for aesthetics. They map exactly to the places where
 Numax's performance actually gets decided: **inside guest execution** and

--- a/docs/nx-site/src/content/docs/guides/observability.md
+++ b/docs/nx-site/src/content/docs/guides/observability.md
@@ -62,20 +62,20 @@ The Numax dashboard is provisioned automatically from
 
 The dashboard uses only metrics currently emitted by Numax:
 
-| Metric | Type | Meaning |
-|---|---|---|
-| `numax_ops_total` | counter | operations processed by the runtime |
-| `numax_peers_connected` | gauge | currently connected peers |
-| `numax_sync_latency_ms` | gauge | last recorded sync latency in milliseconds |
-| `numax_sync_errors_total` | counter | sync-related errors |
-| `numax_observability_requests_total` | counter | observability endpoint requests |
-| `numax_observability_errors_total` | counter | observability endpoint errors |
-| `numax_peer_connects_total` | counter | peer connection events |
-| `numax_peer_disconnects_total` | counter | peer disconnection events |
-| `numax_broadcast_batches_total` | counter | broadcast batches sent |
-| `numax_broadcast_ops_total` | counter | operations broadcast to peers |
-| `numax_store_keys` | gauge | key count in the local store |
-| `numax_store_bytes` | gauge | approximate store payload bytes |
+| Metric                               | Type    | Meaning                                    |
+| ------------------------------------ | ------- | ------------------------------------------ |
+| `numax_ops_total`                    | counter | operations processed by the runtime        |
+| `numax_peers_connected`              | gauge   | currently connected peers                  |
+| `numax_sync_latency_ms`              | gauge   | last recorded sync latency in milliseconds |
+| `numax_sync_errors_total`            | counter | sync-related errors                        |
+| `numax_observability_requests_total` | counter | observability endpoint requests            |
+| `numax_observability_errors_total`   | counter | observability endpoint errors              |
+| `numax_peer_connects_total`          | counter | peer connection events                     |
+| `numax_peer_disconnects_total`       | counter | peer disconnection events                  |
+| `numax_broadcast_batches_total`      | counter | broadcast batches sent                     |
+| `numax_broadcast_ops_total`          | counter | operations broadcast to peers              |
+| `numax_store_keys`                   | gauge   | key count in the local store               |
+| `numax_store_bytes`                  | gauge   | approximate store payload bytes            |
 
 ## Useful PromQL
 
@@ -157,5 +157,24 @@ cargo bench --profile profiling -p nx-core \
   --cpu-profile reports/profiling/three-node-sync-load.svg
 ```
 
-The `cpu-profiling` feature and the `profiling` Cargo profile do not affect the default Numax runtime or the unprofiled regression benchmark. CI uses Ubuntu as the canonical profiling environment and uploads the SVG as `cpu-flamegraph-ubuntu`; cross-platform profiling remains a post-`v0.2.0`
-candidate.
+The `cpu-profiling` feature and the `profiling` Cargo profile do not affect the default Numax runtime or the unprofiled regression benchmark. CI uses Ubuntu as the canonical profiling environment and uploads the SVG as `cpu-flamegraph-ubuntu`; cross-platform profiling remains a post-`v0.2.0` candidate.
+
+## Heap Profiles On Ubuntu/Linux
+
+The same benchmark can generate an opt-in DHAT profile for allocations made during the load phase. Run it separately from CPU profiling so that the DHAT allocator does not distort CPU samples:
+
+```bash
+cargo bench --profile profiling -p nx-core \
+  --features heap-profiling \
+  --bench three_node_sync_load -- \
+  --duration-secs 5 \
+  --target-ops-sec-per-node 250 \
+  --settle-secs 5 \
+  --heap-profile reports/profiling/three-node-sync-load-heap.json
+```
+
+Open the resulting JSON in the DHAT viewer to inspect allocation sites, peak
+memory, and memory still live when the load phase ends. CI validates the JSON
+and uploads it as `heap-profile-ubuntu`; it is a diagnostic artifact, not a
+regression threshold. The feature is disabled in normal builds and does not
+change the default allocator or the unprofiled regression benchmark.

--- a/docs/nx-site/src/content/docs/guides/observability.md
+++ b/docs/nx-site/src/content/docs/guides/observability.md
@@ -74,6 +74,12 @@ The dashboard uses only metrics currently emitted by Numax:
 | `numax_peer_disconnects_total`       | counter | peer disconnection events                  |
 | `numax_broadcast_batches_total`      | counter | broadcast batches sent                     |
 | `numax_broadcast_ops_total`          | counter | operations broadcast to peers              |
+| `numax_remote_ops_received_total`    | counter | remote operations received before deduplication |
+| `numax_remote_ops_applied_total`     | counter | remote operations successfully applied     |
+| `numax_remote_ops_duplicate_total`   | counter | duplicate remote operations skipped        |
+| `numax_remote_op_batches_total`      | counter | non-empty remote operation batches processed |
+| `numax_remote_op_apply_errors_total` | counter | remote batches that failed during apply or persistence |
+| `numax_remote_op_batch_apply_duration_seconds` | histogram | end-to-end remote batch apply latency |
 | `numax_store_keys`                   | gauge   | key count in the local store               |
 | `numax_store_bytes`                  | gauge   | approximate store payload bytes            |
 | `numax_wasm_invocations_total`       | counter | module invocations by outcome              |
@@ -100,6 +106,20 @@ Broadcast throughput:
 
 ```txt
 rate(numax_broadcast_ops_total[1m])
+```
+
+Remote apply p95 latency:
+
+```txt
+histogram_quantile(0.95, rate(numax_remote_op_batch_apply_duration_seconds_bucket[5m]))
+```
+
+Remote duplicate ratio:
+
+```txt
+rate(numax_remote_ops_duplicate_total[5m])
+/
+rate(numax_remote_ops_received_total[5m])
 ```
 
 Recent sync errors:

--- a/docs/nx-site/src/content/docs/guides/observability.md
+++ b/docs/nx-site/src/content/docs/guides/observability.md
@@ -76,6 +76,17 @@ The dashboard uses only metrics currently emitted by Numax:
 | `numax_broadcast_ops_total`          | counter | operations broadcast to peers              |
 | `numax_store_keys`                   | gauge   | key count in the local store               |
 | `numax_store_bytes`                  | gauge   | approximate store payload bytes            |
+| `numax_wasm_invocations_total`       | counter | module invocations by outcome              |
+| `numax_wasm_module_cache_lookups_total` | counter | compiled-module cache hits and misses    |
+| `numax_wasm_*_duration_seconds_total` | counter | compilation, instantiation and execution time |
+| `numax_wasm_linear_memory_*_bytes`   | gauge/counter | current, peak and cumulative growth bytes |
+
+WASM metrics use the module's BLAKE3 digest as the `module` label. 
+This keeps the identity stable without exposing local paths. 
+
+Numax bounds the registry to 128 labels and aggregates additional modules under `module="overflow"`.
+
+Execution duration is wall-clock time and can include asynchronous host-call waits; it is not raw CPU time. Linear-memory metrics describe the guest memory exported as `memory`, not individual `malloc` and `free` operations inside the guest allocator.
 
 ## Useful PromQL
 

--- a/docs/nx-site/src/content/docs/guides/observability.md
+++ b/docs/nx-site/src/content/docs/guides/observability.md
@@ -140,3 +140,22 @@ Store size above 1 GiB:
 ```txt
 numax_store_bytes > 1073741824
 ```
+
+## CPU Flamegraphs On Ubuntu/Linux
+
+The `three_node_sync_load` benchmark can generate an opt-in CPU flamegraph for
+the load phase. Profiling starts after the three-node cluster is connected and
+stops before convergence and shutdown, keeping setup noise out of the report.
+
+```bash
+cargo bench --profile profiling -p nx-core \
+  --features cpu-profiling \
+  --bench three_node_sync_load -- \
+  --duration-secs 10 \
+  --target-ops-sec-per-node 1000 \
+  --settle-secs 10 \
+  --cpu-profile reports/profiling/three-node-sync-load.svg
+```
+
+The `cpu-profiling` feature and the `profiling` Cargo profile do not affect the default Numax runtime or the unprofiled regression benchmark. CI uses Ubuntu as the canonical profiling environment and uploads the SVG as `cpu-flamegraph-ubuntu`; cross-platform profiling remains a post-`v0.2.0`
+candidate.

--- a/docs/nx-site/src/content/docs/reference/cli.md
+++ b/docs/nx-site/src/content/docs/reference/cli.md
@@ -82,6 +82,16 @@ All of them require `--listen`.
 | Flag | Env | Description |
 |---|---|---|
 | `--observability-listen <ADDR>` | `NX_OBSERVABILITY_LISTEN` | Expose a local HTTP metrics endpoint (e.g. `127.0.0.1:9100`) |
+| `--tokio-console` | — | Expose opt-in Tokio task diagnostics from an instrumented build |
+
+`tokio-console` support is excluded from normal builds. Build and run the CLI explicitly with Tokio's experimental instrumentation enabled:
+
+```bash
+RUSTFLAGS="--cfg tokio_unstable" cargo run -p nx-cli \
+  --features tokio-console -- run module.wasm --tokio-console
+```
+
+Then connect from another terminal with `tokio-console`. The subscriber listens on `127.0.0.1:6669` by default; use `TOKIO_CONSOLE_BIND` to select another address. Keep this diagnostic endpoint bound to a trusted interface.
 
 ### TLS / mTLS
 

--- a/docs/nx-site/src/content/docs/reference/crates/index.md
+++ b/docs/nx-site/src/content/docs/reference/crates/index.md
@@ -31,7 +31,7 @@ nx-sdk          (standalone — targets wasm32, no internal deps)
 - `src/main.rs` - command definitions (`nx run`, `nx config`, `nx migrate`), flag parsing via clap, runtime wiring
 - `src/config.rs` - TOML file structs, environment variable resolution, effective config builder, `nx config init` template
 
-**External dependencies:** `clap`, `tokio`, `tracing`, `tracing-subscriber`, `toml`, `serde`
+**External dependencies:** `clap`, `tokio`, `tracing`, `tracing-subscriber`, optional `console-subscriber`, `toml`, `serde`
 
 ---
 

--- a/docs/nx-site/src/content/docs/reference/crates/nx-cli.md
+++ b/docs/nx-site/src/content/docs/reference/crates/nx-cli.md
@@ -21,7 +21,7 @@ and hands a fully-built `RuntimeConfig` to `nx-core`. It never contains runtime 
 | Resolve precedence (CLI > env > file > defaults) | `config.rs` - `EffectiveRunConfig::resolve` |
 | Validate flag combinations (TLS, sync, settle) | `config.rs` - `validate_tls_flags`, `validate_settle_mode`, etc. |
 | Build `SyncConfig`, `TlsConfig`, `ObservabilityConfig` | `config.rs` - `build_sync_config`, `build_tls_config`, `build_observability_config` |
-| Initialize logging | `config.rs` - `init_logging` |
+| Initialize logging and optional Tokio Console diagnostics | `config.rs` - `init_logging` |
 | Generate `numax.toml` template | `config.rs` - `CONFIG_TEMPLATE`, `init_config_file` |
 | Print effective resolved config | `config.rs` - `EffectiveRunConfig::render_effective_toml` |
 
@@ -206,7 +206,7 @@ parse_byte_size("0MiB")     // Err - zero is rejected
 
 ## Logging setup
 
-`init_logging(log_level, log_format)` initializes `tracing_subscriber` once, before the runtime starts.
+`init_logging(log_level, log_format, tokio_console)` initializes `tracing_subscriber` once, before Numax starts its application and sync tasks. Builds compiled with the optional `tokio-console` feature can add the console subscriber as a layer without replacing text or JSON logging. Runtime activation additionally requires `nx run --tokio-console`.
 
 Log level resolution order:
 1. `--log-level` CLI flag

--- a/docs/nx-site/src/content/docs/roadmap/index.md
+++ b/docs/nx-site/src/content/docs/roadmap/index.md
@@ -102,7 +102,7 @@ instead of crashing.
 **Regression gate**:
 - [x] Load benchmarks extended with automatic JSON report
 - [ ] CI workflow that compares with baseline and fails if p99 latency, throughput or RSS regress > X%
-- [ ] Run `scripts/compare-benchmark-report.test.mjs` in CI
+- [x] Run `scripts/compare-benchmark-report.test.mjs` in CI
 - [x] Baseline history committed in `crates/*/reports/baselines/`
 
 **Additional metrics**:

--- a/docs/nx-site/src/content/docs/roadmap/index.md
+++ b/docs/nx-site/src/content/docs/roadmap/index.md
@@ -97,7 +97,8 @@ instead of crashing.
 - [x] `tokio-console` integration (visibility into tasks)
 - [x] CPU flamegraph artifact in Ubuntu CI with feature-gated `pprof-rs`
 - [x] Load-phase heap profile artifact in Ubuntu CI with feature-gated `dhat`
-- [ ] Per-WASM-module profiling (CPU time, bytes allocated)
+- [x] Per-WASM-module execution metrics (duration, outcomes, cache and linear-memory usage)
+- [ ] Opt-in guest allocator instrumentation for exact allocated/freed bytes
 
 **Regression gate**:
 - [x] Load benchmarks extended with automatic JSON report
@@ -106,8 +107,8 @@ instead of crashing.
 - [x] Baseline history committed in `crates/*/reports/baselines/`
 
 **Additional metrics**:
-- [ ] `numax_module_cpu_ms` per module
-- [ ] `numax_module_memory_bytes` per module
+- [x] `numax_wasm_execution_duration_seconds_total` per module
+- [x] `numax_wasm_linear_memory_*_bytes` per module
 - [ ] `numax_op_apply_duration_ms` distribution
 
 **Closing criterion**:

--- a/docs/nx-site/src/content/docs/roadmap/index.md
+++ b/docs/nx-site/src/content/docs/roadmap/index.md
@@ -100,9 +100,10 @@ instead of crashing.
 - [ ] Per-WASM-module profiling (CPU time, bytes allocated)
 
 **Regression gate**:
-- [ ] Load benchmarks extended with automatic JSON report
+- [x] Load benchmarks extended with automatic JSON report
 - [ ] CI workflow that compares with baseline and fails if p99 latency, throughput or RSS regress > X%
-- [ ] Baseline history committed in `crates/*/reports/baselines/`
+  - [ ] Run `scripts/compare-benchmark-report.test.mjs` in CI
+- [x] Baseline history committed in `crates/*/reports/baselines/`
 
 **Additional metrics**:
 - [ ] `numax_module_cpu_ms` per module

--- a/docs/nx-site/src/content/docs/roadmap/index.md
+++ b/docs/nx-site/src/content/docs/roadmap/index.md
@@ -94,7 +94,7 @@ instead of crashing.
 **Goal**: make performance observation automatic and visible, prevent silent regressions.
 
 **Profiling tools**:
-- [ ] `tokio-console` integration (visibility into tasks)
+- [x] `tokio-console` integration (visibility into tasks)
 - [ ] CPU flamegraph in CI with `pprof-rs` or `samply`
 - [ ] Heap profiling with `dhat` integrated into benchmarks
 - [ ] Per-WASM-module profiling (CPU time, bytes allocated)

--- a/docs/nx-site/src/content/docs/roadmap/index.md
+++ b/docs/nx-site/src/content/docs/roadmap/index.md
@@ -98,7 +98,6 @@ instead of crashing.
 - [x] CPU flamegraph artifact in Ubuntu CI with feature-gated `pprof-rs`
 - [x] Load-phase heap profile artifact in Ubuntu CI with feature-gated `dhat`
 - [x] Per-WASM-module execution metrics (duration, outcomes, cache and linear-memory usage)
-- [ ] Opt-in guest allocator instrumentation for exact allocated/freed bytes
 
 **Regression gate**:
 - [x] Load benchmarks extended with automatic JSON report
@@ -109,7 +108,8 @@ instead of crashing.
 **Additional metrics**:
 - [x] `numax_wasm_execution_duration_seconds_total` per module
 - [x] `numax_wasm_linear_memory_*_bytes` per module
-- [ ] `numax_op_apply_duration_ms` distribution
+- [x] `numax_remote_op_batch_apply_duration_seconds` distribution
+- [x] Remote-op received, applied, duplicate, batch, and apply-error counters
 
 **Closing criterion**:
 > A PR that worsens sync p99 by > 5% is automatically blocked by CI with the regression details.
@@ -505,6 +505,9 @@ time = true
 ## v0.2.0 - Stable
 
 **Final goal**: distributed runtime **production-ready for any criticality**.
+
+**Public runtime API evolution**:
+- [ ] Introduce opt-in guest allocator instrumentation for exact allocated/freed bytes together with a `#[non_exhaustive]` `HostState`, a supported constructor/builder, and `0.1.x` migration guidance
 
 **Final release criteria**:
 - [ ] All `0.1.0`–`0.1.15` releases closed

--- a/docs/nx-site/src/content/docs/roadmap/index.md
+++ b/docs/nx-site/src/content/docs/roadmap/index.md
@@ -111,9 +111,10 @@ Unlike `v0.1.0` (declared for non-critical workloads), `v0.2.0` must guarantee:
 - [ ] Per-WASM-module profiling (CPU time, bytes allocated)
 
 **Regression gate**:
-- [ ] Load benchmarks extended with automatic JSON report
+- [x] Load benchmarks extended with automatic JSON report
 - [ ] CI workflow that compares with baseline and fails if p99 latency, throughput or RSS regress > X%
-- [ ] Baseline history committed in `crates/*/reports/baselines/`
+  - [ ] Run `scripts/compare-benchmark-report.test.mjs` in CI
+- [x] Baseline history committed in `crates/*/reports/baselines/`
 
 **Additional metrics**:
 - [ ] `numax_module_cpu_ms` per module

--- a/docs/nx-site/src/content/docs/roadmap/index.md
+++ b/docs/nx-site/src/content/docs/roadmap/index.md
@@ -96,7 +96,7 @@ instead of crashing.
 **Profiling tools**:
 - [x] `tokio-console` integration (visibility into tasks)
 - [x] CPU flamegraph artifact in Ubuntu CI with feature-gated `pprof-rs`
-- [ ] Heap profiling with `dhat` integrated into benchmarks
+- [x] Load-phase heap profile artifact in Ubuntu CI with feature-gated `dhat`
 - [ ] Per-WASM-module profiling (CPU time, bytes allocated)
 
 **Regression gate**:

--- a/docs/nx-site/src/content/docs/roadmap/index.md
+++ b/docs/nx-site/src/content/docs/roadmap/index.md
@@ -105,7 +105,7 @@ Unlike `v0.1.0` (declared for non-critical workloads), `v0.2.0` must guarantee:
 **Goal**: make performance observation automatic and visible, prevent silent regressions.
 
 **Profiling tools**:
-- [ ] `tokio-console` integration (visibility into tasks)
+- [x] `tokio-console` integration (visibility into tasks)
 - [ ] CPU flamegraph in CI with `pprof-rs` or `samply`
 - [ ] Heap profiling with `dhat` integrated into benchmarks
 - [ ] Per-WASM-module profiling (CPU time, bytes allocated)

--- a/docs/nx-site/src/content/docs/roadmap/index.md
+++ b/docs/nx-site/src/content/docs/roadmap/index.md
@@ -44,9 +44,9 @@ Unlike `v0.1.0` (declared for non-critical workloads), `v0.2.0` must guarantee:
 | Version | Theme | Status |
 |---|---|---|
 | `v0.1.0` | First production-ready + Documentation, Distribution & Configuration | released |
-| `v0.1.1` | Architectural Cleanup & Versioning | active |
-| `v0.1.2` | Performance & Profiling | planned |
-| `v0.1.3` | Supply Chain & Fuzzing | planned |
+| `v0.1.1` | Architectural Cleanup & Versioning | released |
+| `v0.1.2` | Performance & Profiling | released |
+| `v0.1.3` | Supply Chain & Fuzzing | active |
 | `v0.1.4` | Management API | planned |
 | `v0.1.5` | Peer Discovery - Foundations | planned |
 | `v0.1.6` | Peer Discovery - SWIM & Gossip K-fanout | planned |
@@ -95,14 +95,14 @@ instead of crashing.
 
 **Profiling tools**:
 - [x] `tokio-console` integration (visibility into tasks)
-- [ ] CPU flamegraph in CI with `pprof-rs` or `samply`
+- [x] CPU flamegraph artifact in Ubuntu CI with feature-gated `pprof-rs`
 - [ ] Heap profiling with `dhat` integrated into benchmarks
 - [ ] Per-WASM-module profiling (CPU time, bytes allocated)
 
 **Regression gate**:
 - [x] Load benchmarks extended with automatic JSON report
 - [ ] CI workflow that compares with baseline and fails if p99 latency, throughput or RSS regress > X%
-  - [ ] Run `scripts/compare-benchmark-report.test.mjs` in CI
+- [ ] Run `scripts/compare-benchmark-report.test.mjs` in CI
 - [x] Baseline history committed in `crates/*/reports/baselines/`
 
 **Additional metrics**:
@@ -523,10 +523,8 @@ time = true
 - **Pluggable storage backends**: redb, fjall, custom
 - **GPU/ML guests**: WASI-NN integration
 - **Edge orchestration**: optional integration with existing edge runtimes
-- **Tiny embedded runtimes**: evaluate interpreter-based WASM engines such as
-  `wasmi` or WAMR for Cortex-M / RISC-V devices with RAM measured in kilobytes.
-  Wasmtime is the right native engine for the current runtime, but it is not a
-  microcontroller-class target.
+- **Cross-platform profiling CI**: extend the canonical Ubuntu/Linux CPU profile to scheduled macOS and Windows artifacts, keeping results separated by OS.
+- **Tiny embedded runtimes**: evaluate interpreter-based WASM engines such as `wasmi` or WAMR for Cortex-M / RISC-V devices with RAM measured in kilobytes. Wasmtime is the right native engine for the current runtime, but it is not a microcontroller-class target.
 
 ---
 
@@ -542,4 +540,4 @@ time = true
 
 ---
 
-*Last revision*: `2026-05-30`
+*Last revision*: `2026-08-16`

--- a/docs/nx-site/src/content/docs/roadmap/index.md
+++ b/docs/nx-site/src/content/docs/roadmap/index.md
@@ -544,4 +544,4 @@ time = true
 
 ---
 
-*Last revision*: `2026-08-16`
+*Last revision*: `2026-07-22`

--- a/scripts/compare-benchmark-report.mjs
+++ b/scripts/compare-benchmark-report.mjs
@@ -1,0 +1,291 @@
+#!/usr/bin/env node
+import { readFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+import { isDeepStrictEqual } from 'node:util';
+
+const DEFAULT_THRESHOLDS = {
+  p99: 5,
+  throughput: 5,
+  rss: 5,
+};
+
+export function compareReports(baseline, current, options = {}) {
+  const thresholds = { ...DEFAULT_THRESHOLDS, ...(options.thresholds || {}) };
+  const comparisons = [];
+
+  ensureReportShape('baseline', baseline);
+  ensureReportShape('current', current);
+
+  if (baseline.scenario !== current.scenario) {
+    throw new Error(`scenario mismatch: baseline=${baseline.scenario} current=${current.scenario}`);
+  }
+  if (baseline.benchmark !== current.benchmark) {
+    throw new Error(`benchmark mismatch: baseline=${baseline.benchmark} current=${current.benchmark}`);
+  }
+  if (baseline.crate !== current.crate) {
+    throw new Error(`crate mismatch: baseline=${baseline.crate} current=${current.crate}`);
+  }
+  if (!isDeepStrictEqual(baseline.profile, current.profile)) {
+    throw new Error(
+      `profile mismatch: baseline=${JSON.stringify(baseline.profile)} current=${JSON.stringify(
+        current.profile
+      )}`
+    );
+  }
+
+  comparisons.push(
+    compareHigherIsWorse({
+      metric: 'latency_ms.p99',
+      baseline: requiredNumber(baseline.latency_ms?.p99, 'baseline latency_ms.p99'),
+      current: requiredNumber(current.latency_ms?.p99, 'current latency_ms.p99'),
+      thresholdPercent: thresholds.p99,
+    })
+  );
+
+  comparisons.push(
+    compareLowerIsWorse({
+      metric: 'ops_sec_avg',
+      baseline: requiredNumber(baseline.ops_sec_avg, 'baseline ops_sec_avg'),
+      current: requiredNumber(current.ops_sec_avg, 'current ops_sec_avg'),
+      thresholdPercent: thresholds.throughput,
+    })
+  );
+
+  const baselineRss = optionalNumber(baseline.resources?.rss_bytes, 'baseline resources.rss_bytes');
+  const currentRss = optionalNumber(current.resources?.rss_bytes, 'current resources.rss_bytes');
+  if (baselineRss === null || currentRss === null) {
+    comparisons.push({
+      metric: 'resources.rss_bytes',
+      baseline: baselineRss,
+      current: currentRss,
+      thresholdPercent: thresholds.rss,
+      deltaPercent: null,
+      status: 'skipped',
+      reason: 'rss_bytes is null in baseline or current report',
+    });
+  } else {
+    comparisons.push(
+      compareHigherIsWorse({
+        metric: 'resources.rss_bytes',
+        baseline: baselineRss,
+        current: currentRss,
+        thresholdPercent: thresholds.rss,
+      })
+    );
+  }
+
+  return {
+    scenario: current.scenario,
+    benchmark: current.benchmark,
+    comparisons,
+    regressions: comparisons.filter((comparison) => comparison.status === 'regression'),
+  };
+}
+
+export function formatComparisonResult(result, mode = 'shadow') {
+  const lines = [
+    `Benchmark regression check (${mode})`,
+    `scenario: ${result.scenario}`,
+    `benchmark: ${result.benchmark}`,
+  ];
+
+  for (const comparison of result.comparisons) {
+    if (comparison.status === 'skipped') {
+      lines.push(
+        `- ${comparison.metric}: skipped (${comparison.reason}; baseline=${formatValue(
+          comparison.baseline
+        )}, current=${formatValue(comparison.current)})`
+      );
+      continue;
+    }
+
+    lines.push(
+      `- ${comparison.metric}: ${comparison.status}; baseline=${formatValue(
+        comparison.baseline
+      )}, current=${formatValue(comparison.current)}, delta=${comparison.deltaPercent.toFixed(
+        2
+      )}%, threshold=${comparison.thresholdPercent.toFixed(2)}%`
+    );
+  }
+
+  return lines.join('\n');
+}
+
+function compareHigherIsWorse({ metric, baseline, current, thresholdPercent }) {
+  if (baseline <= 0) {
+    throw new Error(`${metric} baseline must be greater than zero`);
+  }
+  const deltaPercent = ((current - baseline) / baseline) * 100;
+  return {
+    metric,
+    baseline,
+    current,
+    thresholdPercent,
+    deltaPercent,
+    status: deltaPercent > thresholdPercent ? 'regression' : 'ok',
+  };
+}
+
+function compareLowerIsWorse({ metric, baseline, current, thresholdPercent }) {
+  if (baseline <= 0) {
+    throw new Error(`${metric} baseline must be greater than zero`);
+  }
+  const deltaPercent = ((baseline - current) / baseline) * 100;
+  return {
+    metric,
+    baseline,
+    current,
+    thresholdPercent,
+    deltaPercent,
+    status: deltaPercent > thresholdPercent ? 'regression' : 'ok',
+  };
+}
+
+function ensureReportShape(label, report) {
+  if (report.report_schema_version !== 1) {
+    throw new Error(`${label} report_schema_version must be 1`);
+  }
+  if (!report.scenario) {
+    throw new Error(`${label} scenario is required`);
+  }
+  if (!report.benchmark) {
+    throw new Error(`${label} benchmark is required`);
+  }
+  if (!report.crate) {
+    throw new Error(`${label} crate is required`);
+  }
+  if (!report.profile || typeof report.profile !== 'object' || Array.isArray(report.profile)) {
+    throw new Error(`${label} profile is required`);
+  }
+}
+
+function requiredNumber(value, label) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new Error(`${label} must be a finite number`);
+  }
+  return value;
+}
+
+function optionalNumber(value, label) {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new Error(`${label} must be a finite number or null`);
+  }
+  return value;
+}
+
+function formatValue(value) {
+  return value === null ? 'null' : String(value);
+}
+
+function parseArgs(argv) {
+  const args = {
+    mode: 'shadow',
+    thresholds: { ...DEFAULT_THRESHOLDS },
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    switch (arg) {
+      case '--baseline':
+        args.baselinePath = nextArg(argv, ++index, arg);
+        break;
+      case '--current':
+        args.currentPath = nextArg(argv, ++index, arg);
+        break;
+      case '--mode':
+        args.mode = nextArg(argv, ++index, arg);
+        break;
+      case '--p99-threshold':
+        args.thresholds.p99 = parseThreshold(nextArg(argv, ++index, arg), arg);
+        break;
+      case '--throughput-threshold':
+        args.thresholds.throughput = parseThreshold(nextArg(argv, ++index, arg), arg);
+        break;
+      case '--rss-threshold':
+        args.thresholds.rss = parseThreshold(nextArg(argv, ++index, arg), arg);
+        break;
+      case '--help':
+      case '-h':
+        printHelp();
+        process.exit(0);
+        break;
+      default:
+        throw new Error(`unknown argument: ${arg}`);
+    }
+  }
+
+  if (!args.baselinePath) {
+    throw new Error('--baseline is required');
+  }
+  if (!args.currentPath) {
+    throw new Error('--current is required');
+  }
+  if (!['shadow', 'blocking'].includes(args.mode)) {
+    throw new Error('--mode must be shadow or blocking');
+  }
+
+  return args;
+}
+
+function nextArg(argv, index, name) {
+  const value = argv[index];
+  if (!value) {
+    throw new Error(`missing value for ${name}`);
+  }
+  return value;
+}
+
+function parseThreshold(value, name) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new Error(`${name} must be a non-negative number`);
+  }
+  return parsed;
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function printHelp() {
+  console.log(`Compare a benchmark report against a committed baseline.
+
+Options:
+  --baseline PATH              Baseline JSON report
+  --current PATH               Current JSON report
+  --mode shadow|blocking       Print regressions only, or fail on regressions (default: shadow)
+  --p99-threshold PERCENT      Allowed p99 increase (default: 5)
+  --throughput-threshold PERCENT
+                               Allowed throughput decrease (default: 5)
+  --rss-threshold PERCENT      Allowed RSS increase (default: 5)
+`);
+}
+
+function main() {
+  try {
+    const args = parseArgs(process.argv.slice(2));
+    const result = compareReports(readJson(args.baselinePath), readJson(args.currentPath), {
+      thresholds: args.thresholds,
+    });
+    const output = formatComparisonResult(result, args.mode);
+    console.log(output);
+
+    if (result.regressions.length > 0) {
+      const annotation = args.mode === 'blocking' ? 'error' : 'warning';
+      console.log(`::${annotation}::${result.regressions.length} benchmark regression(s) detected`);
+      if (args.mode === 'blocking') {
+        process.exit(1);
+      }
+    }
+  } catch (error) {
+    console.error(`benchmark comparison failed: ${error.message}`);
+    process.exit(2);
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/scripts/compare-benchmark-report.mjs
+++ b/scripts/compare-benchmark-report.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
-import { readFileSync } from 'node:fs';
-import { pathToFileURL } from 'node:url';
-import { isDeepStrictEqual } from 'node:util';
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import { pathToFileURL } from "node:url";
+import { isDeepStrictEqual } from "node:util";
 
 const DEFAULT_THRESHOLDS = {
   p99: 5,
@@ -9,136 +10,299 @@ const DEFAULT_THRESHOLDS = {
   rss: 5,
 };
 
+const DEFAULT_MINIMUM_DELTAS = {
+  p99: 0,
+  rss: 0,
+};
+
 export function compareReports(baseline, current, options = {}) {
+  return compareReportSet(baseline, [current], options);
+}
+
+export function compareReportSet(baseline, currentReports, options = {}) {
   const thresholds = { ...DEFAULT_THRESHOLDS, ...(options.thresholds || {}) };
+  const minimumDeltas = {
+    ...DEFAULT_MINIMUM_DELTAS,
+    ...(options.minimumDeltas || {}),
+  };
   const comparisons = [];
 
-  ensureReportShape('baseline', baseline);
-  ensureReportShape('current', current);
-
-  if (baseline.scenario !== current.scenario) {
-    throw new Error(`scenario mismatch: baseline=${baseline.scenario} current=${current.scenario}`);
-  }
-  if (baseline.benchmark !== current.benchmark) {
-    throw new Error(`benchmark mismatch: baseline=${baseline.benchmark} current=${current.benchmark}`);
-  }
-  if (baseline.crate !== current.crate) {
-    throw new Error(`crate mismatch: baseline=${baseline.crate} current=${current.crate}`);
-  }
-  if (!isDeepStrictEqual(baseline.profile, current.profile)) {
-    throw new Error(
-      `profile mismatch: baseline=${JSON.stringify(baseline.profile)} current=${JSON.stringify(
-        current.profile
-      )}`
-    );
-  }
+  ensureReportShape("baseline", baseline);
+  const current = aggregateReports(currentReports);
+  ensureCompatibleReports("baseline", baseline, "current aggregate", current);
 
   comparisons.push(
     compareHigherIsWorse({
-      metric: 'latency_ms.p99',
-      baseline: requiredNumber(baseline.latency_ms?.p99, 'baseline latency_ms.p99'),
-      current: requiredNumber(current.latency_ms?.p99, 'current latency_ms.p99'),
+      metric: "latency_ms.p99",
+      baseline: requiredNumber(
+        baseline.latency_ms?.p99,
+        "baseline latency_ms.p99",
+      ),
+      current: requiredNumber(
+        current.latency_ms?.p99,
+        "current latency_ms.p99",
+      ),
       thresholdPercent: thresholds.p99,
-    })
+      minimumDelta: minimumDeltas.p99,
+    }),
   );
 
   comparisons.push(
     compareLowerIsWorse({
-      metric: 'ops_sec_avg',
-      baseline: requiredNumber(baseline.ops_sec_avg, 'baseline ops_sec_avg'),
-      current: requiredNumber(current.ops_sec_avg, 'current ops_sec_avg'),
+      metric: "ops_sec_avg",
+      baseline: requiredNumber(baseline.ops_sec_avg, "baseline ops_sec_avg"),
+      current: requiredNumber(current.ops_sec_avg, "current ops_sec_avg"),
       thresholdPercent: thresholds.throughput,
-    })
+      minimumDelta: 0,
+    }),
   );
 
-  const baselineRss = optionalNumber(baseline.resources?.rss_bytes, 'baseline resources.rss_bytes');
-  const currentRss = optionalNumber(current.resources?.rss_bytes, 'current resources.rss_bytes');
-  if (baselineRss === null || currentRss === null) {
+  const baselineRss = optionalNumber(
+    baseline.resources?.rss_bytes,
+    "baseline resources.rss_bytes",
+  );
+  const currentRss = optionalNumber(
+    current.resources?.rss_bytes,
+    "current resources.rss_bytes",
+  );
+  if (baselineRss === null) {
     comparisons.push({
-      metric: 'resources.rss_bytes',
-      baseline: baselineRss,
+      metric: "resources.rss_bytes",
+      baseline: null,
       current: currentRss,
       thresholdPercent: thresholds.rss,
+      minimumDelta: minimumDeltas.rss,
+      delta: null,
       deltaPercent: null,
-      status: 'skipped',
-      reason: 'rss_bytes is null in baseline or current report',
+      status: "skipped",
+      reason: "rss_bytes is null in the committed baseline",
     });
   } else {
+    if (currentRss === null) {
+      throw new Error(
+        "current resources.rss_bytes is required when the baseline RSS is present",
+      );
+    }
     comparisons.push(
       compareHigherIsWorse({
-        metric: 'resources.rss_bytes',
+        metric: "resources.rss_bytes",
         baseline: baselineRss,
         current: currentRss,
         thresholdPercent: thresholds.rss,
-      })
+        minimumDelta: minimumDeltas.rss,
+      }),
     );
   }
 
   return {
     scenario: current.scenario,
     benchmark: current.benchmark,
+    runs: currentReports.length,
+    aggregate: current,
     comparisons,
-    regressions: comparisons.filter((comparison) => comparison.status === 'regression'),
+    regressions: comparisons.filter(
+      (comparison) => comparison.status === "regression",
+    ),
   };
 }
 
-export function formatComparisonResult(result, mode = 'shadow') {
+export function aggregateReports(reports) {
+  if (!Array.isArray(reports) || reports.length === 0) {
+    throw new Error("at least one current report is required");
+  }
+
+  reports.forEach((report, index) =>
+    ensureReportShape(`current[${index}]`, report),
+  );
+  const first = reports[0];
+  reports.slice(1).forEach((report, index) => {
+    ensureCompatibleReports(
+      "current[0]",
+      first,
+      `current[${index + 1}]`,
+      report,
+    );
+  });
+
+  const aggregate = JSON.parse(JSON.stringify(first));
+  aggregate.ops_sec_avg = median(
+    reports.map((report, index) =>
+      requiredNumber(report.ops_sec_avg, `current[${index}] ops_sec_avg`),
+    ),
+  );
+
+  const rssValues = reports.map((report, index) =>
+    optionalNumber(
+      report.resources?.rss_bytes,
+      `current[${index}] resources.rss_bytes`,
+    ),
+  );
+  aggregate.resources = {
+    ...aggregate.resources,
+    rss_bytes: rssValues.some((value) => value === null)
+      ? null
+      : median(rssValues),
+  };
+
+  const latencyKeys = new Set(
+    reports.flatMap((report) => Object.keys(report.latency_ms || {})),
+  );
+  aggregate.latency_ms = { ...aggregate.latency_ms };
+  for (const key of latencyKeys) {
+    aggregate.latency_ms[key] = median(
+      reports.map((report, index) =>
+        requiredNumber(
+          report.latency_ms?.[key],
+          `current[${index}] latency_ms.${key}`,
+        ),
+      ),
+    );
+  }
+
+  for (const field of [
+    "load_duration_secs",
+    "total_duration_secs",
+    "convergence_wait_secs",
+  ]) {
+    if (reports.every((report) => typeof report[field] === "number")) {
+      aggregate[field] = median(reports.map((report) => report[field]));
+    }
+  }
+
+  aggregate.aggregation = {
+    method: "median",
+    runs: reports.length,
+  };
+  return aggregate;
+}
+
+export function formatComparisonResult(result, mode = "shadow") {
   const lines = [
     `Benchmark regression check (${mode})`,
     `scenario: ${result.scenario}`,
     `benchmark: ${result.benchmark}`,
+    `current runs: ${result.runs} (median)`,
   ];
 
   for (const comparison of result.comparisons) {
-    if (comparison.status === 'skipped') {
+    if (comparison.status === "skipped") {
       lines.push(
         `- ${comparison.metric}: skipped (${comparison.reason}; baseline=${formatValue(
-          comparison.baseline
-        )}, current=${formatValue(comparison.current)})`
+          comparison.baseline,
+        )}, current=${formatValue(comparison.current)})`,
       );
       continue;
     }
 
+    const minimumDelta =
+      comparison.minimumDelta > 0
+        ? `, minimum_delta=${comparison.minimumDelta}`
+        : "";
     lines.push(
       `- ${comparison.metric}: ${comparison.status}; baseline=${formatValue(
-        comparison.baseline
+        comparison.baseline,
       )}, current=${formatValue(comparison.current)}, delta=${comparison.deltaPercent.toFixed(
-        2
-      )}%, threshold=${comparison.thresholdPercent.toFixed(2)}%`
+        2,
+      )}%, threshold=${comparison.thresholdPercent.toFixed(2)}%${minimumDelta}`,
     );
   }
 
-  return lines.join('\n');
+  return lines.join("\n");
 }
 
-function compareHigherIsWorse({ metric, baseline, current, thresholdPercent }) {
+function compareHigherIsWorse({
+  metric,
+  baseline,
+  current,
+  thresholdPercent,
+  minimumDelta,
+}) {
   if (baseline <= 0) {
     throw new Error(`${metric} baseline must be greater than zero`);
   }
-  const deltaPercent = ((current - baseline) / baseline) * 100;
+  const delta = current - baseline;
+  const deltaPercent = (delta / baseline) * 100;
+  return comparisonResult({
+    metric,
+    baseline,
+    current,
+    thresholdPercent,
+    minimumDelta,
+    delta,
+    deltaPercent,
+  });
+}
+
+function compareLowerIsWorse({
+  metric,
+  baseline,
+  current,
+  thresholdPercent,
+  minimumDelta,
+}) {
+  if (baseline <= 0) {
+    throw new Error(`${metric} baseline must be greater than zero`);
+  }
+  const delta = baseline - current;
+  const deltaPercent = (delta / baseline) * 100;
+  return comparisonResult({
+    metric,
+    baseline,
+    current,
+    thresholdPercent,
+    minimumDelta,
+    delta,
+    deltaPercent,
+  });
+}
+
+function comparisonResult({
+  metric,
+  baseline,
+  current,
+  thresholdPercent,
+  minimumDelta,
+  delta,
+  deltaPercent,
+}) {
   return {
     metric,
     baseline,
     current,
     thresholdPercent,
+    minimumDelta,
+    delta,
     deltaPercent,
-    status: deltaPercent > thresholdPercent ? 'regression' : 'ok',
+    status:
+      deltaPercent > thresholdPercent && delta > minimumDelta
+        ? "regression"
+        : "ok",
   };
 }
 
-function compareLowerIsWorse({ metric, baseline, current, thresholdPercent }) {
-  if (baseline <= 0) {
-    throw new Error(`${metric} baseline must be greater than zero`);
+function ensureCompatibleReports(leftLabel, left, rightLabel, right) {
+  if (left.scenario !== right.scenario) {
+    throw new Error(
+      `scenario mismatch: ${leftLabel}=${left.scenario} ${rightLabel}=${right.scenario}`,
+    );
   }
-  const deltaPercent = ((baseline - current) / baseline) * 100;
-  return {
-    metric,
-    baseline,
-    current,
-    thresholdPercent,
-    deltaPercent,
-    status: deltaPercent > thresholdPercent ? 'regression' : 'ok',
-  };
+  if (left.benchmark !== right.benchmark) {
+    throw new Error(
+      `benchmark mismatch: ${leftLabel}=${left.benchmark} ${rightLabel}=${right.benchmark}`,
+    );
+  }
+  if (left.crate !== right.crate) {
+    throw new Error(
+      `crate mismatch: ${leftLabel}=${left.crate} ${rightLabel}=${right.crate}`,
+    );
+  }
+  if (!isDeepStrictEqual(left.profile, right.profile)) {
+    throw new Error(
+      `profile mismatch: ${leftLabel}=${JSON.stringify(
+        left.profile,
+      )} ${rightLabel}=${JSON.stringify(right.profile)}`,
+    );
+  }
 }
 
 function ensureReportShape(label, report) {
@@ -154,13 +318,17 @@ function ensureReportShape(label, report) {
   if (!report.crate) {
     throw new Error(`${label} crate is required`);
   }
-  if (!report.profile || typeof report.profile !== 'object' || Array.isArray(report.profile)) {
+  if (
+    !report.profile ||
+    typeof report.profile !== "object" ||
+    Array.isArray(report.profile)
+  ) {
     throw new Error(`${label} profile is required`);
   }
 }
 
 function requiredNumber(value, label) {
-  if (typeof value !== 'number' || !Number.isFinite(value)) {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
     throw new Error(`${label} must be a finite number`);
   }
   return value;
@@ -170,45 +338,73 @@ function optionalNumber(value, label) {
   if (value === null || value === undefined) {
     return null;
   }
-  if (typeof value !== 'number' || !Number.isFinite(value)) {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
     throw new Error(`${label} must be a finite number or null`);
   }
   return value;
 }
 
+function median(values) {
+  const sorted = [...values].sort((left, right) => left - right);
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? (sorted[middle - 1] + sorted[middle]) / 2
+    : sorted[middle];
+}
+
 function formatValue(value) {
-  return value === null ? 'null' : String(value);
+  return value === null ? "null" : String(value);
 }
 
 function parseArgs(argv) {
   const args = {
-    mode: 'shadow',
+    currentPaths: [],
+    mode: "shadow",
     thresholds: { ...DEFAULT_THRESHOLDS },
+    minimumDeltas: { ...DEFAULT_MINIMUM_DELTAS },
   };
 
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
     switch (arg) {
-      case '--baseline':
+      case "--baseline":
         args.baselinePath = nextArg(argv, ++index, arg);
         break;
-      case '--current':
-        args.currentPath = nextArg(argv, ++index, arg);
+      case "--current":
+        args.currentPaths.push(nextArg(argv, ++index, arg));
         break;
-      case '--mode':
+      case "--write-aggregate":
+        args.aggregatePath = nextArg(argv, ++index, arg);
+        break;
+      case "--mode":
         args.mode = nextArg(argv, ++index, arg);
         break;
-      case '--p99-threshold':
+      case "--p99-threshold":
         args.thresholds.p99 = parseThreshold(nextArg(argv, ++index, arg), arg);
         break;
-      case '--throughput-threshold':
-        args.thresholds.throughput = parseThreshold(nextArg(argv, ++index, arg), arg);
+      case "--throughput-threshold":
+        args.thresholds.throughput = parseThreshold(
+          nextArg(argv, ++index, arg),
+          arg,
+        );
         break;
-      case '--rss-threshold':
+      case "--rss-threshold":
         args.thresholds.rss = parseThreshold(nextArg(argv, ++index, arg), arg);
         break;
-      case '--help':
-      case '-h':
+      case "--p99-min-delta-ms":
+        args.minimumDeltas.p99 = parseThreshold(
+          nextArg(argv, ++index, arg),
+          arg,
+        );
+        break;
+      case "--rss-min-delta-bytes":
+        args.minimumDeltas.rss = parseThreshold(
+          nextArg(argv, ++index, arg),
+          arg,
+        );
+        break;
+      case "--help":
+      case "-h":
         printHelp();
         process.exit(0);
         break;
@@ -218,13 +414,13 @@ function parseArgs(argv) {
   }
 
   if (!args.baselinePath) {
-    throw new Error('--baseline is required');
+    throw new Error("--baseline is required");
   }
-  if (!args.currentPath) {
-    throw new Error('--current is required');
+  if (args.currentPaths.length === 0) {
+    throw new Error("at least one --current is required");
   }
-  if (!['shadow', 'blocking'].includes(args.mode)) {
-    throw new Error('--mode must be shadow or blocking');
+  if (!["shadow", "blocking"].includes(args.mode)) {
+    throw new Error("--mode must be shadow or blocking");
   }
 
   return args;
@@ -247,36 +443,56 @@ function parseThreshold(value, name) {
 }
 
 function readJson(path) {
-  return JSON.parse(readFileSync(path, 'utf8'));
+  return JSON.parse(readFileSync(path, "utf8"));
 }
 
 function printHelp() {
-  console.log(`Compare a benchmark report against a committed baseline.
+  console.log(`Compare one or more benchmark reports against a committed baseline.
 
 Options:
   --baseline PATH              Baseline JSON report
-  --current PATH               Current JSON report
-  --mode shadow|blocking       Print regressions only, or fail on regressions (default: shadow)
-  --p99-threshold PERCENT      Allowed p99 increase (default: 5)
+  --current PATH               Current report; repeat to compare their median
+  --write-aggregate PATH       Write the median aggregate report
+  --mode shadow|blocking       Warn, or fail on regressions (default: shadow)
+  --p99-threshold PERCENT      Allowed median p99 increase (default: 5)
+  --p99-min-delta-ms VALUE     Minimum absolute p99 increase (default: 0)
   --throughput-threshold PERCENT
-                               Allowed throughput decrease (default: 5)
-  --rss-threshold PERCENT      Allowed RSS increase (default: 5)
+                               Allowed median throughput decrease (default: 5)
+  --rss-threshold PERCENT      Allowed median RSS increase (default: 5)
+  --rss-min-delta-bytes VALUE  Minimum absolute RSS increase (default: 0)
 `);
 }
 
 function main() {
   try {
     const args = parseArgs(process.argv.slice(2));
-    const result = compareReports(readJson(args.baselinePath), readJson(args.currentPath), {
-      thresholds: args.thresholds,
-    });
+    const currentReports = args.currentPaths.map(readJson);
+    const result = compareReportSet(
+      readJson(args.baselinePath),
+      currentReports,
+      {
+        thresholds: args.thresholds,
+        minimumDeltas: args.minimumDeltas,
+      },
+    );
+
+    if (args.aggregatePath) {
+      mkdirSync(dirname(args.aggregatePath), { recursive: true });
+      writeFileSync(
+        args.aggregatePath,
+        `${JSON.stringify(result.aggregate, null, 2)}\n`,
+      );
+    }
+
     const output = formatComparisonResult(result, args.mode);
     console.log(output);
 
     if (result.regressions.length > 0) {
-      const annotation = args.mode === 'blocking' ? 'error' : 'warning';
-      console.log(`::${annotation}::${result.regressions.length} benchmark regression(s) detected`);
-      if (args.mode === 'blocking') {
+      const annotation = args.mode === "blocking" ? "error" : "warning";
+      console.log(
+        `::${annotation}::${result.regressions.length} benchmark regression(s) detected`,
+      );
+      if (args.mode === "blocking") {
         process.exit(1);
       }
     }

--- a/scripts/compare-benchmark-report.test.mjs
+++ b/scripts/compare-benchmark-report.test.mjs
@@ -1,13 +1,17 @@
-import assert from 'node:assert/strict';
-import test from 'node:test';
+import assert from "node:assert/strict";
+import test from "node:test";
 
-import { compareReports } from './compare-benchmark-report.mjs';
+import {
+  aggregateReports,
+  compareReports,
+  compareReportSet,
+} from "./compare-benchmark-report.mjs";
 
 const baseline = {
   report_schema_version: 1,
-  crate: 'nx-core',
-  benchmark: 'three_node_sync_load',
-  scenario: 'multi-node-sync-gcounter',
+  crate: "nx-core",
+  benchmark: "three_node_sync_load",
+  scenario: "multi-node-sync-gcounter",
   profile: {
     nodes: 3,
     duration_secs: 10,
@@ -23,7 +27,7 @@ const baseline = {
   },
 };
 
-test('accepts metrics within thresholds', () => {
+test("accepts metrics within thresholds", () => {
   const result = compareReports(baseline, {
     ...baseline,
     ops_sec_avg: 960,
@@ -38,7 +42,7 @@ test('accepts metrics within thresholds', () => {
   assert.equal(result.regressions.length, 0);
 });
 
-test('detects p99 throughput and rss regressions', () => {
+test("detects p99 throughput and rss regressions", () => {
   const result = compareReports(baseline, {
     ...baseline,
     ops_sec_avg: 900,
@@ -52,11 +56,11 @@ test('detects p99 throughput and rss regressions', () => {
 
   assert.deepEqual(
     result.regressions.map((regression) => regression.metric),
-    ['latency_ms.p99', 'ops_sec_avg', 'resources.rss_bytes']
+    ["latency_ms.p99", "ops_sec_avg", "resources.rss_bytes"],
   );
 });
 
-test('skips rss when either side is null', () => {
+test("skips rss while the committed baseline is null", () => {
   const result = compareReports(
     {
       ...baseline,
@@ -64,26 +68,28 @@ test('skips rss when either side is null', () => {
         rss_bytes: null,
       },
     },
-    baseline
+    baseline,
   );
 
-  const rss = result.comparisons.find((comparison) => comparison.metric === 'resources.rss_bytes');
-  assert.equal(rss.status, 'skipped');
+  const rss = result.comparisons.find(
+    (comparison) => comparison.metric === "resources.rss_bytes",
+  );
+  assert.equal(rss.status, "skipped");
   assert.equal(result.regressions.length, 0);
 });
 
-test('rejects mismatched scenarios', () => {
+test("rejects mismatched scenarios", () => {
   assert.throws(
     () =>
       compareReports(baseline, {
         ...baseline,
-        scenario: 'different',
+        scenario: "different",
       }),
-    /scenario mismatch/
+    /scenario mismatch/,
   );
 });
 
-test('rejects mismatched workload profiles', () => {
+test("rejects mismatched workload profiles", () => {
   assert.throws(
     () =>
       compareReports(baseline, {
@@ -93,6 +99,77 @@ test('rejects mismatched workload profiles', () => {
           nodes: 10,
         },
       }),
-    /profile mismatch/
+    /profile mismatch/,
+  );
+});
+
+test("compares the median of multiple current reports", () => {
+  const result = compareReportSet(baseline, [
+    {
+      ...baseline,
+      ops_sec_avg: 950,
+      resources: { rss_bytes: 1040 },
+      latency_ms: { p99: 10.4 },
+    },
+    {
+      ...baseline,
+      ops_sec_avg: 100,
+      resources: { rss_bytes: 9000 },
+      latency_ms: { p99: 100 },
+    },
+    {
+      ...baseline,
+      ops_sec_avg: 970,
+      resources: { rss_bytes: 1020 },
+      latency_ms: { p99: 10.2 },
+    },
+  ]);
+
+  assert.equal(result.runs, 3);
+  assert.equal(result.aggregate.ops_sec_avg, 950);
+  assert.equal(result.aggregate.resources.rss_bytes, 1040);
+  assert.equal(result.aggregate.latency_ms.p99, 10.4);
+  assert.equal(result.regressions.length, 0);
+});
+
+test("requires both relative and absolute thresholds to flag a regression", () => {
+  const result = compareReports(
+    baseline,
+    {
+      ...baseline,
+      ops_sec_avg: 1000,
+      resources: { rss_bytes: 1100 },
+      latency_ms: { p99: 11 },
+    },
+    {
+      thresholds: { p99: 5, throughput: 5, rss: 5 },
+      minimumDeltas: { p99: 2, rss: 200 },
+    },
+  );
+
+  assert.equal(result.regressions.length, 0);
+  assert.equal(result.comparisons[0].delta, 1);
+  assert.equal(result.comparisons[2].delta, 100);
+});
+
+test("aggregates latency fields and records aggregation metadata", () => {
+  const aggregate = aggregateReports([
+    { ...baseline, latency_ms: { p50: 1, p99: 9 } },
+    { ...baseline, latency_ms: { p50: 3, p99: 11 } },
+    { ...baseline, latency_ms: { p50: 2, p99: 10 } },
+  ]);
+
+  assert.deepEqual(aggregate.latency_ms, { p50: 2, p99: 10 });
+  assert.deepEqual(aggregate.aggregation, { method: "median", runs: 3 });
+});
+
+test("rejects a missing current RSS once the baseline has RSS", () => {
+  assert.throws(
+    () =>
+      compareReports(baseline, {
+        ...baseline,
+        resources: { rss_bytes: null },
+      }),
+    /current resources\.rss_bytes is required/,
   );
 });

--- a/scripts/compare-benchmark-report.test.mjs
+++ b/scripts/compare-benchmark-report.test.mjs
@@ -1,0 +1,98 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { compareReports } from './compare-benchmark-report.mjs';
+
+const baseline = {
+  report_schema_version: 1,
+  crate: 'nx-core',
+  benchmark: 'three_node_sync_load',
+  scenario: 'multi-node-sync-gcounter',
+  profile: {
+    nodes: 3,
+    duration_secs: 10,
+    target_ops_sec_per_node: 1000,
+    anti_entropy_interval_secs: 80,
+  },
+  ops_sec_avg: 1000,
+  resources: {
+    rss_bytes: 1000,
+  },
+  latency_ms: {
+    p99: 10,
+  },
+};
+
+test('accepts metrics within thresholds', () => {
+  const result = compareReports(baseline, {
+    ...baseline,
+    ops_sec_avg: 960,
+    resources: {
+      rss_bytes: 1040,
+    },
+    latency_ms: {
+      p99: 10.4,
+    },
+  });
+
+  assert.equal(result.regressions.length, 0);
+});
+
+test('detects p99 throughput and rss regressions', () => {
+  const result = compareReports(baseline, {
+    ...baseline,
+    ops_sec_avg: 900,
+    resources: {
+      rss_bytes: 1100,
+    },
+    latency_ms: {
+      p99: 11,
+    },
+  });
+
+  assert.deepEqual(
+    result.regressions.map((regression) => regression.metric),
+    ['latency_ms.p99', 'ops_sec_avg', 'resources.rss_bytes']
+  );
+});
+
+test('skips rss when either side is null', () => {
+  const result = compareReports(
+    {
+      ...baseline,
+      resources: {
+        rss_bytes: null,
+      },
+    },
+    baseline
+  );
+
+  const rss = result.comparisons.find((comparison) => comparison.metric === 'resources.rss_bytes');
+  assert.equal(rss.status, 'skipped');
+  assert.equal(result.regressions.length, 0);
+});
+
+test('rejects mismatched scenarios', () => {
+  assert.throws(
+    () =>
+      compareReports(baseline, {
+        ...baseline,
+        scenario: 'different',
+      }),
+    /scenario mismatch/
+  );
+});
+
+test('rejects mismatched workload profiles', () => {
+  assert.throws(
+    () =>
+      compareReports(baseline, {
+        ...baseline,
+        profile: {
+          ...baseline.profile,
+          nodes: 10,
+        },
+      }),
+    /profile mismatch/
+  );
+});


### PR DESCRIPTION
Hi! This PR lands the `v0.1.2` performance-profiling and regression-gate
scaffolding on `main`.

**This merge does not finalize `v0.1.2`.**

The benchmark regression infrastructure lands in shadow mode first. Regression
verdicts are reported but do not yet fail CI, while benchmark, convergence,
validation and infrastructure failures remain blocking.

The roadmap item

> CI workflow that compares with baseline and fails if p99 latency,
> throughput or RSS regress > X%

remains open. Closing it requires a follow-up PR based on a baseline calibrated
on `main`, with a populated `rss_bytes` value, followed by activation of
`blocking` mode and end-to-end CI validation.