### PR TITLE
cli: add nx completions <shell> subcommand (bash/zsh/fish/powershell)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -514,6 +514,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f84a88507dbd05c695f2cb5e8558e747179134005e9893882dec964190ed89"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1965,6 +1974,7 @@ version = "0.1.2"
 dependencies = [
  "anyhow",
  "clap",
+ "clap_complete",
  "console-subscriber",
  "nx-core",
  "serde",

--- a/crates/nx-cli/Cargo.toml
+++ b/crates/nx-cli/Cargo.toml
@@ -10,6 +10,7 @@ tokio-console = ["dep:console-subscriber", "tokio/tracing"]
 [dependencies]
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
+clap_complete = "4"
 console-subscriber = { version = "0.5", optional = true }
 nx-core = { version = "0.1.2", path = "../nx-core" }
 serde = { version = "1", features = ["derive"] }

--- a/crates/nx-cli/src/main.rs
+++ b/crates/nx-cli/src/main.rs
@@ -1,12 +1,14 @@
 mod config;
 
 use std::fs;
+use std::io::{self, Write};
 use std::num::{NonZeroU32, NonZeroUsize};
 use std::path::PathBuf;
 use std::time::Duration;
 
 use anyhow::Result;
-use clap::{Parser, Subcommand};
+use clap::{CommandFactory, Parser, Subcommand};
+use clap_complete::{Shell, generate};
 use config::*;
 use nx_core::runtime::{DEFAULT_SHUTDOWN_TIMEOUT, Runtime, RuntimeConfig};
 use nx_core::sync_manager::{
@@ -144,6 +146,13 @@ enum Cli {
         #[arg(long, value_name = "BYTES", default_value_t = DEFAULT_MIGRATION_BATCH_BYTES, value_parser = parse_nonzero_byte_size)]
         max_bytes: NonZeroUsize,
     },
+
+    /// Generate shell completion scripts
+    Completions {
+        /// Shell to generate completions for
+        #[arg(value_enum)]
+        shell: Shell,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -178,21 +187,33 @@ enum ConfigCommand {
     },
 }
 
+fn generate_completions(shell: Shell, writer: &mut dyn Write) {
+    let mut command = Cli::command();
+    generate(shell, &mut command, "nx", writer);
+}
+
 fn main() {
+    let cli = match Cli::parse() {
+        Cli::Completions { shell } => {
+            let stdout = io::stdout();
+            generate_completions(shell, &mut stdout.lock());
+            return;
+        }
+        cli => cli,
+    };
+
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
         .expect("failed to build tokio runtime");
 
-    if let Err(e) = rt.block_on(real_main()) {
+    if let Err(e) = rt.block_on(real_main(cli)) {
         eprintln!("[nx-cli] error: {e}");
         std::process::exit(1);
     }
 }
 
-async fn real_main() -> Result<()> {
-    let cli = Cli::parse();
-
+async fn real_main(cli: Cli) -> Result<()> {
     match cli {
         Cli::Run {
             module,
@@ -382,6 +403,9 @@ async fn real_main() -> Result<()> {
             migrate_sync_schema_at_path(&datastore_path, options)?;
             println!("datastore migrated: {}", datastore_path.display());
         }
+        Cli::Completions { .. } => {
+            unreachable!("completion generation returns before runtime initialization")
+        }
     }
 
     Ok(())
@@ -405,6 +429,62 @@ mod tests {
 
     fn p(s: &str) -> Option<PathBuf> {
         Some(PathBuf::from(s))
+    }
+
+    mod completions {
+        use super::*;
+
+        #[test]
+        fn generates_nonempty_scripts_for_supported_shells() {
+            for shell in [
+                Shell::Bash,
+                Shell::Zsh,
+                Shell::Fish,
+                Shell::PowerShell,
+                Shell::Elvish,
+            ] {
+                let mut output = Vec::new();
+                generate_completions(shell, &mut output);
+
+                let output = String::from_utf8(output).unwrap();
+                assert!(!output.is_empty(), "empty completion output for {shell}");
+                assert!(
+                    output.contains("nx"),
+                    "completion output did not name nx for {shell}"
+                );
+            }
+        }
+
+        #[test]
+        fn parses_a_supported_shell() {
+            let cli = Cli::try_parse_from(["nx", "completions", "bash"]).unwrap();
+
+            assert!(matches!(
+                cli,
+                Cli::Completions { shell: Shell::Bash }
+            ));
+        }
+
+        #[test]
+        fn rejects_an_unsupported_shell() {
+            let error = Cli::try_parse_from(["nx", "completions", "nushell"]).unwrap_err();
+
+            assert_eq!(error.kind(), clap::error::ErrorKind::InvalidValue);
+            let rendered = error.to_string();
+            for shell in ["bash", "elvish", "fish", "powershell", "zsh"] {
+                assert!(rendered.contains(shell), "missing {shell} in: {rendered}");
+            }
+        }
+
+        #[test]
+        fn rejects_a_missing_shell() {
+            let error = Cli::try_parse_from(["nx", "completions"]).unwrap_err();
+
+            assert_eq!(
+                error.kind(),
+                clap::error::ErrorKind::MissingRequiredArgument
+            );
+        }
     }
 
     mod duration_parser {

--- a/crates/nx-cli/src/main.rs
+++ b/crates/nx-cli/src/main.rs
@@ -459,10 +459,7 @@ mod tests {
         fn parses_a_supported_shell() {
             let cli = Cli::try_parse_from(["nx", "completions", "bash"]).unwrap();
 
-            assert!(matches!(
-                cli,
-                Cli::Completions { shell: Shell::Bash }
-            ));
+            assert!(matches!(cli, Cli::Completions { shell: Shell::Bash }));
         }
 
         #[test]

--- a/crates/nx-cli/tests/completions.rs
+++ b/crates/nx-cli/tests/completions.rs
@@ -1,0 +1,71 @@
+use std::fs;
+use std::path::PathBuf;
+use std::process::{Command, Output};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn run_nx(args: &[&str], working_directory: &PathBuf) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_nx"))
+        .args(args)
+        .current_dir(working_directory)
+        .output()
+        .unwrap()
+}
+
+fn empty_working_directory() -> PathBuf {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let path =
+        std::env::temp_dir().join(format!("nx-completions-{}-{unique}", std::process::id()));
+    fs::create_dir(&path).unwrap();
+    path
+}
+
+#[test]
+fn supported_shells_write_scripts_without_creating_files() {
+    let working_directory = empty_working_directory();
+
+    for shell in ["bash", "zsh", "fish", "powershell", "elvish"] {
+        let output = run_nx(&["completions", shell], &working_directory);
+
+        assert!(
+            output.status.success(),
+            "{shell}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(!output.stdout.is_empty(), "empty stdout for {shell}");
+        assert!(output.stderr.is_empty(), "unexpected stderr for {shell}");
+        assert_eq!(fs::read_dir(&working_directory).unwrap().count(), 0);
+    }
+
+    fs::remove_dir(working_directory).unwrap();
+}
+
+#[test]
+fn missing_shell_lists_the_required_argument() {
+    let working_directory = empty_working_directory();
+    let output = run_nx(&["completions"], &working_directory);
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("required"), "{stderr}");
+    assert!(stderr.contains("<SHELL>"), "{stderr}");
+
+    fs::remove_dir(working_directory).unwrap();
+}
+
+#[test]
+fn invalid_shell_lists_supported_values() {
+    let working_directory = empty_working_directory();
+    let output = run_nx(&["completions", "nushell"], &working_directory);
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    for shell in ["bash", "elvish", "fish", "powershell", "zsh"] {
+        assert!(stderr.contains(shell), "missing {shell} in: {stderr}");
+    }
+
+    fs::remove_dir(working_directory).unwrap();
+}
+

--- a/crates/nx-cli/tests/completions.rs
+++ b/crates/nx-cli/tests/completions.rs
@@ -16,8 +16,7 @@ fn empty_working_directory() -> PathBuf {
         .duration_since(UNIX_EPOCH)
         .unwrap()
         .as_nanos();
-    let path =
-        std::env::temp_dir().join(format!("nx-completions-{}-{unique}", std::process::id()));
+    let path = std::env::temp_dir().join(format!("nx-completions-{}-{unique}", std::process::id()));
     fs::create_dir(&path).unwrap();
     path
 }
@@ -68,4 +67,3 @@ fn invalid_shell_lists_supported_values() {
 
     fs::remove_dir(working_directory).unwrap();
 }
-


### PR DESCRIPTION
Closes #84

Adds `nx completions <shell>` for Bash, Zsh, Fish, PowerShell, and Elvish.

Completion generation is handled immediately after CLI parsing, before Tokio or the Numax runtime is initialized. The generated script is written only to stdout.

Tests cover:
- non-empty output for every supported shell
- missing and invalid shell diagnostics
- no files created in an empty working directory