### PR TITLE
finalizes the V0.1.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,8 +135,6 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     needs: benchmark-tools
-    env:
-      NUMAX_BENCH_GATE_MODE: ${{ vars.NUMAX_BENCH_GATE_MODE || 'shadow' }}
     steps:
       - uses: actions/checkout@v6
       - uses: actions-rust-lang/setup-rust-toolchain@9d7e65c320fdb52dcd45ffaa68deb6c02c8754d9 # v1.10.1
@@ -162,7 +160,7 @@ jobs:
             --current reports/bench/three-node-sync-smoke-2.json \
             --current reports/bench/three-node-sync-smoke-3.json \
             --write-aggregate reports/bench/three-node-sync-smoke-median.json \
-            --mode "${NUMAX_BENCH_GATE_MODE}" \
+            --mode blocking \
             --p99-threshold 10 \
             --p99-min-delta-ms 0.1 \
             --throughput-threshold 5 \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1961,7 +1961,7 @@ dependencies = [
 
 [[package]]
 name = "nx-cli"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -1976,7 +1976,7 @@ dependencies = [
 
 [[package]]
 name = "nx-core"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "blake3",
@@ -1997,7 +1997,7 @@ dependencies = [
 
 [[package]]
 name = "nx-net"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bincode",
  "hex",
@@ -2019,11 +2019,11 @@ dependencies = [
 
 [[package]]
 name = "nx-sdk"
-version = "0.1.1"
+version = "0.1.2"
 
 [[package]]
 name = "nx-store"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "sled",
  "tempfile",
@@ -2032,7 +2032,7 @@ dependencies = [
 
 [[package]]
 name = "nx-sync"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "serde",
  "serde_json",

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Three things, and only three:
 
 You write a WASM module. numax runs it. The state is there. Sync just happens.
 
+> **Status:** `v0.1.2` - current stable Numax release for controlled,
+> non-critical workloads. It adds opt-in runtime profiling, hot-path metrics,
+> and a blocking CI gate for p99 latency, throughput, and RSS regressions.
+
 ---
 
 ## Why

--- a/crates/nx-cli/Cargo.toml
+++ b/crates/nx-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nx-cli"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 
 [features]
@@ -11,7 +11,7 @@ tokio-console = ["dep:console-subscriber", "tokio/tracing"]
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 console-subscriber = { version = "0.5", optional = true }
-nx-core = { version = "0.1.1", path = "../nx-core" }
+nx-core = { version = "0.1.2", path = "../nx-core" }
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 toml = "0.9"

--- a/crates/nx-core/Cargo.toml
+++ b/crates/nx-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nx-core"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 
 [features]
@@ -15,9 +15,9 @@ sha2 = "0.11.0"
 serde_json = "1"
 wasmtime = "43.0.1"
 wasmtime-wasi = "43.0.1"
-nx-store = { version = "0.1.1", path = "../nx-store" }
-nx-sync = { version = "0.1.1", path = "../nx-sync" }
-nx-net = { version = "0.1.1", path = "../nx-net" }
+nx-store = { version = "0.1.2", path = "../nx-store" }
+nx-sync = { version = "0.1.2", path = "../nx-sync" }
+nx-net = { version = "0.1.2", path = "../nx-net" }
 tokio = { version = "1", features = ["io-util", "net", "signal", "sync", "time"] }
 tracing = "0.1"
 

--- a/crates/nx-core/reports/baselines/README.md
+++ b/crates/nx-core/reports/baselines/README.md
@@ -1,36 +1,26 @@
 Baseline reports for `nx-core` load benchmarks.
 
-These files use `report_schema_version = 1` and are the inputs future
-regression checks compare against. They are intentionally separate from
-`reports/load/`, which remains historical benchmark output.
+These files use `report_schema_version = 1` and are the inputs future regression checks compare against. They are intentionally separate from `reports/load/`, which remains historical benchmark output.
 
 Naming convention:
 
 - `<scenario-profile>.json` for committed baselines;
-- `*-smoke.json` for short PR or shadow-CI scenarios;
+- `*-smoke.json` for short PR or CI scenarios;
 - longer release-gate scenarios can be added beside them once they are stable.
 
-Initial baselines are normalized from existing committed load reports, so
-`resources.rss_bytes` is `null` until fresh v1 reports replace them.
+Legacy baselines normalized from historical load reports may have a null `resources.rss_bytes`. A baseline used by a blocking RSS gate must come from the calibration workflow and contain a finite RSS value.
 
 ## Regression gate
 
-Pull-request CI runs the three-node smoke profile three times on
-`ubuntu-24.04` and compares the median p99 latency, throughput, and RSS against
-`three-node-sync-smoke.json`. Raw runs, the median report, and the comparison
-summary are uploaded as the `benchmark-regression-report` artifact.
+Pull-request CI runs the three-node smoke profile three times on `ubuntu-24.04` and compares the median p99 latency, throughput, and RSS against `three-node-sync-smoke.json`. Raw runs, the median report, and the comparison summary are uploaded as the `benchmark-regression-report` artifact.
 
-The gate starts in `shadow` mode. Set the repository variable
-`NUMAX_BENCH_GATE_MODE=blocking` only after committing a reviewed CI-generated
-baseline with a non-null RSS value.
+The gate runs in `blocking` mode against a reviewed CI-generated baseline. A regression beyond the configured thresholds fails the pull-request workflow;
+invalid reports and benchmark correctness failures remain separate hard failures.
 
 ## Baseline calibration
 
-Run the manual **Benchmark Baseline Calibration** workflow. It executes five
-identical benchmark runs, writes their median to
-`reports/baseline-candidate/three-node-sync-smoke.json`, and uploads the
-candidate together with every raw report. The workflow never modifies the
-repository automatically.
+Run the manual **Benchmark Baseline Calibration** workflow. 
+It executes five identical benchmark runs, writes their median to `reports/baseline-candidate/three-node-sync-smoke.json`, and uploads the candidate together with every raw report. The workflow never modifies the repository automatically.
 
 Before replacing the committed baseline:
 
@@ -39,6 +29,4 @@ Before replacing the committed baseline:
 3. review the p99, throughput, and RSS deltas in the workflow summary;
 4. commit the candidate through a normal pull request.
 
-The initial shadow thresholds are 10% plus 0.1 ms for p99, 5% for throughput,
-and 10% plus 16 MiB for RSS. Both the relative and absolute threshold must be
-exceeded for p99 or RSS to count as a regression.
+The blocking thresholds are 10% plus 0.1 ms for p99, 5% for throughput, and 10% plus 16 MiB for RSS. Both the relative and absolute threshold must be exceeded for p99 or RSS to count as a regression.

--- a/crates/nx-core/reports/baselines/three-node-sync-smoke.json
+++ b/crates/nx-core/reports/baselines/three-node-sync-smoke.json
@@ -10,12 +10,12 @@
     "anti_entropy_interval_secs": 80
   },
   "nodes": 3,
-  "load_duration_secs": 10.024,
-  "total_duration_secs": 10.024,
+  "load_duration_secs": 10.009,
+  "total_duration_secs": 10.112,
   "target_ops_sec_per_node": 1000,
   "target_ops_sec_total": 3000,
   "ops_total": 30000,
-  "ops_sec_avg": 2992.69,
+  "ops_sec_avg": 2997.27,
   "errors_total": 0,
   "queued_ops_limit": 110000,
   "op_log_limit": 110000,
@@ -24,15 +24,19 @@
   "expected_counter": 30000,
   "observed_counters": [30000, 30000, 30000],
   "converged": true,
-  "convergence_wait_secs": 0.000,
+  "convergence_wait_secs": 0.102,
   "resources": {
-    "rss_bytes": null
+    "rss_bytes": 136601600
   },
   "latency_ms": {
-    "p50": 0.004,
-    "p95": 0.008,
-    "p99": 0.226,
-    "max": 25.563,
-    "avg": 0.057
+    "p50": 0.001,
+    "p95": 0.002,
+    "p99": 0.031,
+    "max": 0.422,
+    "avg": 0.002
+  },
+  "aggregation": {
+    "method": "median",
+    "runs": 5
   }
 }

--- a/crates/nx-net/Cargo.toml
+++ b/crates/nx-net/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "nx-net"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 
 [dependencies]
-nx-sync = { version = "0.1.1", path = "../nx-sync" }
+nx-sync = { version = "0.1.2", path = "../nx-sync" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 bincode = "1"

--- a/crates/nx-sdk/Cargo.toml
+++ b/crates/nx-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nx-sdk"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 
 [lib]

--- a/crates/nx-store/Cargo.toml
+++ b/crates/nx-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nx-store"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 
 [dependencies]

--- a/crates/nx-sync/Cargo.toml
+++ b/crates/nx-sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nx-sync"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 
 [dependencies]

--- a/docs/nx-site/package-lock.json
+++ b/docs/nx-site/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nx-site",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nx-site",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "@astrojs/starlight": "^0.32.0",
         "astro": "^5.0.0"

--- a/docs/nx-site/package.json
+++ b/docs/nx-site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nx-site",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/docs/nx-site/src/content/docs/getting-started/installation.md
+++ b/docs/nx-site/src/content/docs/getting-started/installation.md
@@ -5,7 +5,7 @@ description: Install Numax on Linux, macOS, Windows or with Cargo.
 
 Numax installs the `nx` CLI.
 
-For `v0.1.1`, the recommended path is:
+For `v0.1.2`, the recommended path is:
 
 1. download a prebuilt binary from the GitHub Release;
 2. or build/install from source with Cargo.
@@ -38,7 +38,7 @@ rustup target add wasm32-unknown-unknown
 Use the Linux x86_64 musl build:
 
 ```bash
-VERSION=v0.1.1
+VERSION=v0.1.2
 TARGET=x86_64-unknown-linux-musl
 ARCHIVE="numax-${VERSION}-${TARGET}.tar.gz"
 
@@ -61,7 +61,7 @@ For ARM64 Linux, use `TARGET=aarch64-unknown-linux-musl`.
 Apple Silicon:
 
 ```bash
-VERSION=v0.1.1
+VERSION=v0.1.2
 TARGET=aarch64-apple-darwin
 ARCHIVE="numax-${VERSION}-${TARGET}.tar.gz"
 
@@ -78,7 +78,7 @@ nx --version
 Intel Mac:
 
 ```bash
-VERSION=v0.1.1
+VERSION=v0.1.2
 TARGET=x86_64-apple-darwin
 ARCHIVE="numax-${VERSION}-${TARGET}.tar.gz"
 
@@ -99,7 +99,7 @@ nx --version
 Open PowerShell:
 
 ```powershell
-$Version = "v0.1.1"
+$Version = "v0.1.2"
 $Target = "x86_64-pc-windows-msvc"
 $Archive = "numax-$Version-$Target.zip"
 $Base = "https://github.com/GianIac/numax/releases/download/$Version"

--- a/docs/nx-site/src/content/docs/roadmap/index.md
+++ b/docs/nx-site/src/content/docs/roadmap/index.md
@@ -24,7 +24,7 @@ description: Current status and planned versions.
 
 ## Status and goal
 
-- **Current release line**: `v0.1.1` (active - architectural cleanup & versioning)
+- **Current release line**: `v0.1.2` (active - performance & profiling)
 - **Final goal of the cycle**: stable `v0.2.0`.
 - **Philosophy of intermediate releases**: every `0.1.x` is a **stable and usable** release. Capabilities are added incrementally without sacrificing quality.
 

--- a/docs/nx-site/src/content/docs/roadmap/index.md
+++ b/docs/nx-site/src/content/docs/roadmap/index.md
@@ -45,8 +45,8 @@ Unlike `v0.1.0` (declared for non-critical workloads), `v0.2.0` must guarantee:
 |---|---|---|
 | `v0.1.0` | First production-ready + Documentation, Distribution & Configuration | released |
 | `v0.1.1` | Architectural Cleanup & Versioning | released |
-| `v0.1.2` | Performance & Profiling | released |
-| `v0.1.3` | Supply Chain & Fuzzing | active |
+| `v0.1.2` | Performance & Profiling | active |
+| `v0.1.3` | Supply Chain & Fuzzing | planned |
 | `v0.1.4` | Management API | planned |
 | `v0.1.5` | Peer Discovery - Foundations | planned |
 | `v0.1.6` | Peer Discovery - SWIM & Gossip K-fanout | planned |
@@ -101,7 +101,7 @@ instead of crashing.
 
 **Regression gate**:
 - [x] Load benchmarks extended with automatic JSON report
-- [ ] CI workflow that compares with baseline and fails if p99 latency, throughput or RSS regress > X%
+- [x] CI workflow that compares with baseline and fails if p99 latency, throughput or RSS regress beyond configured thresholds
 - [x] Run `scripts/compare-benchmark-report.test.mjs` in CI
 - [x] Baseline history committed in `crates/*/reports/baselines/`
 
@@ -112,7 +112,7 @@ instead of crashing.
 - [x] Remote-op received, applied, duplicate, batch, and apply-error counters
 
 **Closing criterion**:
-> A PR that worsens sync p99 by > 5% is automatically blocked by CI with the regression details.
+> A PR whose median sync benchmark exceeds the configured p99, throughput, or RSS regression thresholds is automatically blocked by CI with the regression details.
 
 ---
 

--- a/docs/nx-site/src/content/docs/whitepaper/index.md
+++ b/docs/nx-site/src/content/docs/whitepaper/index.md
@@ -5,7 +5,7 @@ description: Numax vision, architecture and principles.
 
 
 > **Note**
-> This whitepaper is aligned with **v0.1.1**, the current stable Numax release.
+> This whitepaper is aligned with **v0.1.2**, the current stable Numax release.
 > Compared to previous drafts, most of the `TODO`s have been resolved based on the code present in the repository. What remains open is explicitly labeled as *(Planned)* and tracked in the roadmap.
 >
 > **Status labels (consistent with the code):**
@@ -13,7 +13,7 @@ description: Numax vision, architecture and principles.
 > - **(Prototype)**: partially present; internal wiring or critical paths already verified, but not yet production-ready.
 > - **(Planned)**: foreseen in the roadmap, not yet implemented.
 >
-> **Version reference**: `v0.1.1` - stable release for controlled, non-critical workloads. Wire and persisted-schema versions are explicit: mixed `v0.1.0`/`v0.1.1` nodes reject the connection safely, while `v0.1.0` datastores can be upgraded offline with `nx migrate`.
+> **Version reference**: `v0.1.2` - stable release for controlled, non-critical workloads. It retains the explicit wire and persisted-schema versioning introduced in `v0.1.1`, and adds opt-in runtime profiling, hot-path metrics, and a blocking CI performance-regression gate.
 >
 > **Reference roadmap:** future work is tracked by release line and milestone in [Roadmap](/numax/roadmap/).
 
@@ -171,7 +171,7 @@ The separation keeps responsibilities clear and allows components to evolve inde
 
 ### 4.2 Supported environments
 
-Numax `v0.1.1` is designed to run as a native runtime on:
+Numax `v0.1.2` is designed to run as a native runtime on:
 
 - servers (x86_64, ARM64),
 - edge nodes,
@@ -856,7 +856,8 @@ The project includes an automated test suite that covers runtime, store, CRDT, n
 4. `test` - full test suite execution
 5. `build-wasm` - compilation of WASM examples
 
-**Load testing** - `v0.1.0` includes reproducible load gates with JSON reports:
+**Load testing and profiling** - the reproducible load gates introduced in
+`v0.1.0` emit JSON reports for:
 
 - single-node store throughput: 10k ops/sec for 1 hour
 - 3-node continuous sync: 1k ops/sec per node
@@ -864,15 +865,18 @@ The project includes an automated test suite that covers runtime, store, CRDT, n
 - chaos restart runner: continuous load with follower restart every 60s
 
 The reports capture throughput, p50/p95/p99 latency, convergence time and
-restart count for chaos runs. RAM/CPU profiling is intentionally left as a
-future hardening extension rather than mixed into the current correctness/load
-gates.
+restart count for chaos runs. In `v0.1.2`, pull requests also run the 3-node
+sync benchmark three times and compare its median p99 latency, throughput, and
+RSS against a baseline calibrated on `main`. The comparison is blocking with
+relative thresholds and absolute floors to limit false positives from
+numerically irrelevant changes. A separate Ubuntu CI path produces opt-in CPU
+flamegraphs with `pprof-rs` and load-phase heap profiles with `dhat`.
 
 ---
 
 ## 8. Use Cases
 
-The use cases below are **concretely achievable today** with the primitives of `v0.1.1`. They do not describe visions: they describe what the runtime already knows how to do with the current stable feature set.
+The use cases below are **concretely achievable today** with the primitives of `v0.1.2`. They do not describe visions: they describe what the runtime already knows how to do with the current stable feature set.
 
 ### 8.1 Distributed counters and metrics (example: `distributed_counter`)
 
@@ -902,7 +906,7 @@ The compute is portable across Numax nodes: the same `.wasm` module can run on a
 
 **Problem.** Applications that must work without a connection (collaborative notes, distributed configurations, field applications, maritime/aerial/rural devices) and reconcile when they come back online, without imposing manual conflict resolution.
 
-**Why Numax.** This is exactly the sweet spot of CRDTs: each node operates locally on its own store, changes propagate opportunistically, convergence is mathematically guaranteed. With PNCounter, LWW-Register, ORSet, LWW-Map and RGA available since `v0.1.0` and retained in `v0.1.1`, the model covers counters, statuses, observed-remove sets, replicated settings and ordered collaborative sequences.
+**Why Numax.** This is exactly the sweet spot of CRDTs: each node operates locally on its own store, changes propagate opportunistically, convergence is mathematically guaranteed. With PNCounter, LWW-Register, ORSet, LWW-Map and RGA available since `v0.1.0` and retained in `v0.1.2`, the model covers counters, statuses, observed-remove sets, replicated settings and ordered collaborative sequences.
 
 The `distributed_chat` example (today in local-only mode) represents the skeleton of this use case.
 
@@ -938,7 +942,7 @@ Numax is not AI. It is one of the things that AI can, comfortably, run on top of
 
 ## 10. Limitations
 
-`v0.1.1` is the current stable release, building on the first stable `v0.1.0` line. We recognize its limits explicitly:
+`v0.1.2` is the current stable release, building on the first stable `v0.1.0` line. We recognize its limits explicitly:
 
 - **Network resilience is still prototype-grade.** Automatic reconnect, peer health tracking, peer rotation, anti-entropy and bounded dedup are implemented for configured peers, but full dynamic discovery and K-fanout gossip remain future work.
 - **Deduplication is bounded.** Recent duplicate remote operations are prevented across restart, but this is not an infinite causal history. Stronger guarantees would require a fuller durable op-log/causal metadata strategy.
@@ -965,11 +969,11 @@ Numax proposes a unified runtime that combines:
 
 The goal is not to replicate the existing ecosystem, but **to reduce the self-imposed complexity** that today dominates distributed systems development, while preserving control over the necessary complexity of one's own domain.
 
-`v0.1.1` is the current stable Numax release. It retains the real, tested foundation established by `v0.1.0` - WASM runtime, sled store, six CRDT families, async replication, TCP networking, TLS 1.3 + mTLS, extended host APIs, observability and reproducible test gates - and adds a modular SyncManager, explicit wire/schema versioning, typed protocol errors and offline datastore migration.
+`v0.1.2` is the current stable Numax release. It retains the real, tested foundation established by `v0.1.0` and hardened in `v0.1.1` - WASM runtime, sled store, six CRDT families, async replication, TCP networking, TLS 1.3 + mTLS, extended host APIs, modular SyncManager, explicit wire/schema versioning, typed protocol errors and offline datastore migration - and adds opt-in task, CPU and heap profiling, WASM and sync hot-path metrics, and a blocking performance-regression gate.
 
 What is still missing is declared explicitly and tracked in the roadmap. Subsequent iterations will refine details, practical examples, comparisons and experimental results.
 
-**`v0.1.1` is the current stable release.** It is built on code, tests and documented limits rather than promises; `v0.1.0` remains the first stable line it evolved from.
+**`v0.1.2` is the current stable release.** It is built on code, tests and documented limits rather than promises; `v0.1.0` remains the first stable line it evolved from.
 
 In closing, I love software and I love numax.
 

--- a/examples/distributed_chat/Cargo.lock
+++ b/examples/distributed_chat/Cargo.lock
@@ -4,11 +4,11 @@ version = 4
 
 [[package]]
 name = "distributed_chat"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "nx-sdk",
 ]
 
 [[package]]
 name = "nx-sdk"
-version = "0.1.1"
+version = "0.1.2"

--- a/examples/distributed_chat/Cargo.toml
+++ b/examples/distributed_chat/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "distributed_chat"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]
 
 [dependencies]
-nx-sdk = { version = "0.1.1", path = "../../crates/nx-sdk" }
+nx-sdk = { version = "0.1.2", path = "../../crates/nx-sdk" }
 
 [workspace]

--- a/examples/distributed_comments/Cargo.lock
+++ b/examples/distributed_comments/Cargo.lock
@@ -4,11 +4,11 @@ version = 4
 
 [[package]]
 name = "distributed_comments"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "nx-sdk",
 ]
 
 [[package]]
 name = "nx-sdk"
-version = "0.1.1"
+version = "0.1.2"

--- a/examples/distributed_comments/Cargo.toml
+++ b/examples/distributed_comments/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "distributed_comments"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]
 
 [dependencies]
-nx-sdk = { version = "0.1.1", path = "../../crates/nx-sdk" }
+nx-sdk = { version = "0.1.2", path = "../../crates/nx-sdk" }
 
 [profile.release]
 lto = true

--- a/examples/distributed_counter/Cargo.lock
+++ b/examples/distributed_counter/Cargo.lock
@@ -4,11 +4,11 @@ version = 4
 
 [[package]]
 name = "distributed_counter"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "nx-sdk",
 ]
 
 [[package]]
 name = "nx-sdk"
-version = "0.1.1"
+version = "0.1.2"

--- a/examples/distributed_counter/Cargo.toml
+++ b/examples/distributed_counter/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "distributed_counter"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]
 
 [dependencies]
-nx-sdk = { version = "0.1.1", path = "../../crates/nx-sdk" }
+nx-sdk = { version = "0.1.2", path = "../../crates/nx-sdk" }
 
 [profile.release]
 lto = true

--- a/examples/distributed_inventory/Cargo.lock
+++ b/examples/distributed_inventory/Cargo.lock
@@ -4,11 +4,11 @@ version = 4
 
 [[package]]
 name = "distributed_inventory"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "nx-sdk",
 ]
 
 [[package]]
 name = "nx-sdk"
-version = "0.1.1"
+version = "0.1.2"

--- a/examples/distributed_inventory/Cargo.toml
+++ b/examples/distributed_inventory/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "distributed_inventory"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]
 
 [dependencies]
-nx-sdk = { version = "0.1.1", path = "../../crates/nx-sdk" }
+nx-sdk = { version = "0.1.2", path = "../../crates/nx-sdk" }
 
 [profile.release]
 lto = true

--- a/examples/distributed_settings/Cargo.lock
+++ b/examples/distributed_settings/Cargo.lock
@@ -4,11 +4,11 @@ version = 4
 
 [[package]]
 name = "distributed_settings"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "nx-sdk",
 ]
 
 [[package]]
 name = "nx-sdk"
-version = "0.1.1"
+version = "0.1.2"

--- a/examples/distributed_settings/Cargo.toml
+++ b/examples/distributed_settings/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "distributed_settings"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]
 
 [dependencies]
-nx-sdk = { version = "0.1.1", path = "../../crates/nx-sdk" }
+nx-sdk = { version = "0.1.2", path = "../../crates/nx-sdk" }
 
 [profile.release]
 lto = true

--- a/examples/distributed_status/Cargo.lock
+++ b/examples/distributed_status/Cargo.lock
@@ -4,11 +4,11 @@ version = 4
 
 [[package]]
 name = "distributed_status"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "nx-sdk",
 ]
 
 [[package]]
 name = "nx-sdk"
-version = "0.1.1"
+version = "0.1.2"

--- a/examples/distributed_status/Cargo.toml
+++ b/examples/distributed_status/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "distributed_status"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]
 
 [dependencies]
-nx-sdk = { version = "0.1.1", path = "../../crates/nx-sdk" }
+nx-sdk = { version = "0.1.2", path = "../../crates/nx-sdk" }
 
 [profile.release]
 lto = true

--- a/examples/distributed_tags/Cargo.lock
+++ b/examples/distributed_tags/Cargo.lock
@@ -4,11 +4,11 @@ version = 4
 
 [[package]]
 name = "distributed_tags"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "nx-sdk",
 ]
 
 [[package]]
 name = "nx-sdk"
-version = "0.1.1"
+version = "0.1.2"

--- a/examples/distributed_tags/Cargo.toml
+++ b/examples/distributed_tags/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "distributed_tags"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]
 
 [dependencies]
-nx-sdk = { version = "0.1.1", path = "../../crates/nx-sdk" }
+nx-sdk = { version = "0.1.2", path = "../../crates/nx-sdk" }
 
 [profile.release]
 lto = true

--- a/examples/hello_sdk/Cargo.lock
+++ b/examples/hello_sdk/Cargo.lock
@@ -4,11 +4,11 @@ version = 4
 
 [[package]]
 name = "hello_sdk"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "nx-sdk",
 ]
 
 [[package]]
 name = "nx-sdk"
-version = "0.1.1"
+version = "0.1.2"

--- a/examples/hello_sdk/Cargo.toml
+++ b/examples/hello_sdk/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "hello_sdk"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]
 
 [dependencies]
-nx-sdk = { version = "0.1.1", path = "../../crates/nx-sdk" }
+nx-sdk = { version = "0.1.2", path = "../../crates/nx-sdk" }
 
 [profile.release]
 lto = true

--- a/examples/hello_wasi/Cargo.lock
+++ b/examples/hello_wasi/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "hello_wasi"
-version = "0.1.1"
+version = "0.1.2"

--- a/examples/hello_wasi/Cargo.toml
+++ b/examples/hello_wasi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello_wasi"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 
 [dependencies]

--- a/examples/hello_wasm/Cargo.lock
+++ b/examples/hello_wasm/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "hello_wasm"
-version = "0.1.1"
+version = "0.1.2"

--- a/examples/hello_wasm/Cargo.toml
+++ b/examples/hello_wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello_wasm"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 
 [lib]

--- a/examples/kv_counter/Cargo.lock
+++ b/examples/kv_counter/Cargo.lock
@@ -4,11 +4,11 @@ version = 4
 
 [[package]]
 name = "kv_counter"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "nx-sdk",
 ]
 
 [[package]]
 name = "nx-sdk"
-version = "0.1.1"
+version = "0.1.2"

--- a/examples/kv_counter/Cargo.toml
+++ b/examples/kv_counter/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "kv_counter"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]
 
 [dependencies]
-nx-sdk = { version = "0.1.1", path = "../../crates/nx-sdk" }
+nx-sdk = { version = "0.1.2", path = "../../crates/nx-sdk" }
 
 [workspace]

--- a/examples/kv_get_set_delete/Cargo.lock
+++ b/examples/kv_get_set_delete/Cargo.lock
@@ -4,11 +4,11 @@ version = 4
 
 [[package]]
 name = "kv_get_set_delete"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "nx-sdk",
 ]
 
 [[package]]
 name = "nx-sdk"
-version = "0.1.1"
+version = "0.1.2"

--- a/examples/kv_get_set_delete/Cargo.toml
+++ b/examples/kv_get_set_delete/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "kv_get_set_delete"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]
 
 [dependencies]
-nx-sdk = { version = "0.1.1", path = "../../crates/nx-sdk" }
+nx-sdk = { version = "0.1.2", path = "../../crates/nx-sdk" }
 
 [profile.release]
 lto = true

--- a/examples/kv_roundtrip/Cargo.lock
+++ b/examples/kv_roundtrip/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "kv_roundtrip"
-version = "0.1.1"
+version = "0.1.2"

--- a/examples/kv_roundtrip/Cargo.toml
+++ b/examples/kv_roundtrip/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kv_roundtrip"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 
 [lib]

--- a/examples/kv_sdk_roundtrip/Cargo.lock
+++ b/examples/kv_sdk_roundtrip/Cargo.lock
@@ -4,11 +4,11 @@ version = 4
 
 [[package]]
 name = "kv_sdk_roundtrip"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "nx-sdk",
 ]
 
 [[package]]
 name = "nx-sdk"
-version = "0.1.1"
+version = "0.1.2"

--- a/examples/kv_sdk_roundtrip/Cargo.toml
+++ b/examples/kv_sdk_roundtrip/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "kv_sdk_roundtrip"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]
 
 [dependencies]
-nx-sdk = { version = "0.1.1", path = "../../crates/nx-sdk" }
+nx-sdk = { version = "0.1.2", path = "../../crates/nx-sdk" }
 
 [workspace]

--- a/examples/vote_tally_tls/Cargo.lock
+++ b/examples/vote_tally_tls/Cargo.lock
@@ -4,11 +4,11 @@ version = 4
 
 [[package]]
 name = "nx-sdk"
-version = "0.1.1"
+version = "0.1.2"
 
 [[package]]
 name = "vote_tally_tls"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "nx-sdk",
 ]

--- a/examples/vote_tally_tls/Cargo.toml
+++ b/examples/vote_tally_tls/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "vote_tally_tls"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]
 
 [dependencies]
-nx-sdk = { version = "0.1.1", path = "../../crates/nx-sdk" }
+nx-sdk = { version = "0.1.2", path = "../../crates/nx-sdk" }
 
 [profile.release]
 lto = true

--- a/scripts/compare-benchmark-report.test.mjs
+++ b/scripts/compare-benchmark-report.test.mjs
@@ -1,5 +1,10 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 
 import {
   aggregateReports,
@@ -26,6 +31,49 @@ const baseline = {
     p99: 10,
   },
 };
+
+const comparatorPath = fileURLToPath(
+  new URL("./compare-benchmark-report.mjs", import.meta.url),
+);
+
+function reportWith({
+  opsSec = baseline.ops_sec_avg,
+  rssBytes = baseline.resources.rss_bytes,
+  p99 = baseline.latency_ms.p99,
+} = {}) {
+  return {
+    ...baseline,
+    profile: { ...baseline.profile },
+    ops_sec_avg: opsSec,
+    resources: { rss_bytes: rssBytes },
+    latency_ms: { p99 },
+  };
+}
+
+function writeReport(directory, name, report) {
+  const path = join(directory, name);
+  writeFileSync(path, `${JSON.stringify(report)}\n`);
+  return path;
+}
+
+function runComparator(args) {
+  const env = { ...process.env };
+  delete env.NODE_TEST_CONTEXT;
+  const result = spawnSync(process.execPath, [comparatorPath, ...args], {
+    encoding: "utf8",
+    env,
+  });
+  if (result.error) {
+    throw result.error;
+  }
+  return result;
+}
+
+function withTemporaryDirectory(testContext) {
+  const directory = mkdtempSync(join(tmpdir(), "numax-benchmark-comparator-"));
+  testContext.after(() => rmSync(directory, { recursive: true, force: true }));
+  return directory;
+}
 
 test("accepts metrics within thresholds", () => {
   const result = compareReports(baseline, {
@@ -172,4 +220,110 @@ test("rejects a missing current RSS once the baseline has RSS", () => {
       }),
     /current resources\.rss_bytes is required/,
   );
+});
+
+test("CLI aggregates repeated current reports and writes the median", (t) => {
+  const directory = withTemporaryDirectory(t);
+  const baselinePath = writeReport(directory, "baseline.json", baseline);
+  const currentPaths = [
+    writeReport(
+      directory,
+      "current-1.json",
+      reportWith({ opsSec: 980, rssBytes: 1020, p99: 10.2 }),
+    ),
+    writeReport(
+      directory,
+      "current-2.json",
+      reportWith({ opsSec: 960, rssBytes: 1040, p99: 10.4 }),
+    ),
+    writeReport(
+      directory,
+      "current-3.json",
+      reportWith({ opsSec: 970, rssBytes: 1030, p99: 10.3 }),
+    ),
+  ];
+  const aggregatePath = join(directory, "aggregate", "median.json");
+
+  const result = runComparator([
+    "--baseline",
+    baselinePath,
+    ...currentPaths.flatMap((path) => ["--current", path]),
+    "--write-aggregate",
+    aggregatePath,
+    "--mode",
+    "blocking",
+  ]);
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.match(result.stdout, /current runs: 3 \(median\)/);
+  const aggregate = JSON.parse(readFileSync(aggregatePath, "utf8"));
+  assert.equal(aggregate.ops_sec_avg, 970);
+  assert.equal(aggregate.resources.rss_bytes, 1030);
+  assert.equal(aggregate.latency_ms.p99, 10.3);
+  assert.deepEqual(aggregate.aggregation, { method: "median", runs: 3 });
+});
+
+test("CLI blocking mode exits 1 when metrics regress", (t) => {
+  const directory = withTemporaryDirectory(t);
+  const baselinePath = writeReport(directory, "baseline.json", baseline);
+  const currentPath = writeReport(
+    directory,
+    "current.json",
+    reportWith({ opsSec: 900, rssBytes: 1100, p99: 11 }),
+  );
+
+  const result = runComparator([
+    "--baseline",
+    baselinePath,
+    "--current",
+    currentPath,
+    "--mode",
+    "blocking",
+  ]);
+
+  assert.equal(result.status, 1, result.stderr || result.stdout);
+  assert.match(result.stdout, /3 benchmark regression\(s\) detected/);
+  assert.match(result.stdout, /::error::/);
+});
+
+test("CLI shadow mode reports regressions without failing", (t) => {
+  const directory = withTemporaryDirectory(t);
+  const baselinePath = writeReport(directory, "baseline.json", baseline);
+  const currentPath = writeReport(
+    directory,
+    "current.json",
+    reportWith({ opsSec: 900, rssBytes: 1100, p99: 11 }),
+  );
+
+  const result = runComparator([
+    "--baseline",
+    baselinePath,
+    "--current",
+    currentPath,
+    "--mode",
+    "shadow",
+  ]);
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.match(result.stdout, /3 benchmark regression\(s\) detected/);
+  assert.match(result.stdout, /::warning::/);
+});
+
+test("CLI exits 2 for malformed JSON input", (t) => {
+  const directory = withTemporaryDirectory(t);
+  const baselinePath = writeReport(directory, "baseline.json", baseline);
+  const malformedPath = join(directory, "malformed.json");
+  writeFileSync(malformedPath, "{ not valid JSON");
+
+  const result = runComparator([
+    "--baseline",
+    baselinePath,
+    "--current",
+    malformedPath,
+    "--mode",
+    "blocking",
+  ]);
+
+  assert.equal(result.status, 2, result.stderr || result.stdout);
+  assert.match(result.stderr, /benchmark comparison failed:/);
 });


### PR DESCRIPTION
This MR finalizes the `v0.1.2` Performance & Profiling release.

It enables the blocking CI regression gate using the baseline calibrated on
`main`, adds CLI end-to-end tests, bumps all packages to `0.1.2`, and aligns
the documentation.

CI now blocks regressions beyond the configured thresholds for p99 latency,
throughput, and RSS.

Validation:

- `cargo test --workspace`
- `cargo check --workspace --locked`
- `cargo fmt --all -- --check`
- documentation check and build

Once merged with green CI, `v0.1.2` is ready to be tagged and released.