### PR TITLE
Add a minimal Zig guest example for Numax

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+        with:
+          version: 0.16.0
       - uses: actions-rust-lang/setup-rust-toolchain@9d7e65c320fdb52dcd45ffaa68deb6c02c8754d9 # v1.10.1
         with:
           toolchain: stable
@@ -98,6 +104,10 @@ jobs:
         run: cargo build --release --target wasm32-unknown-unknown --manifest-path examples/distributed_chat/Cargo.toml
       - name: Build vote_tally_tls
         run: cargo build --release --target wasm32-unknown-unknown --manifest-path examples/vote_tally_tls/Cargo.toml
+      - name: Build and test Zig guest
+        run: |
+          examples/guest_zig/build.sh
+          node examples/guest_zig/test.mjs
 
   cli-smoke:
     name: CLI Multi-process Smoke

--- a/examples/guest_zig/.gitignore
+++ b/examples/guest_zig/.gitignore
@@ -1,0 +1,1 @@
+/guest.wasm

--- a/examples/guest_zig/README.md
+++ b/examples/guest_zig/README.md
@@ -1,0 +1,46 @@
+# Zig guest
+
+This minimal guest uses Zig 0.16.0 to build a freestanding core WebAssembly
+module. It imports `host_log_v2` directly from the `nx` namespace and exports
+the `run` entrypoint Numax expects.
+
+## Requirements
+
+- Zig 0.16.0
+- Node.js 22 or newer for the ABI smoke test
+- a built Numax CLI for the runtime smoke test
+
+## Build and test
+
+From the repository root:
+
+```sh
+examples/guest_zig/build.sh
+node examples/guest_zig/test.mjs
+```
+
+The build writes `examples/guest_zig/guest.wasm`. The test verifies that the
+module imports only `nx.host_log_v2`, exports `memory` and `run`, and logs the
+expected message through a mock host.
+
+## Run with Numax
+
+```sh
+cargo build -p nx-cli
+./target/debug/nx run examples/guest_zig/guest.wasm
+```
+
+Expected output includes:
+
+```text
+[guest] Hello from Zig guest!
+```
+
+## ABI notes and limitations
+
+- This is a core WebAssembly module, not a Component Model component.
+- Zig calls the raw Numax ABI directly; there is no generated Zig SDK yet.
+- Strings cross the boundary as a pointer and byte length into exported guest
+  memory.
+- The example logs one static message and does not demonstrate allocation,
+  database access, or error recovery.

--- a/examples/guest_zig/build.sh
+++ b/examples/guest_zig/build.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+set -eu
+
+cd "$(dirname "$0")"
+
+zig build-exe src/main.zig \
+  -target wasm32-freestanding \
+  -O ReleaseSmall \
+  -fno-entry \
+  --export-memory \
+  --export=run \
+  -femit-bin=guest.wasm

--- a/examples/guest_zig/src/main.zig
+++ b/examples/guest_zig/src/main.zig
@@ -1,0 +1,7 @@
+const message = "Hello from Zig guest!";
+
+extern "nx" fn host_log_v2(pointer: [*]const u8, length: usize) i32;
+
+export fn run() void {
+    _ = host_log_v2(message.ptr, message.len);
+}

--- a/examples/guest_zig/test.mjs
+++ b/examples/guest_zig/test.mjs
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const moduleBytes = await readFile(new URL("guest.wasm", import.meta.url));
+const module = await WebAssembly.compile(moduleBytes);
+
+assert.deepEqual(WebAssembly.Module.imports(module), [
+  { module: "nx", name: "host_log_v2", kind: "function" },
+]);
+
+const exportNames = WebAssembly.Module.exports(module).map(({ name }) => name);
+assert(exportNames.includes("memory"));
+assert(exportNames.includes("run"));
+
+let memory;
+let message;
+const instance = await WebAssembly.instantiate(module, {
+  nx: {
+    host_log_v2(pointer, length) {
+      const bytes = new Uint8Array(memory.buffer, pointer, length);
+      message = new TextDecoder().decode(bytes);
+      return 0;
+    },
+  },
+});
+
+memory = instance.exports.memory;
+instance.exports.run();
+
+assert.equal(message, "Hello from Zig guest!");
+console.log("Zig guest ABI smoke test passed");


### PR DESCRIPTION
## Summary

- add a minimal Zig 0.16.0 guest that imports only nx.host_log_v2 and exports memory plus run
- add a Node ABI smoke test that inspects and executes the compiled WebAssembly module
- document build, test, runtime usage, raw ABI details, and current limitations
- build and test the Zig example in the existing WASM CI job with pinned tooling

## Verification

- examples/guest_zig/build.sh
- node examples/guest_zig/test.mjs
- wasm-tools validate examples/guest_zig/guest.wasm
- ./target/debug/nx run examples/guest_zig/guest.wasm
- cargo test --workspace -q (498 passed)
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- git diff --check

Closes #59