### PR TITLE
Add nx_log! usage examples and unit tests for the log macro

### DIFF
--- a/crates/nx-sdk/src/ffi.rs
+++ b/crates/nx-sdk/src/ffi.rs
@@ -116,5 +116,12 @@ unsafe extern "C" {
     pub fn host_log(msg_ptr: u32, msg_len: u32);
 
     // Preferred: allows error codes.
+    #[cfg_attr(
+        test,
+        expect(
+            dead_code,
+            reason = "unit tests replace host logging with an in-memory sink"
+        )
+    )]
     pub fn host_log_v2(msg_ptr: u32, msg_len: u32) -> i32;
 }

--- a/crates/nx-sdk/src/log.rs
+++ b/crates/nx-sdk/src/log.rs
@@ -1,7 +1,10 @@
+#[cfg(not(test))]
 use crate::ffi;
 
+#[cfg(not(test))]
 const ERR_INTERNAL: i32 = -3;
 
+#[cfg(not(test))]
 pub fn log(s: &str) {
     unsafe {
         // If you exported only v2 on the host side, this must exist.
@@ -17,11 +20,77 @@ pub fn log(s: &str) {
     }
 }
 
-/// public API for guests
+#[cfg(test)]
+std::thread_local! {
+    static TEST_MESSAGES: std::cell::RefCell<Vec<String>> = const {
+        std::cell::RefCell::new(Vec::new())
+    };
+}
+
+#[cfg(test)]
+pub fn log(s: &str) {
+    TEST_MESSAGES.with(|messages| messages.borrow_mut().push(s.to_owned()));
+}
+
+#[cfg(test)]
+fn take_test_messages() -> Vec<String> {
+    TEST_MESSAGES.with(|messages| core::mem::take(&mut *messages.borrow_mut()))
+}
+
+/// Logs a formatted message through the Numax host.
+///
+/// # Examples
+///
+/// ```
+/// # #[cfg(target_arch = "wasm32")]
+/// # fn main() {
+/// use nx_sdk::nx_log;
+///
+/// nx_log!("hello");
+///
+/// let id = 42;
+/// nx_log!("user {} created", id);
+///
+/// let (a, b) = ("source", "destination");
+/// nx_log!("{} -> {}", a, b);
+/// # }
+/// # #[cfg(not(target_arch = "wasm32"))]
+/// # fn main() {}
+/// ```
 #[macro_export]
 macro_rules! nx_log {
     ($($arg:tt)*) => {{
         let msg = $crate::__alloc::format!($($arg)*);
         $crate::log::log(&msg);
     }};
+}
+
+#[cfg(test)]
+mod tests {
+    fn assert_logged_message(expected: &str, log_message: impl FnOnce()) {
+        let _ = super::take_test_messages();
+        log_message();
+        assert_eq!(super::take_test_messages(), vec![expected.to_owned()]);
+    }
+
+    #[test]
+    fn logs_plain_literal() {
+        assert_logged_message("hello", || crate::nx_log!("hello"));
+    }
+
+    #[test]
+    fn logs_formatted_message() {
+        let id = 42;
+        assert_logged_message("user 42 created", || {
+            crate::nx_log!("user {} created", id);
+        });
+    }
+
+    #[test]
+    fn logs_multiple_format_arguments() {
+        let (a, b) = ("source", "destination");
+        assert_logged_message("source -> destination", || {
+            crate::nx_log!("{} -> {}", a, b);
+        });
+    }
 }


### PR DESCRIPTION
## Summary

- document literal, formatted, and multi-argument `nx_log!` usage
- capture log messages in unit tests without invoking the wasm host ABI
- assert the exact output produced by each formatting form

## Verification

- `/Users/loi/.cargo/bin/cargo test -p nx-sdk`
- `/Users/loi/.cargo/bin/cargo doc -p nx-sdk --no-deps`
- `/Users/loi/.cargo/bin/cargo fmt --all -- --check`
- `/Users/loi/.cargo/bin/cargo clippy -p nx-sdk --all-targets -- -D warnings`
- `git diff --check`

Closes #67