### PR TITLE
cli: colorize nx --help output using owo-colors (behind a --color flag)  

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1304,6 +1304,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1604,6 +1610,23 @@ name = "ipnet"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "is_ci"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -1915,6 +1938,7 @@ dependencies = [
  "clap_complete",
  "console-subscriber",
  "nx-core",
+ "owo-colors",
  "serde",
  "tokio",
  "toml 1.1.4+spec-1.1.0",
@@ -2031,6 +2055,16 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "owo-colors"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c45bb4a6ae1280ec0803b1ef9d3455eb50f01efbbe1447ab020f1d54fba9d8"
+dependencies = [
+ "supports-color 2.1.0",
+ "supports-color 3.0.2",
+]
 
 [[package]]
 name = "parking_lot"
@@ -2769,6 +2803,25 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "supports-color"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6398cde53adc3c4557306a96ce67b302968513830a77a95b2b17305d9719a89"
+dependencies = [
+ "is-terminal",
+ "is_ci",
+]
+
+[[package]]
+name = "supports-color"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64fc7232dd8d2e4ac5ce4ef302b1d81e0b80d055b9d77c7c4f51f6aa4c867d6"
+dependencies = [
+ "is_ci",
+]
 
 [[package]]
 name = "symbolic-common"

--- a/crates/nx-cli/Cargo.toml
+++ b/crates/nx-cli/Cargo.toml
@@ -14,6 +14,7 @@ clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
 console-subscriber = { version = "0.5", optional = true }
 nx-core = { version = "0.1.3", path = "../nx-core" }
+owo-colors = { version = "4", features = ["supports-colors"] }
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 toml = "1.1"

--- a/crates/nx-cli/src/main.rs
+++ b/crates/nx-cli/src/main.rs
@@ -1,5 +1,6 @@
 mod config;
 
+use std::ffi::OsString;
 use std::fs;
 use std::io::{self, Write};
 use std::num::{NonZeroU32, NonZeroUsize};
@@ -7,7 +8,10 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use anyhow::Result;
-use clap::{CommandFactory, Parser, Subcommand};
+use clap::builder::styling::{AnsiColor, Effects, Styles};
+use clap::{
+    Arg, ColorChoice, Command, CommandFactory, FromArgMatches, Parser, Subcommand, ValueEnum,
+};
 use clap_complete::{Shell, generate};
 use config::*;
 use nx_core::runtime::{DEFAULT_SHUTDOWN_TIMEOUT, Runtime, RuntimeConfig};
@@ -15,7 +19,114 @@ use nx_core::sync_manager::{
     DEFAULT_MIGRATION_BATCH_BYTES, DEFAULT_MIGRATION_BATCH_SIZE, MigrationOptions,
     migrate_sync_schema_at_path,
 };
+use owo_colors::{OwoColorize, Stream};
 use tracing::info;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+enum ColorWhen {
+    Auto,
+    Always,
+    Never,
+}
+
+impl std::fmt::Display for ColorWhen {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(match self {
+            Self::Auto => "auto",
+            Self::Always => "always",
+            Self::Never => "never",
+        })
+    }
+}
+
+fn colors_enabled(mode: ColorWhen, stdout_supports_color: bool, no_color: bool) -> bool {
+    if no_color {
+        return false;
+    }
+
+    match mode {
+        ColorWhen::Auto => stdout_supports_color,
+        ColorWhen::Always => true,
+        ColorWhen::Never => false,
+    }
+}
+
+fn parse_requested_color(
+    args: impl IntoIterator<Item = OsString>,
+) -> std::result::Result<ColorWhen, clap::Error> {
+    let mut args = args.into_iter().peekable();
+    while let Some(arg) = args.next() {
+        let Some(arg) = arg.to_str() else {
+            continue;
+        };
+
+        let value = if arg == "--color" {
+            match args.peek().and_then(|value| value.to_str()) {
+                Some(next) if !next.starts_with('-') => {
+                    args.next().and_then(|value| value.into_string().ok())
+                }
+                _ => {
+                    return Err(clap::Error::raw(
+                        clap::error::ErrorKind::TooFewValues,
+                        "--color requires a value: auto, always, or never",
+                    ));
+                }
+            }
+        } else {
+            arg.strip_prefix("--color=").map(str::to_owned)
+        };
+
+        if let Some(value) = value {
+            return match value.as_str() {
+                "auto" => Ok(ColorWhen::Auto),
+                "always" => Ok(ColorWhen::Always),
+                "never" => Ok(ColorWhen::Never),
+                _ => Err(clap::Error::raw(
+                    clap::error::ErrorKind::InvalidValue,
+                    format!(
+                        "invalid value '{value}' for '--color <WHEN>'\n  [possible values: auto, always, never]"
+                    ),
+                )),
+            };
+        }
+    }
+
+    Ok(ColorWhen::Auto)
+}
+
+fn requested_color() -> std::result::Result<ColorWhen, clap::Error> {
+    parse_requested_color(std::env::args_os().skip(1))
+}
+
+fn stdout_supports_color() -> bool {
+    "color-probe"
+        .if_supports_color(Stream::Stdout, |text| text.green())
+        .to_string()
+        .contains('\u{1b}')
+}
+
+fn help_styles() -> Styles {
+    Styles::styled()
+        .header(AnsiColor::Cyan.on_default().effects(Effects::BOLD))
+        .usage(AnsiColor::Cyan.on_default().effects(Effects::BOLD))
+        .literal(AnsiColor::Green.on_default().effects(Effects::BOLD))
+        .placeholder(AnsiColor::Yellow.on_default())
+}
+
+fn cli_command(color_choice: ColorChoice) -> Command {
+    Cli::command()
+        .arg(
+            Arg::new("color")
+                .long("color")
+                .global(true)
+                .value_name("WHEN")
+                .value_parser(clap::value_parser!(ColorWhen))
+                .default_value("auto")
+                .help("Control help colors: auto, always, or never"),
+        )
+        .styles(help_styles())
+        .color(color_choice)
+}
 
 #[derive(Parser, Debug)]
 #[command(name = "nx")]
@@ -188,18 +299,34 @@ enum ConfigCommand {
 }
 
 fn generate_completions(shell: Shell, writer: &mut dyn Write) {
-    let mut command = Cli::command();
+    let mut command = cli_command(ColorChoice::Never);
     generate(shell, &mut command, "nx", writer);
 }
 
+fn parse_cli() -> std::result::Result<Cli, clap::Error> {
+    let use_color = colors_enabled(
+        requested_color()?,
+        stdout_supports_color(),
+        std::env::var_os("NO_COLOR").is_some(),
+    );
+    let color_choice = if use_color {
+        ColorChoice::Always
+    } else {
+        ColorChoice::Never
+    };
+    let matches = cli_command(color_choice).try_get_matches()?;
+    Cli::from_arg_matches(&matches)
+}
+
 fn main() {
-    let cli = match Cli::parse() {
-        Cli::Completions { shell } => {
+    let cli = match parse_cli() {
+        Ok(Cli::Completions { shell }) => {
             let stdout = io::stdout();
             generate_completions(shell, &mut stdout.lock());
             return;
         }
-        cli => cli,
+        Ok(cli) => cli,
+        Err(err) => err.exit(),
     };
 
     let rt = tokio::runtime::Builder::new_multi_thread()
@@ -1235,7 +1362,56 @@ mod tests {
     // clap parsing
     mod clap_parsing {
         use super::*;
-        use clap::CommandFactory;
+        use clap::{ColorChoice, CommandFactory};
+
+        #[test]
+        fn color_policy_respects_mode_terminal_and_no_color() {
+            assert!(colors_enabled(ColorWhen::Always, false, false));
+            assert!(!colors_enabled(ColorWhen::Never, true, false));
+            assert!(colors_enabled(ColorWhen::Auto, true, false));
+            assert!(!colors_enabled(ColorWhen::Auto, false, false));
+            assert!(!colors_enabled(ColorWhen::Always, true, true));
+        }
+
+        #[test]
+        fn global_color_flag_accepts_all_modes() {
+            for value in ["auto", "always", "never"] {
+                let matches = cli_command(ColorChoice::Never)
+                    .try_get_matches_from(["nx", "--color", value, "run", "x.wasm"])
+                    .unwrap();
+                assert_eq!(
+                    matches.get_one::<ColorWhen>("color").unwrap().to_string(),
+                    value
+                );
+            }
+        }
+
+        #[test]
+        fn requested_color_rejects_invalid_values() {
+            let err = parse_requested_color(["--color=foobar".into()]).unwrap_err();
+            assert!(err.to_string().contains("invalid value 'foobar'"));
+        }
+
+        #[test]
+        fn requested_color_requires_a_value() {
+            let err = parse_requested_color(["--color".into(), "--help".into()]).unwrap_err();
+            assert!(err.to_string().contains("--color requires a value"));
+        }
+
+        #[test]
+        fn help_color_choice_controls_ansi_output() {
+            let colored_error = cli_command(ColorChoice::Always)
+                .try_get_matches_from(["nx", "--help"])
+                .unwrap_err();
+            let colored = colored_error.render().ansi().to_string();
+            assert!(colored.contains("\u{1b}["), "help output: {colored}");
+
+            let plain_error = cli_command(ColorChoice::Never)
+                .try_get_matches_from(["nx", "--help"])
+                .unwrap_err();
+            let plain = plain_error.render().to_string();
+            assert!(!plain.contains("\u{1b}["), "help output: {plain}");
+        }
 
         #[test]
         fn minimal_args() {


### PR DESCRIPTION
## Summary

- add a global `--color <auto|always|never>` option for CLI help
- use `owo-colors` terminal detection and a conservative cyan/green/yellow help palette
- keep piped output plain by default and give `NO_COLOR` precedence over explicit color settings
- cover color policy, flag parsing, and ANSI/plain rendering with tests

## Verification

- `/Users/loi/.cargo/bin/cargo test -p nx-cli`
- `/Users/loi/.cargo/bin/cargo fmt --all -- --check`
- `/Users/loi/.cargo/bin/cargo clippy -p nx-cli --all-targets -- -D warnings`
- `git diff --check`
- binary checks for piped auto, never, always, and `NO_COLOR=1` modes

Closes #83