### PR TITLE
sdk: add #[inline] to trivial FFI wrapper functions in nx-sdk

### DIFF
--- a/crates/nx-sdk/src/crdt/gcounter.rs
+++ b/crates/nx-sdk/src/crdt/gcounter.rs
@@ -8,6 +8,7 @@ const ERR_SYNC_DISABLED: i32 = -5;
 
 /// Increment the GCounter under `key` by `delta` on the local node.
 #[must_use = "this SDK call can fail; handle the Result"]
+#[inline]
 pub fn inc(key: &str, delta: u64) -> Result<()> {
     let rc = unsafe { ffi::crdt_gcounter_inc(key.as_ptr() as u32, key.len() as u32, delta) };
     match rc {
@@ -22,6 +23,7 @@ pub fn inc(key: &str, delta: u64) -> Result<()> {
 
 /// Read the current converged value of the GCounter under `key`.
 #[must_use = "this SDK call can fail; handle the Result"]
+#[inline]
 pub fn value(key: &str) -> Result<u64> {
     let mut buf = [0u8; 8];
     let n = unsafe {

--- a/crates/nx-sdk/src/crdt/lww_map.rs
+++ b/crates/nx-sdk/src/crdt/lww_map.rs
@@ -16,6 +16,7 @@ const MAX_LWW_MAP_BUFFER: usize = 1024 * 1024;
 ///
 /// The host assigns the timestamp and local writer NodeId.
 #[must_use = "this SDK call can fail; handle the Result"]
+#[inline]
 pub fn set(key: &str, field: &str, value: &[u8]) -> Result<()> {
     let rc = unsafe {
         ffi::crdt_lww_map_set(
@@ -32,6 +33,7 @@ pub fn set(key: &str, field: &str, value: &[u8]) -> Result<()> {
 
 /// Remove `field` from the LWW-Map under `key`.
 #[must_use = "this SDK call can fail; handle the Result"]
+#[inline]
 pub fn remove(key: &str, field: &str) -> Result<()> {
     let rc = unsafe {
         ffi::crdt_lww_map_remove(
@@ -84,6 +86,7 @@ pub fn get(key: &str, field: &str) -> Result<Option<Vec<u8>>> {
 
 /// Return true when `field` currently has a visible value.
 #[must_use = "this SDK call can fail; handle the Result"]
+#[inline]
 pub fn contains(key: &str, field: &str) -> Result<bool> {
     let rc = unsafe {
         ffi::crdt_lww_map_contains(

--- a/crates/nx-sdk/src/crdt/lww_register.rs
+++ b/crates/nx-sdk/src/crdt/lww_register.rs
@@ -15,6 +15,7 @@ const MAX_LWW_BUFFER: usize = 1024 * 1024;
 ///
 /// The host assigns the timestamp and local writer NodeId.
 #[must_use = "this SDK call can fail; handle the Result"]
+#[inline]
 pub fn set(key: &str, value: &[u8]) -> Result<()> {
     let rc = unsafe {
         ffi::crdt_lww_set(

--- a/crates/nx-sdk/src/crdt/orset.rs
+++ b/crates/nx-sdk/src/crdt/orset.rs
@@ -13,6 +13,7 @@ const MAX_ORSET_BUFFER: usize = 1024 * 1024;
 
 /// Add `element` to the ORSet under `key`.
 #[must_use = "this SDK call can fail; handle the Result"]
+#[inline]
 pub fn add(key: &str, element: &str) -> Result<()> {
     let rc = unsafe {
         ffi::crdt_orset_add(
@@ -27,6 +28,7 @@ pub fn add(key: &str, element: &str) -> Result<()> {
 
 /// Remove the locally observed add-tags for `element` from the ORSet under `key`.
 #[must_use = "this SDK call can fail; handle the Result"]
+#[inline]
 pub fn remove(key: &str, element: &str) -> Result<()> {
     let rc = unsafe {
         ffi::crdt_orset_remove(
@@ -41,6 +43,7 @@ pub fn remove(key: &str, element: &str) -> Result<()> {
 
 /// Return true when `element` is currently visible in the ORSet under `key`.
 #[must_use = "this SDK call can fail; handle the Result"]
+#[inline]
 pub fn contains(key: &str, element: &str) -> Result<bool> {
     let rc = unsafe {
         ffi::crdt_orset_contains(

--- a/crates/nx-sdk/src/crdt/pncounter.rs
+++ b/crates/nx-sdk/src/crdt/pncounter.rs
@@ -8,6 +8,7 @@ const ERR_SYNC_DISABLED: i32 = -5;
 
 /// Increment the positive side of the PNCounter under `key` by `delta`.
 #[must_use = "this SDK call can fail; handle the Result"]
+#[inline]
 pub fn inc(key: &str, delta: u64) -> Result<()> {
     let rc = unsafe { ffi::crdt_pncounter_inc(key.as_ptr() as u32, key.len() as u32, delta) };
     map_unit_result(rc)
@@ -15,6 +16,7 @@ pub fn inc(key: &str, delta: u64) -> Result<()> {
 
 /// Increment the negative side of the PNCounter under `key` by `delta`.
 #[must_use = "this SDK call can fail; handle the Result"]
+#[inline]
 pub fn dec(key: &str, delta: u64) -> Result<()> {
     let rc = unsafe { ffi::crdt_pncounter_dec(key.as_ptr() as u32, key.len() as u32, delta) };
     map_unit_result(rc)
@@ -22,6 +24,7 @@ pub fn dec(key: &str, delta: u64) -> Result<()> {
 
 /// Read the current converged signed value of the PNCounter under `key`.
 #[must_use = "this SDK call can fail; handle the Result"]
+#[inline]
 pub fn value(key: &str) -> Result<i64> {
     let mut buf = [0u8; 8];
     let n = unsafe {

--- a/crates/nx-sdk/src/crdt/rga.rs
+++ b/crates/nx-sdk/src/crdt/rga.rs
@@ -59,6 +59,7 @@ pub fn insert_after(key: &str, parent: Option<&str>, value: &[u8]) -> Result<Str
 
 /// Delete the element identified by `id`.
 #[must_use = "this SDK call can fail; handle the Result"]
+#[inline]
 pub fn delete(key: &str, id: &str) -> Result<()> {
     let rc = unsafe {
         ffi::crdt_rga_delete(

--- a/crates/nx-sdk/src/crypto.rs
+++ b/crates/nx-sdk/src/crypto.rs
@@ -44,6 +44,7 @@ pub fn random_bytes(len: usize) -> Result<Vec<u8>> {
 
 /// SHA-256 digest of `input`.
 #[must_use = "this SDK call can fail; handle the Result"]
+#[inline]
 pub fn hash_sha256(input: &[u8]) -> Result<[u8; HASH_LEN]> {
     let mut out = [0u8; HASH_LEN];
     let input_len = u32::try_from(input.len()).map_err(|_| NxError::Internal)?;
@@ -61,6 +62,7 @@ pub fn hash_sha256(input: &[u8]) -> Result<[u8; HASH_LEN]> {
 
 /// BLAKE3 digest of `input`.
 #[must_use = "this SDK call can fail; handle the Result"]
+#[inline]
 pub fn hash_blake3(input: &[u8]) -> Result<[u8; HASH_LEN]> {
     let mut out = [0u8; HASH_LEN];
     let input_len = u32::try_from(input.len()).map_err(|_| NxError::Internal)?;

--- a/crates/nx-sdk/src/db.rs
+++ b/crates/nx-sdk/src/db.rs
@@ -23,6 +23,7 @@ fn map_rc_unit(rc: i32) -> Result<()> {
 
 /// set(key, value) -> Result<(), NxError>
 #[must_use = "this SDK call can fail; handle the Result"]
+#[inline]
 pub fn set(key: &str, value: &[u8]) -> Result<()> {
     let rc = unsafe {
         ffi::db_set(
@@ -37,6 +38,7 @@ pub fn set(key: &str, value: &[u8]) -> Result<()> {
 
 /// delete(key) -> Result<(), NxError>
 #[must_use = "this SDK call can fail; handle the Result"]
+#[inline]
 pub fn delete(key: &str) -> Result<()> {
     let rc = unsafe { ffi::db_delete(key.as_ptr() as u32, key.len() as u32) };
     map_rc_unit(rc)
@@ -44,6 +46,7 @@ pub fn delete(key: &str) -> Result<()> {
 
 /// exists(key) -> Result<bool, NxError>
 #[must_use = "this SDK call can fail; handle the Result"]
+#[inline]
 pub fn exists(key: &str) -> Result<bool> {
     let rc = unsafe { ffi::db_exists(key.as_ptr() as u32, key.len() as u32) };
     match rc {

--- a/crates/nx-sdk/src/log.rs
+++ b/crates/nx-sdk/src/log.rs
@@ -2,6 +2,7 @@ use crate::ffi;
 
 const ERR_INTERNAL: i32 = -3;
 
+#[inline]
 pub fn log(s: &str) {
     unsafe {
         // If you exported only v2 on the host side, this must exist.

--- a/crates/nx-sdk/src/system.rs
+++ b/crates/nx-sdk/src/system.rs
@@ -78,6 +78,7 @@ pub fn host_capabilities() -> Result<Vec<String>> {
 
 /// Emit a named event to the runtime.
 #[must_use = "this SDK call can fail; handle the Result"]
+#[inline]
 pub fn event_emit(name: &str, payload: &[u8]) -> Result<()> {
     let rc = unsafe {
         ffi::event_emit(

--- a/crates/nx-sdk/src/time.rs
+++ b/crates/nx-sdk/src/time.rs
@@ -1,11 +1,13 @@
 use crate::ffi;
 
 /// Current Unix timestamp in milliseconds.
+#[inline]
 pub fn now() -> u64 {
     unsafe { ffi::time_now() }
 }
 
 /// Monotonic milliseconds since the runtime process initialized its monotonic clock.
+#[inline]
 pub fn monotonic() -> u64 {
     unsafe { ffi::time_monotonic() }
 }


### PR DESCRIPTION
## Summary
- add bare `#[inline]` hints to 22 public nx-sdk wrappers that directly trampoline to one host FFI call
- include bounded scalar/result mapping and fixed-size stack-backed hash outputs
- leave dynamic-buffer readers, allocation/parsing paths, loops, private helpers, `random_bytes`, `net`, and `system::abort` unchanged

## Verification
- `/Users/loi/.cargo/bin/cargo fmt --all --check`
- `/Users/loi/.cargo/bin/cargo build -p nx-sdk`
- `/Users/loi/.cargo/bin/cargo test -p nx-sdk`
- `/Users/loi/.cargo/bin/cargo clippy -p nx-sdk --all-targets -- -D warnings`
- `/Users/loi/.cargo/bin/cargo test --workspace`

Closes #88