### PR TITLE
docs: fix repository-relative paths in guest guides

### DIFF
--- a/examples/guest_c/README.md
+++ b/examples/guest_c/README.md
@@ -24,17 +24,19 @@ cargo build --release
 
 ## Build
 
+From the repository root:
+
 ### Windows
 
 ```bash
-cd /examples/guest_c
+cd examples/guest_c
 ./build.bat
 ```
 
-### Linux / MacOS
+### Linux / macOS
 
 ```bash
-cd /examples/guest_c
+cd examples/guest_c
 chmod +x build.sh
 ./build.sh
 ```
@@ -45,7 +47,7 @@ This generates:
 guest.wasm
 ```
 
-In the guest_c directory
+The output is written to the `examples/guest_c` directory.
 
 ## Run
 
@@ -57,13 +59,13 @@ From the repository root:
 .\target\release\nx.exe run .\examples\guest_c\guest.wasm
 ```
 
-### Run on MacOS/Linux
+### Run on Linux / macOS
 
 ```bash
 ./target/release/nx run ./examples/guest_c/guest.wasm
 ```
 
-output:
+Output:
 
 ```bash
 [guest] Hello from C guest!

--- a/examples/guest_cpp/README.md
+++ b/examples/guest_cpp/README.md
@@ -54,17 +54,19 @@ cargo build --release
 
 ## Build
 
+From the repository root:
+
 ### Windows
 
 ```bash
-cd /examples/guest_cpp
+cd examples/guest_cpp
 ./build.bat
 ```
 
 ### Linux / macOS
 
 ```bash
-cd /examples/guest_cpp
+cd examples/guest_cpp
 chmod +x build.sh
 ./build.sh
 ```
@@ -75,7 +77,7 @@ This generates:
 guest.wasm
 ```
 
-In the guest_cpp directory
+The output is written to the `examples/guest_cpp` directory.
 
 ## Run
 
@@ -87,13 +89,13 @@ From the repository root:
 .\target\release\nx.exe run .\examples\guest_cpp\guest.wasm
 ```
 
-### Run on MacOS/Linux
+### Run on Linux / macOS
 
 ```bash
 ./target/release/nx run ./examples/guest_cpp/guest.wasm
 ```
 
-## output
+## Output
 
 ```bash
 [guest] Hello from C++ guest!


### PR DESCRIPTION
Closes #103

## Changes

- Fix repository-relative paths in the C and C++ guest READMEs.
- Clarify that build commands start from the repository root.
- Align Linux/macOS naming and output formatting.
- Clarify where `guest.wasm` is generated.

## Verification

- `git diff --check` passes.
- Confirmed the build scripts expect execution from their respective guest directories.
- Confirmed no `cd /examples/...` paths remain.

I was not able to run the Linux/macOS build locally because my verification environment is Windows.