### PR TITLE
docs: document crash handling workflow in fuzzing README (#102)

### DIFF
--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -32,3 +32,74 @@ After changing a JSON seed, regenerate its deterministic Bincode counterpart:
 ```bash
 cargo run --manifest-path fuzz/Cargo.toml --example generate_binary_corpus
 ```
+
+## Handling crashes
+
+When a fuzz target finds a crash, the following steps explain how to reproduce,
+minimize, and report it.
+
+### Artifacts directory
+
+Crashed inputs are stored in:
+
+```
+fuzz/artifacts/<target>/
+```
+
+Each file in this directory is a raw input that triggered a panic or other
+failure in the target. The filenames are assigned by cargo-fuzz and do not
+carry semantic meaning — keep the original name when reproducing.
+
+### Reproducing a crash
+
+Run the target directly against the crashing input:
+
+```bash
+cargo +nightly fuzz run <target> fuzz/artifacts/<target>/<crash-file> -- \
+  -max_len=1048576 -timeout=10
+```
+
+This replays the exact input and should produce the same backtrace you saw
+during the original fuzz run. If the crash no longer reproduces, the bug
+has likely been fixed by an intervening commit.
+
+### Minimizing a crash
+
+`cargo fuzz tmin` strips bytes from the crashing input while preserving the
+bug-triggering behavior. A smaller input is easier to read, debug, and add
+to a regression test.
+
+```bash
+cargo +nightly fuzz tmin <target> fuzz/artifacts/<target>/<crash-file> \
+  --output minimized.bin
+```
+
+The minimized file lands in the current directory. Inspect it to confirm the
+reduced input still triggers the same code path:
+
+```bash
+cargo +nightly fuzz run <target> minimized.bin -- \
+  -max_len=1048576 -timeout=10
+```
+
+### When to add to the seed corpus
+
+A minimized input belongs in `fuzz/corpus/<target>/` when it exercises a
+code path not covered by the existing seeds — for example, a new branch
+condition, a different error path, or an edge case in length-prefix
+framing. If the minimized input is a duplicate of an existing seed, there
+is no benefit to adding it.
+
+Promote a minimized crash to the corpus with:
+
+```bash
+cp minimized.bin fuzz/corpus/<target>/
+```
+
+For JSON-based targets, consider whether the same shape can be expressed
+as a Bincode seed as well. After changing a JSON seed, regenerate the
+deterministic Bincode counterpart:
+
+```bash
+cargo run --manifest-path fuzz/Cargo.toml --example generate_binary_corpus
+```


### PR DESCRIPTION
## Summary
Documents the full crash handling workflow in the fuzzing README: artifacts directory layout, reproduction, minimization with cargo fuzz tmin, and when to promote inputs to the seed corpus.

## What was added

1. **Artifacts directory** - explains where crashes are saved and naming conventions
2. **Reproducing a crash** - concrete command to replay a specific crashing input
3. **Minimizing a crash** - step-by-step cargo fuzz tmin example with verification
4. **When to add to seed corpus** - guidance on when a minimized input should be promoted

## Checklist from issue
- [x] the fuzzing README documents the artifacts directory
- [x] the README shows a concrete reproduce command
- [x] the README shows a concrete cargo fuzz tmin example
- [x] the README explains when a minimized input belongs in the seed corpus
- [x] no .github/workflows/* file is modified

Closes #102